### PR TITLE
feat: drag-and-drop file paths into terminals (Terminal.app parity)

### DIFF
--- a/src/components/workspace/AuxTerminal.tsx
+++ b/src/components/workspace/AuxTerminal.tsx
@@ -10,6 +10,7 @@ import { useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { loadTerminalRenderer } from "@/lib/terminalRenderer";
+import { registerTerminalDropTarget } from "@/lib/terminalDrop";
 import * as ipc from "@/lib/ipc";
 import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg } from "@/store/prefs";
 
@@ -31,6 +32,10 @@ export function AuxTerminal({ wsPath, active, onExited }: { wsPath: string; acti
 
   useEffect(() => {
     if (!hostRef.current) return;
+    const host = hostRef.current;
+    // Drop target: dragging a file onto the scratch shell inserts its
+    // escaped path at the prompt — same affordance as the agent terminals.
+    const unregisterDrop = registerTerminalDropTarget(host, () => ptyRef.current);
     setExited(false);
     let cancelled = false;
     let unlistenData: (() => void) | null = null;
@@ -117,6 +122,7 @@ export function AuxTerminal({ wsPath, active, onExited }: { wsPath: string; acti
     return () => {
       cancelled = true;
       ro.disconnect();
+      unregisterDrop();
       unlistenData?.(); unlistenExit?.();
       if (ptyRef.current) ipc.ptyKill(ptyRef.current).catch(() => {});
       // Dispose the renderer addon FIRST so its render loop can't fire

--- a/src/components/workspace/TerminalPane.tsx
+++ b/src/components/workspace/TerminalPane.tsx
@@ -12,6 +12,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { loadTerminalRenderer } from "@/lib/terminalRenderer";
+import { registerTerminalDropTarget } from "@/lib/terminalDrop";
 import type { TerminalTab, Workspace } from "@/lib/types";
 import * as ipc from "@/lib/ipc";
 import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg } from "@/store/prefs";
@@ -195,6 +196,11 @@ export function TerminalPane({ ws, tab, active }: Props) {
     term.open(host);
     termRef.current = term;
     fitRef.current = fit;
+
+    // Drop target: dragging a file (screenshot, etc.) onto this terminal
+    // inserts the file's escaped path at the prompt — like macOS Terminal.
+    // The getter reads ptyRef lazily so a Restart (fresh pty id) still works.
+    const unregisterDrop = registerTerminalDropTarget(host, () => ptyRef.current);
 
     // Shift+Enter → newline-without-submit.
     //
@@ -881,6 +887,7 @@ export function TerminalPane({ ws, tab, active }: Props) {
     return () => {
       cancelled = true;
       ro.disconnect();
+      unregisterDrop();
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", onBlur);

--- a/src/index.css
+++ b/src/index.css
@@ -275,3 +275,11 @@
 .termic-progress-indeterminate {
   animation: termic-progress-indeterminate 1.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }
+
+/* Drop-target ring — applied to a terminal host while a file is dragged over
+   it (see src/lib/terminalDrop.ts). Inset box-shadow paints a ring WITHOUT
+   affecting layout, so it can't perturb xterm's fit()/cell grid mid-drag. */
+.termic-drop-target {
+  box-shadow: inset 0 0 0 2px var(--color-accent);
+  background-color: var(--color-accent-soft);
+}

--- a/src/lib/terminalDrop.ts
+++ b/src/lib/terminalDrop.ts
@@ -1,0 +1,106 @@
+// Drag-and-drop file paths into terminals — macOS Terminal.app / iTerm2 parity.
+//
+// Termic runs inside a Tauri WKWebView, and Tauri's native file-drop (the
+// window's `dragDropEnabled`, which defaults to true) intercepts an OS drag
+// BEFORE the webview's HTML5 `drop` event would ever fire. So the usual
+// browser drag-and-drop route is a dead end on two counts: the DOM `drop`
+// event never arrives, AND WKWebView wouldn't expose the dropped File's real
+// filesystem path even if it did (a webview security restriction). Tauri's
+// native `onDragDropEvent` is the only place the absolute paths surface —
+// together with the physical-pixel drop point.
+//
+// We register ONE window-level listener and route each drop to whichever
+// terminal sits under the cursor, writing the file path(s) into that
+// terminal's PTY through the exact same byte channel as a keystroke
+// (ipc.ptyWrite). To the agent CLI it's indistinguishable from the user
+// typing the path — which is precisely what dragging a screenshot into iTerm
+// does today, so paths land in a shape claude/gemini/codex already parse.
+
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import * as ipc from "@/lib/ipc";
+
+// host element → getter for that terminal's CURRENT pty id (or null when the
+// PTY has exited). Each TerminalPane / AuxTerminal registers its xterm host on
+// mount and removes it on unmount. We store a getter rather than a bare string
+// so a Restart that mints a fresh pty id is picked up at drop time without the
+// component having to re-register.
+const targets = new Map<HTMLElement, () => string | null>();
+
+export function registerTerminalDropTarget(
+  host: HTMLElement,
+  ptyId: () => string | null,
+): () => void {
+  targets.set(host, ptyId);
+  return () => { targets.delete(host); };
+}
+
+// Backslash-escape every character outside a conservative safe set, mirroring
+// how macOS Terminal.app / iTerm2 insert a dragged file's path. This is the
+// exact shape the agent CLIs already receive when you drag a screenshot into
+// iTerm, so spaces / parens / $ / & / etc. survive verbatim into the prompt
+// (or into a plain shell, where the escaping is also correct).
+function shellEscapePath(p: string): string {
+  return p.replace(/[^A-Za-z0-9._/-]/g, "\\$&");
+}
+
+// Walk up from the drop point to the nearest registered terminal host. Returns
+// the host element, or null if the drop landed outside any terminal (editor,
+// file tree, diff pane, sidebar, …) — those drops are left untouched.
+function hostForPoint(xCss: number, yCss: number): HTMLElement | null {
+  let el = document.elementFromPoint(xCss, yCss) as HTMLElement | null;
+  while (el) {
+    if (targets.has(el)) return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+// ── Drop highlight ─────────────────────────────────────────────────────────
+// Outline the terminal a drop would land in, so the target is obvious mid-drag.
+// The class paints an inset ring via box-shadow (see index.css); box-shadow
+// doesn't affect layout, so it can't perturb xterm's fit()/cell grid.
+const HILITE = "termic-drop-target";
+let hilited: HTMLElement | null = null;
+
+function setHighlight(host: HTMLElement | null): void {
+  if (hilited === host) return;
+  hilited?.classList.remove(HILITE);
+  host?.classList.add(HILITE);
+  hilited = host;
+}
+
+let unlisten: UnlistenFn | null = null;
+
+// Register the single app-wide drag-drop listener. Call once at startup.
+export async function initTerminalDropHandler(): Promise<void> {
+  // Idempotent: a second call (e.g. an HMR module re-eval in dev) must not
+  // stack a second listener that would double-insert every dropped path.
+  if (unlisten) return;
+  unlisten = await getCurrentWebview().onDragDropEvent((event) => {
+    const p = event.payload;
+    // Tauri reports the drop point in PHYSICAL pixels; document.elementFromPoint
+    // wants CSS pixels. (Testing heads-up: with devtools open the reported
+    // position can be inaccurate — a documented Tauri limitation. Detach the
+    // debugger to verify drop targeting.)
+    const dpr = window.devicePixelRatio || 1;
+
+    if (p.type === "enter" || p.type === "over") {
+      setHighlight(hostForPoint(p.position.x / dpr, p.position.y / dpr));
+      return;
+    }
+    if (p.type === "leave") {
+      setHighlight(null);
+      return;
+    }
+    // p.type === "drop"
+    setHighlight(null);
+    if (!p.paths || p.paths.length === 0) return;
+    const host = hostForPoint(p.position.x / dpr, p.position.y / dpr);
+    if (!host) return;                       // dropped outside any terminal
+    const ptyId = targets.get(host)?.() ?? null;
+    if (!ptyId) return;                      // terminal present but PTY exited
+    const text = p.paths.map(shellEscapePath).join(" ") + " ";
+    ipc.ptyWrite(ptyId, Array.from(new TextEncoder().encode(text))).catch(() => {});
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import { App } from "./App";
 import { logLine } from "@/lib/ipc";
+import { initTerminalDropHandler } from "@/lib/terminalDrop";
 
 // StrictMode disabled: it double-mounts effects in dev, which races our async
 // PTY spawn flow (first spawn gets killed by the strict teardown before its
@@ -32,3 +33,9 @@ window.addEventListener("unhandledrejection", (e) => {
 });
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+// App-wide terminal drag-and-drop: dropping a file onto a terminal inserts
+// its path at the prompt (like macOS Terminal). One native Tauri listener for
+// the whole app — see src/lib/terminalDrop.ts for why the browser DnD API
+// can't be used here. Fire-and-forget; failure just means no drop support.
+initTerminalDropHandler().catch(() => {});


### PR DESCRIPTION
## What

Dropping a file (e.g. a screenshot) onto a terminal now inserts the file's escaped path at the prompt, matching macOS Terminal.app / iTerm2. This is the move you reach for to hand an agent a screenshot — drag it in, the path lands where you're typing, and claude/gemini/codex read it from there. Before this, dropping a file did nothing.

## Why not HTML5 drag-and-drop

Tauri's native file-drop (the window's `dragDropEnabled`, which defaults to `true`) intercepts the OS drag **before** the WKWebView's HTML5 `drop` event would fire — and WKWebView won't expose a dropped `File`'s real filesystem path anyway. So the browser DnD route is a dead end on both counts. Tauri's native `onDragDropEvent` is the only source of the absolute paths (plus a physical-pixel drop point). Nothing happened on drop before simply because that native event had no listener.

## Implementation (frontend-only — no Rust, config, or capability changes)

- **`src/lib/terminalDrop.ts`** (new): one app-wide `onDragDropEvent` listener + a `host element → pty-id` registry. On drop it walks up from the drop point to the terminal under the cursor and writes the escaped path(s) through the **same `ipc.ptyWrite` channel as a keystroke** — so to the agent CLI it's indistinguishable from typing. Drop position is converted physical→CSS px via `devicePixelRatio` for `elementFromPoint`.
- **`TerminalPane.tsx` / `AuxTerminal.tsx`**: register their xterm host on mount, unregister on teardown. The registry stores a *getter* for the pty id, so a Restart that mints a fresh PTY is picked up without re-registering.
- **`main.tsx`**: initialise the single listener once at startup (idempotent against HMR re-eval).
- **`index.css`**: a layout-safe inset-ring highlight (`box-shadow`, so it can't perturb xterm's `fit()`/cell grid) on the terminal under the cursor during a drag.

Paths are backslash-escaped like Terminal.app (spaces, parens, `$`, `&` all survive), so they work both at an agent prompt and in a plain shell. Multiple files are space-joined; a trailing space is appended.

## Testing

Manually verified on macOS (Tauri 2.11, dev build):
- Drag a screenshot onto an agent pane → accent ring appears during drag, escaped path lands at the prompt on drop.
- Works on the scratch shell (`AuxTerminal`) too.
- Paths with spaces/parens escape correctly.

Note: the registry approach means any future terminal surface gets drop support by registering its host. The same `ptyWrite` plumbing could also back a clipboard-image paste later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)