### PR TITLE
docs: context picker design spec

### DIFF
--- a/docs/plans/2026-05-28-001-feat-context-picker-plan.md
+++ b/docs/plans/2026-05-28-001-feat-context-picker-plan.md
@@ -1,0 +1,357 @@
+---
+title: "feat: Advanced context picker for inserting @path tokens into agent terminals"
+type: feat
+status: active
+date: 2026-05-28
+origin: docs/superpowers/specs/2026-05-28-context-picker-design.md
+---
+
+# feat: Advanced context picker for inserting @path tokens into agent terminals
+
+## Summary
+
+Add a two-pane fuzzy picker that inserts workspace-relative `@path` tokens into
+the active agent terminal's PTY. Multi-select, recency-ranked, folder-aware,
+with a live preview pane. Opened by a new `⌘I` shortcut (always) and, behind an
+opt-in preference, by typing `@` at a word boundary inside a terminal.
+
+---
+
+## Problem Frame
+
+Handing files to an agent CLI (claude / codex / gemini) today means typing
+paths by hand or dragging files in one at a time. The existing `⌘P`
+`FileFinderDialog` is the closest primitive, but it is single-select, has no
+preview, no recency bias, and its action is "open an editor tab" — not "insert
+context into the conversation the user is having with an agent."
+
+This plan builds the advanced sibling: a picker tuned for the agent-context
+workflow. The insertion mechanism is the same channel keystrokes already use
+(`ipc.ptyWrite`), so inserted text is indistinguishable from typing. The work
+is almost entirely additive — the one change to existing behavior is extracting
+the fuzzy matcher out of `FileFinderDialog` into a shared module, which must
+preserve `⌘P` behavior exactly.
+
+---
+
+## Requirements
+
+### Picker behavior
+
+- R1. `⌘I` in a workspace that has at least one terminal opens the context picker over the active terminal. With no terminal in the workspace, it shows a toast ("No terminal to insert into") and does not open.
+- R2. Typing in the search field filters the file list with the same fuzzy matcher `⌘P` uses (substring-first, multi-term AND).
+- R3. With an empty query, results are ordered by recency (recently modified and git-changed files first).
+- R4. The list supports multi-select: `Tab` or `Space` toggles the highlighted row; selected files render a check and appear as removable chips. `↑`/`↓` navigate, highlight follows the mouse.
+- R5. `Enter` confirms — inserting all selected files, or the single highlighted row when nothing is checked. `Esc` cancels.
+- R6. Directories are selectable and insert with a trailing slash (`@path/`).
+- R7. A preview pane shows the highlighted file's content (text), flags binaries, and lists children for a highlighted folder.
+
+### Insertion
+
+- R8. Confirming writes `@<relative-path>` tokens to the resolved terminal's PTY: space-separated, one trailing space, directories with a trailing slash, spaces in paths backslash-escaped. The picker then closes.
+
+### Triggers
+
+- R9. The `⌘I` trigger always works regardless of the `@`-interception preference.
+- R10. A preference `contextAtTrigger` (default off) gates `@`-interception. When on, typing `@` at a word boundary in a terminal opens the picker and swallows the `@`; cancelling re-emits the literal `@`; confirming inserts tokens with no duplicated `@`. When off, `@` types normally.
+
+### Non-regression
+
+- R11. `⌘P` `FileFinderDialog` behaves exactly as before — same fuzzy ranking, same highlighting, same open-tab action.
+
+---
+
+## Key Technical Decisions
+
+- New component, shared matcher: A standalone `ContextPickerDialog` owns multi-select / preview / recency / insertion; the fuzzy matcher moves to `src/lib/fuzzy.ts` and is imported by both pickers. Keeps the clean `FileFinderDialog` untouched in behavior while avoiding a second copy of the scoring logic. (see origin: docs/superpowers/specs/2026-05-28-context-picker-design.md)
+- Recency data via a new Tauri command, not the existing finder command: `workspace_list_files_for_finder` returns a flat `Vec<String>` with no mtime and no directories. Rather than overload it (and perturb `⌘P`), add `workspace_context_files` that runs the same `git ls-files --cached --others --exclude-standard`, adds a per-path modified-time, and synthesizes directory entries from path prefixes. Ignore rules stay identical because both issue the same git call.
+- Git-changed boost reuses `workspace_changes`: the changed-file set comes from flattening the existing `workspace_changes` groups' file paths, so no new git plumbing is needed for the "what I'm working on" boost.
+- Insertion target resolved from tab state, not a DOM registry: terminal tabs already carry `ptyId`. The target PTY is resolved with the same focus rule `⌘W`/`⌘T`/`⌘K` use (bottom-split focus → active bottom tab; else active main terminal tab; else first terminal tab; else none). The drag-drop host→pty registry does not exist on this branch, so we do not depend on it.
+- `@`-interception is a layer inside `term.onData`, not a new global listener: the keystroke is swallowed before `ipc.ptyWrite`; cancel re-emits it. Word-boundary detection is a heuristic read of `term.buffer.active` (the agent TUI owns the real cursor), which is acceptable because the layer is opt-in and `⌘I` is the always-available reliable path.
+- TS test harness: the frontend currently has no test runner (no Vitest/Jest, no `*.test.*`); the repo verifies frontend work manually/empirically. Recommendation: pull all decision logic (fuzzy match, ranking blend, insertion formatter, target resolution, word-boundary check) into pure exported functions and add Vitest (Vite-native, dev-only) covering just those modules; verify UI and wiring manually in-app per repo convention. If introducing a runner is unwanted, the same enumerated scenarios become a manual checklist and the pure functions still isolate the risk. The new Rust command is tested with the existing inline `#[cfg(test)]` pattern in `src-tauri/src/lib.rs` (`cargo test` already runs).
+- Refetch-on-open, no cache: mirrors `FileFinderDialog`'s deliberate "fresh listing each open, no invalidation story" trade-off. Preview reads are debounced and cancellable so arrow-key nav on a large repo never blocks on file IO.
+
+---
+
+## High-Level Technical Design
+
+The picker has two open paths that converge on one confirm/cancel lifecycle.
+The branching that prose alone leaves ambiguous is the `@`-swallow/cancel logic
+and the target-PTY resolution, so they are drawn explicitly. This diagram is
+authoritative for the control flow.
+
+```mermaid
+flowchart TB
+  A["⌘I pressed"] --> B{"workspace has a terminal?"}
+  B -->|no| T["toast: no terminal; do not open"]
+  B -->|yes| R["resolve target PTY:\nbottom-split focus → active bottom tab\nelse active main terminal tab\nelse first terminal tab"]
+  R --> O["open picker (wsId, ptyId)"]
+
+  AT["'@' typed in terminal onData"] --> P{"contextAtTrigger pref on\nAND at word boundary?"}
+  P -->|no| FW["forward '@' to PTY normally"]
+  P -->|yes| SW["swallow '@' (no ptyWrite)\nopen picker (wsId, this pty)"]
+
+  O --> PICK["fuzzy filter + recency rank;\nTab/Space multi-select; debounced preview"]
+  SW --> PICK
+  PICK --> C{"confirm or cancel?"}
+  C -->|"Enter (confirm)"| INS["build @path tokens\n(dirs trailing slash, spaces escaped,\none trailing space) → ptyWrite → close"]
+  C -->|"Esc (cancel)"| CAN{"opened via '@' swallow?"}
+  CAN -->|yes| RE["re-emit literal '@' to PTY; close"]
+  CAN -->|no| CL["close"]
+```
+
+Ranking data flow (open → render): fetch `workspace_context_files` (paths +
+mtime + is_dir) and `workspace_changes` (changed-path set) in parallel; for each
+file compute `fuzzyScore(path, query)` plus a recency boost (mtime half-life,
+~14 days) plus a flat boost when the path is in the changed set; empty query
+sorts by recency alone; cap rendered rows at `MAX_RESULTS`.
+
+---
+
+## Implementation Units
+
+Phase 1 (U1–U6) is a complete, usable feature on its own. Phase 2 (U7–U8) layers
+the opt-in `@` trigger on top without touching the Phase 1 confirm path.
+
+### U1. Extract shared fuzzy matcher
+
+**Goal:** Move the fuzzy-match logic out of `FileFinderDialog` into a shared module so the context picker reuses one matcher.
+
+**Requirements:** R2, R11
+
+**Dependencies:** none
+
+**Files:**
+- create `src/lib/fuzzy.ts`
+- modify `src/components/dialogs/FileFinderDialog.tsx`
+- create `src/lib/fuzzy.test.ts` (Vitest; see test-harness KTD)
+
+**Approach:** Move `matchTerm`, `fuzzyScore`, and the `Scored` interface verbatim into `src/lib/fuzzy.ts` and export them. `FileFinderDialog` imports them and deletes its inline copies. No scoring change — this is a pure relocation. The `Highlighted` component and `MAX_RESULTS` stay in `FileFinderDialog` (or `MAX_RESULTS` moves to `fuzzy.ts` if the context picker wants to share the cap; either is fine — pick one home and import).
+
+**Patterns to follow:** the existing functions in `src/components/dialogs/FileFinderDialog.tsx`.
+
+**Test scenarios:**
+- Substring match beats scattered subsequence (e.g. query `review` highlights contiguous `Review`, not greedy r-e-v-i-e-w).
+- Multi-term query is AND-ed: `components broa` matches a path containing both terms; missing either term returns null.
+- Word-boundary / basename bonuses applied (match after `/`, `-`, `_`, `.` scores higher; basename match beats dir match).
+- Empty query returns a zero-score match (not null).
+- Characterization: a fixed sample list ranks in the same order before and after extraction.
+
+**Verification:** `⌘P` still fuzzy-finds and highlights identically in-app; pure-function scenarios pass.
+
+### U2. `workspace_context_files` Rust command + IPC wrapper
+
+**Goal:** Provide a file list enriched with modification time and directory entries for recency ranking and folder selection.
+
+**Requirements:** R3, R6
+
+**Dependencies:** none
+
+**Files:**
+- modify `src-tauri/src/lib.rs` (new `async fn workspace_context_files`, `ContextFile` struct, register in the `invoke_handler!`, `#[cfg(test)]` unit test for the dir-synthesis helper)
+- modify `src/lib/ipc.ts` (`workspaceContextFiles` wrapper + `ContextFile` interface)
+- modify `src/lib/types.ts` if the shared type lives there instead of `ipc.ts`
+
+**Approach:** `async fn` + `tauri::async_runtime::spawn_blocking` (per the long-running-IPC rule). Run the same `git ls-files --cached --others --exclude-standard` the finder uses. For each returned file, `fs::metadata(...).modified()` → epoch milliseconds (`mtime_ms: i64`; on stat failure default to 0). Synthesize directory entries: collect the set of unique ancestor directory prefixes across all file paths; emit each as a `ContextFile { is_dir: true }` with `mtime_ms` = max child mtime (or 0). Return `Vec<ContextFile { path, mtime_ms, is_dir }>`. Keep the dir-synthesis as a small pure helper so it is unit-testable without a real repo.
+
+**Patterns to follow:** `workspace_list_files_for_finder` (the git call + spawn_blocking shape) and the inline `#[cfg(test)]` tests near `src-tauri/src/lib.rs:4539`.
+
+**Test scenarios:** (Rust `cargo test`, on the pure dir-synthesis helper)
+- A flat file list with no nesting yields zero synthesized directories.
+- `a/b/c.ts` plus `a/d.ts` yields directories `a` and `a/b` exactly once each (no duplicates).
+- Directory `mtime_ms` equals the max of its descendant files' mtimes.
+- Empty file list yields an empty result.
+- Note: ignore-rule correctness is delegated to `git ls-files` (integration-level, verified in-app), not unit-tested here.
+
+**Verification:** command returns files + dirs + mtimes for a real workspace; `cargo test` passes for the synthesis helper.
+
+### U3. Context-picker UI store state
+
+**Goal:** Hold the picker's open state and its insertion target without churning the workspace tree.
+
+**Requirements:** R1, R8
+
+**Dependencies:** none
+
+**Files:**
+- modify `src/store/ui.ts`
+
+**Approach:** Add `contextPicker: { wsId: string; ptyId: string } | null` to `UIState`, plus `openContextPicker(wsId, ptyId)` and `closeContextPicker()`, mirroring the `fileFinderWsId` / `openFileFinder` / `closeFileFinder` triple. Keeps the target PTY alongside the open flag so the dialog knows where to write on confirm.
+
+**Patterns to follow:** the `fileFinderWsId` state + actions in `src/store/ui.ts`.
+
+**Test expectation:** none — trivial store wiring; exercised through U5 behavior.
+
+**Verification:** dialog opens/closes off this state; no workspace-tree re-render churn when toggled.
+
+### U4. Ranking and insertion-string helpers
+
+**Goal:** Pure functions for recency-blended ranking and `@path` insertion-string construction.
+
+**Requirements:** R3, R6, R8
+
+**Dependencies:** U1 (uses `fuzzyScore`), U2 (consumes `ContextFile`)
+
+**Files:**
+- create `src/lib/contextPicker.ts`
+- create `src/lib/contextPicker.test.ts` (Vitest)
+
+**Approach:** `rankContextFiles(files, changedSet, query, nowMs)` → scored/sorted rows: combine `fuzzyScore` with a recency boost (mtime half-life ~14 days, normalized) weighted at roughly a quarter of the match magnitude, plus a flat boost when the path is in `changedSet`; empty query short-circuits to a recency (then changed) sort. `buildInsertion(selected)` where each entry knows its path + is_dir → joins `@<path>` tokens space-separated with one trailing space, appends `/` to directory tokens, backslash-escapes spaces in paths. `nowMs` is passed in (not read from a clock inside) so the function is deterministic in tests.
+
+**Patterns to follow:** pi-agent reference recency model (14-day half-life) noted in the origin doc; the backslash-escape convention from the app's drag-drop behavior described in the origin doc.
+
+**Test scenarios:**
+- Recency: with equal fuzzy scores, the more recently modified file ranks higher; a file modified ~14 days ago gets roughly half the boost of a just-modified file.
+- Git-changed boost: a changed file outranks an equal-fuzzy unchanged file.
+- Match dominance: a strong exact-name match outranks a stale file with a weaker fuzzy match.
+- Empty query: results are ordered newest-first (changed files ahead of equal-mtime unchanged).
+- Insertion single file: `@src/a.ts ` (trailing space).
+- Insertion multiple: `@src/a.ts @src/b.ts ` (space-joined, one trailing space).
+- Insertion directory: `@src/components/ ` (trailing slash).
+- Insertion path with space: `@my\ file.ts ` (escaped).
+- Empty selection: empty string.
+
+**Verification:** pure-function scenarios pass; ranking "feels right" in-app (recent/changed surface first).
+
+### U5. ContextPickerDialog component
+
+**Goal:** The two-pane picker UI: search + multi-select list + chips + live preview, inserting on confirm.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8
+
+**Dependencies:** U1, U2, U3, U4
+
+**Files:**
+- create `src/components/dialogs/ContextPickerDialog.tsx`
+- modify `src/components/dialogs/Dialogs.tsx` (mount `<ContextPickerDialog />`)
+
+**Approach:** Radix dialog, top-anchored like `FileFinderDialog` (`fixed top-12`), wider for two panes (`w-[min(880px,92vw)]`), flexbox-centered with no transform on `Dialog.Content` (sub-pixel rule). On open (keyed off `useUI(s => s.contextPicker)`), fetch `workspaceContextFiles` and `workspaceChanges` in parallel; build the changed-path set; rank via U4. Left pane: search input (`spellCheck=false`, `autoCorrect/Capitalize/Complete=off`), a chips row for the current selection (click chip to remove), and a `MAX_RESULTS`-capped results list with file icons (`fileIconUrl`), check marks on selected rows, mouse-follow highlight. Right pane: preview of the highlighted entry — debounced (~120ms) `workspaceFileRead`, cancellable (ignore late results for a path no longer highlighted), client-side truncate (~200 lines / ~10KB), null-byte → "Binary file", strip ANSI/control chars; for a highlighted directory show a short child listing instead. Keyboard: `↑/↓` move, `Tab`/`Space` toggle selection, `Enter` confirm (`buildInsertion` → `ipc.ptyWrite(contextPicker.ptyId, encodedBytes)` → `closeContextPicker`), `Esc` cancel. Round any pixel dimensions.
+
+**Patterns to follow:** `src/components/dialogs/FileFinderDialog.tsx` (dialog shell, list, keyboard nav, icons), `src/components/dialogs/FindInFilesDialog.tsx` (preview rendering, cancellable streaming/late-result guard), `src/lib/ipc.ts#ptyWrite` (`Array.from(new TextEncoder().encode(str))`).
+
+**Test scenarios:** (UI — manual/in-app per repo convention; pure pieces delegated to U4)
+- Open with empty query shows recent/changed files first.
+- Typing filters; highlighting matched characters mirrors `⌘P`.
+- `Tab`/`Space` adds a chip; clicking a chip removes it; `Enter` with checked files inserts all; `Enter` with none checked inserts the highlighted row.
+- Highlighting a text file shows a preview; a binary shows "Binary file"; a folder shows a child listing.
+- Confirm writes the expected `@path` string into the focused terminal and closes.
+- Large repo (thousands of files): typing and arrow-nav stay responsive; preview never blocks nav.
+- `Esc` closes without inserting.
+
+**Verification:** end-to-end in-app insertion into a live agent terminal; no terminal flicker or nav jank on a large repo.
+
+### U6. `⌘I` shortcut + target-PTY resolution
+
+**Goal:** Open the picker over the correct terminal from a global shortcut.
+
+**Requirements:** R1, R9
+
+**Dependencies:** U3, U5
+
+**Files:**
+- modify `src/hooks/useShortcuts.ts`
+- create `src/lib/activeTerminal.ts` (pure resolver) + `src/lib/activeTerminal.test.ts` (Vitest)
+
+**Approach:** Add an `⌘I` (`i`, no shift) branch in `useShortcuts.ts`, scoped to an active workspace, no `isTyping` guard (xterm hidden-textarea rationale, same as `⌘P`), always `preventDefault`. Factor the target resolution into a pure `resolveTargetPty(state, wsId, bottomFocused)` helper that returns a `ptyId` or null using the precedence: bottom-split focused → active bottom tab's `ptyId`; else active main tab if it is a terminal → its `ptyId`; else first terminal tab in the workspace → its `ptyId`; else null. The handler passes `document.activeElement.closest("[data-bottom-split]")` as `bottomFocused`. Null → `pushToast("No terminal to insert into")`; otherwise `openContextPicker(wsId, ptyId)`.
+
+**Patterns to follow:** the `⌘P` handler and the `[data-bottom-split]` focus checks for `⌘W`/`⌘T`/`⌘K` in `src/hooks/useShortcuts.ts`; `pushToast` in `src/store/ui.ts`.
+
+**Test scenarios:** (`resolveTargetPty`, pure)
+- Bottom-split focused with an active bottom tab → that bottom tab's pty.
+- Main terminal tab active (no bottom focus) → that tab's pty.
+- Active main tab is an editor but a terminal tab exists → first terminal tab's pty.
+- No terminal tabs in the workspace → null.
+- Terminal tab present but with no `ptyId` yet (not spawned) → skipped / null as appropriate.
+
+**Verification:** `⌘I` from a focused agent terminal opens the picker targeting it; from the editor it still opens targeting a terminal; in a terminal-less workspace it toasts.
+
+### U7. `contextAtTrigger` preference + Settings toggle
+
+**Goal:** Persisted, default-off preference gating the `@` trigger, exposed in Settings.
+
+**Requirements:** R10
+
+**Dependencies:** none
+
+**Files:**
+- modify `src/store/prefs.ts`
+- modify `src/components/settings/GeneralSection.tsx`
+
+**Approach:** Add `contextAtTrigger: boolean` to `PrefsState` with localStorage key `contextAtTrigger`, default `false`, plus `setContextAtTrigger` following the `desktopNotifications` setter shape (localStorage write + `set`). Add a `<Toggle>` in `GeneralSection` ("Open the context picker when you type @ in a terminal") in a bordered section like the existing toggles.
+
+**Patterns to follow:** `desktopNotifications` / `settledHighlight` prefs in `src/store/prefs.ts` and the local `Toggle` component in `src/components/settings/GeneralSection.tsx`.
+
+**Test expectation:** none — pref plumbing; verify the toggle persists across relaunch in-app.
+
+**Verification:** toggling persists; `usePrefs.getState().contextAtTrigger` reflects it.
+
+### U8. `@`-key interception in TerminalPane
+
+**Goal:** When enabled, typing `@` at a word boundary opens the picker and swallows the `@`; cancel re-emits it.
+
+**Requirements:** R10
+
+**Dependencies:** U3, U5, U7
+
+**Files:**
+- modify `src/components/workspace/TerminalPane.tsx`
+- create `src/lib/atTrigger.ts` (pure word-boundary check) + `src/lib/atTrigger.test.ts` (Vitest)
+
+**Approach:** Inside the existing `term.onData` callback (around `src/components/workspace/TerminalPane.tsx:830`), before the `ipc.ptyWrite`: if `data === "@"` and `usePrefs.getState().contextAtTrigger` and `isAtWordBoundary(term)` — swallow (return without writing) and `openContextPicker(ws.id, ptyId)`. Factor the boundary check into a pure `isAtWordBoundary(buffer-ish)` helper reading `term.buffer.active`: boundary when cursor is at column 0 or the cell immediately before the cursor is whitespace/empty. Cancel re-emit: `closeContextPicker` cannot tell why it closed, so track open-origin — when the picker was opened via `@`-swallow and closes without insertion, write the literal `@` back to that pty. (Store the origin on the `contextPicker` state set in U3, e.g. an `atOrigin?: boolean`, or have the dialog's cancel path re-emit when an origin flag is present.)
+
+**Patterns to follow:** the `term.onData` encode→`ipc.ptyWrite` path already in `src/components/workspace/TerminalPane.tsx`.
+
+**Technical design (directional, not implementation spec):** the cancel re-emit is the one piece of state to thread — closing the picker needs to know whether to put the `@` back. Simplest shape: `openContextPicker(wsId, ptyId, atOrigin)` records `atOrigin`; the dialog's cancel handler, when `atOrigin` is set and no insertion happened, calls `ptyWrite(ptyId, ["@"])` before closing. Confirm never re-emits (the `@` is already the first char of the inserted token).
+
+**Test scenarios:**
+- `isAtWordBoundary`: cursor at column 0 → true.
+- `isAtWordBoundary`: previous cell is a space/empty → true.
+- `isAtWordBoundary`: previous cell is a non-space char → false.
+- (manual/in-app) Pref off: `@` types into the terminal normally, picker does not open.
+- (manual/in-app) Pref on, boundary: `@` opens the picker and does not appear in the terminal.
+- (manual/in-app) Pref on, cancel: the literal `@` appears after Esc.
+- (manual/in-app) Pref on, confirm: inserted tokens start with a single `@` (no doubled `@`).
+- (manual/in-app) Pref on, mid-word (`foo@`): `@` types normally, picker does not open.
+
+**Verification:** all four enabled/disabled × confirm/cancel paths behave per R10 in a live terminal; the boundary helper's scenarios pass.
+
+---
+
+## Scope Boundaries
+
+In scope: the picker, its two triggers, recency + git-changed ranking, folder
+selection, live preview, the new Rust command, and the opt-in preference. Both
+phases ship in this plan.
+
+### Deferred to Follow-Up Work
+
+- Cross-project / global file search (the pi-agent reference's `Ctrl+G`). The picker is workspace-scoped.
+- A byte-capped Rust preview-read command. v1 reuses `workspace_file_read` with client-side truncation; revisit only if huge files slip past the `git ls-files` filter and cause preview jank.
+- Caching the file list across opens. Refetch-on-open is the deliberate choice, matching `⌘P`.
+
+### Non-goals
+
+- Inserting context into the CodeMirror editor. Context is an agent-terminal concept; the editor is not an insertion target.
+- A bespoke `@`-token escaping scheme per agent CLI. Backslash-escaping spaces is best-effort parity with Terminal.app; agent `@`-parsers vary and full per-agent quoting is out of scope (see Risks).
+
+---
+
+## Risks & Dependencies
+
+- `@`-parser variance: agents differ in how they parse `@path` tokens, especially paths containing spaces. Backslash-escaping is best-effort; a path with spaces may not resolve in every agent. Mitigation: spaces in repo paths are rare; document the limitation; `⌘I` users see exactly what was inserted.
+- Word-boundary heuristic fragility: `term.buffer.active` reflects the rendered TUI, which the agent controls, so the boundary check can misfire in unusual prompts. Mitigation: the `@` layer is opt-in (default off) and `⌘I` is the always-correct fallback.
+- Preview IO on large files: a file that passes the `git ls-files` filter but is very large could make `workspace_file_read` expensive. Mitigation: debounced + cancellable preview; client truncation; deferred byte-capped command if it bites.
+- Extraction regression (U1): moving the matcher risks subtly changing `⌘P`. Mitigation: characterization test pins ranking order; in-app `⌘P` check.
+- No existing frontend test harness: the pure-logic test scenarios assume Vitest is added (see KTD). If not added, they convert to a manual checklist. Either way the logic is isolated in pure modules.
+
+---
+
+## Sources / Research
+
+- Origin design spec: `docs/superpowers/specs/2026-05-28-context-picker-design.md` (approved; full behavioral spec and the pi-agent reference model).
+- `src/components/dialogs/FileFinderDialog.tsx` — fuzzy matcher to extract; dialog shell, keyboard nav, icon resolution to mirror.
+- `src/components/dialogs/FindInFilesDialog.tsx` — cancellable late-result guard and preview rendering pattern.
+- `src-tauri/src/lib.rs` — `workspace_list_files_for_finder` (`git ls-files` shape), `workspace_changes` (changed-set source), inline `#[cfg(test)]` tests (~line 4539) to mirror.
+- `src/lib/ipc.ts` — `ptyWrite`, `workspaceFileRead`, `workspaceChanges` wrappers and the camelCase/snake_case convention for adding `workspaceContextFiles`.
+- `src/hooks/useShortcuts.ts` — `⌘P` handler and `[data-bottom-split]` focus checks to mirror for `⌘I` and target resolution.
+- `src/store/prefs.ts` / `src/components/settings/GeneralSection.tsx` — boolean-pref + `Toggle` patterns.

--- a/docs/superpowers/specs/2026-05-28-context-picker-design.md
+++ b/docs/superpowers/specs/2026-05-28-context-picker-design.md
@@ -1,0 +1,223 @@
+# Context Picker — Design Spec
+
+**Date:** 2026-05-28
+**Branch:** `feature/add-context-picker`
+**Status:** Approved, pending implementation plan
+
+## Goal
+
+A two-pane fuzzy file/folder picker that inserts workspace-relative `@path`
+tokens into the active agent terminal, so the user can hand files and folders
+to an agent CLI (claude / codex / gemini) without typing paths by hand.
+
+This is the "advanced" sibling of the existing `⌘P` `FileFinderDialog`: that one
+is single-select, no preview, no recency, and opens an editor tab. The context
+picker is multi-select, has a live preview pane, ranks by recency, and inserts
+into a terminal's PTY instead of opening a tab.
+
+### In scope
+- Multi-select with selection chips.
+- Recency ranking (mtime half-life + git-changed boost).
+- Folder selection (inserts `@path/`).
+- Live preview pane.
+- Two triggers: `⌘I` shortcut (always) and `@`-key interception (toggleable, off by default).
+
+### Out of scope (YAGNI)
+- Cross-project / global search (the pi-agent reference's `Ctrl+G`). Workspace-scoped only.
+- Inserting context into the CodeMirror editor. Context is an agent-terminal concept; the editor is not a target.
+- Caching the file list across opens (refetch-on-open, matching `FileFinderDialog`).
+
+## Target resolution: which terminal receives the insertion
+
+Terminal tabs carry a `ptyId` on the `TerminalTab` type (set via
+`patchTab(ws.id, tab.id, { ptyId })` in the app store). The insertion target
+PTY is resolved with the same focus rule `⌘W` / `⌘T` / `⌘K` already use in
+`useShortcuts.ts`:
+
+1. If the bottom split (`[data-bottom-split]` ancestor) owns focus → the active
+   bottom tab's `ptyId`.
+2. Else if the active main tab is a terminal → its `ptyId`.
+3. Else the first terminal tab in the workspace.
+4. If no terminal tab exists at all → do not open; show a toast
+   ("No terminal to insert into").
+
+For the `@`-interception trigger, no resolution is needed: `TerminalPane`'s
+`term.onData` already has its own `ptyId` in scope and passes it directly.
+
+## Triggers
+
+### Phase 1 — `⌘I` shortcut (robust core)
+
+- Added to `useShortcuts.ts` alongside `⌘P`. `⌘I` (`i`, no shift) is currently
+  unbound.
+- No `isTyping` guard (xterm's hidden textarea always reports as typing, same
+  rationale as `⌘P`). Requires an active workspace.
+- Resolves the target PTY (see above), then calls
+  `openContextPicker(wsId, ptyId)`. `preventDefault` always.
+
+### Phase 2 — `@`-key interception (toggleable enhancement)
+
+- Gated behind a new pref `contextAtTrigger`, **default `false`**.
+- Implemented inside the existing `term.onData` callback in `TerminalPane.tsx`
+  (line ~830), before the `ipc.ptyWrite`:
+  - When `data === "@"` AND the cell immediately before the cursor in
+    `term.buffer.active` is empty / whitespace, or the cursor is at column 0
+    (a "word boundary"), then **swallow** the `@` (do not write it to the PTY)
+    and call `openContextPicker(ws.id, ptyId)`.
+  - Otherwise forward `@` normally.
+- **Cancel** (Esc / dismiss): write the literal `@` back to the PTY so the
+  keystroke the user typed is not lost.
+- **Confirm**: the `@` is the leading character of the first inserted token, so
+  nothing extra is re-added.
+- The word-boundary check is heuristic (the agent's TUI owns the real cursor /
+  prompt rendering). This is acceptable because the feature is opt-in and the
+  `⌘I` path is always available as the reliable fallback.
+
+## Components & files
+
+### New
+- **`src/lib/fuzzy.ts`** — `matchTerm`, `fuzzyScore`, and the `Scored` interface
+  extracted verbatim from `FileFinderDialog`. `FileFinderDialog` is updated to
+  import from here (its UX and scoring stay byte-for-byte identical). Single
+  matcher shared by both pickers.
+- **`src/components/dialogs/ContextPickerDialog.tsx`** — the new picker (see
+  layout below).
+
+### Modified
+- **`src/components/dialogs/FileFinderDialog.tsx`** — import the matcher from
+  `lib/fuzzy.ts` instead of defining it inline. No behavior change.
+- **`src/store/ui.ts`** — add `contextPicker: { wsId: string; ptyId: string } | null`
+  plus `openContextPicker(wsId, ptyId)` / `closeContextPicker()`, mirroring the
+  `fileFinderWsId` pattern. Lives in the UI store so opening it does not churn
+  the workspace tree.
+- **`src/store/prefs.ts`** — add `contextAtTrigger: boolean` (localStorage key
+  `contextAtTrigger`, default `false`) + `setContextAtTrigger`.
+- **`src/hooks/useShortcuts.ts`** — add the `⌘I` handler.
+- **`src/components/workspace/TerminalPane.tsx`** — add the `@`-interception
+  branch inside `term.onData`.
+- **`src/components/dialogs/Dialogs.tsx`** — mount `<ContextPickerDialog/>`.
+- **`src/components/settings/General.tsx`** (Settings → General) — checkbox for
+  "Open the context picker when you type @ in a terminal".
+- **`src/lib/ipc.ts`** — wrapper for the new Rust command.
+- **`src-tauri/src/lib.rs`** — new command + shared ignore-walk helper.
+
+## Rust: file list with mtime
+
+`workspace_list_files_for_finder` returns a flat `Vec<String>` with no mtime, so
+recency ranking needs file modification times.
+
+- New command **`workspace_context_files(id: String) -> Result<Vec<ContextFile>, String>`**
+  where `ContextFile { path: String, mtime_ms: i64, is_dir: bool }`.
+- The walk reuses the **same ignore rules** as
+  `workspace_list_files_for_finder`. Extract a shared Rust helper so the two
+  commands cannot drift (the finder keeps returning `Vec<String>`; the new
+  command returns the richer struct). The walk includes directory entries
+  (needed for folder selection).
+- `mtime_ms` is epoch milliseconds; `is_dir` distinguishes folders for the
+  trailing-slash insertion.
+- IPC wrapper in `lib/ipc.ts`:
+  `workspaceContextFiles(id) => invoke<ContextFile[]>("workspace_context_files", { id })`.
+
+## Ranking
+
+On open, fetch in parallel:
+- `workspaceContextFiles(wsId)` → paths + mtime + is_dir.
+- `workspaceChanges(wsId)` → the set of git-changed paths.
+
+Score for a row = `fuzzyScore(path, query)` + recency boost:
+- **Recency:** 14-day half-life on `mtime_ms` (pi-agent's constant). Normalize to
+  0..1, weight at ~25% of the fuzzy match magnitude so a strong name match still
+  beats a stale-but-fuzzier file.
+- **Git-changed boost:** files in the `workspaceChanges` set get an additional
+  flat bonus so "what I'm actively working on" floats to the top.
+- **Empty query:** sort by recency (and git-changed) alone — the picker opens
+  showing recently-touched files first.
+
+`MAX_RESULTS` caps rendered rows (reuse FileFinder's value).
+
+## Multi-select & insertion
+
+- A `Set<string>` of selected relative paths.
+- `Tab` or `Space` toggles the highlighted row in/out of the set.
+- `↑` / `↓` move the highlight; highlight follows the mouse too (FileFinder
+  convention).
+- Selected rows render a check; a chips row above/below the input shows the
+  count and selected names, removable by click.
+- `Enter` confirms: inserts the selected set, or — if nothing is checked — the
+  single highlighted row.
+- `Esc` cancels (and, for the `@` trigger, re-emits the literal `@`).
+
+**Insertion string:**
+- Each path → `@<relpath>` token. Directories → `@<relpath>/` (trailing slash).
+- Tokens are space-separated with exactly **one trailing space** so the user can
+  keep typing.
+- Spaces inside a path are **backslash-escaped** (`@my\ file.ts`). This is
+  best-effort parity with Terminal.app / iTerm drag-drop; agent `@`-parsers vary
+  in whether they honor the escape, so this is documented as a known limitation.
+  The overwhelming majority of repo paths have no spaces.
+- No leading space is prepended. The `⌘I` path is typically hit at a word
+  boundary; the `@` trigger already sits at one.
+- Write via `ipc.ptyWrite(targetPtyId, Array.from(new TextEncoder().encode(str)))`,
+  then `closeContextPicker()`.
+
+## Preview pane
+
+- Debounced (~120 ms after the highlight settles) `workspaceFileRead(wsId, path)`.
+- Client-side truncate to ~200 lines / ~10 KB before render.
+- Null-byte detection → render "Binary file" instead of garbage.
+- Strip ANSI / control characters before render (render safety).
+- Fetch is cancellable: ignore results for a path that is no longer highlighted
+  (same late-result-guard idea as the grep `searchId` pattern).
+- For a highlighted **folder**, show a short child listing instead of file
+  content.
+- Relies on the file list already excluding `node_modules` / binaries, so reads
+  stay cheap; no new byte-capped Rust read command in v1.
+
+## Layout
+
+Top-anchored Radix dialog (same vertical placement as `FileFinderDialog`,
+`fixed top-12`), wider to fit two panes: `w-[min(880px,92vw)]`. Flexbox-centered
+horizontally, no transforms on `Dialog.Content` (sub-pixel rule). Left column:
+search input, chips row, scrollable results list. Right column: preview. Uses
+`@theme` CSS vars and `cn()` throughout; file icons via `fileIconUrl` (same as
+FileFinder). All inputs `spellCheck={false}` + `autoCorrect/Capitalize/Complete=off`.
+
+## Performance & correctness guards
+
+- Refetch-on-open, no persistent cache.
+- `MAX_RESULTS` cap on rendered rows.
+- Preview fetch debounced + cancellable.
+- `⌘I` and the `@`-swallow both `preventDefault` / suppress the PTY write so the
+  keystroke cannot double-fire.
+- No new always-on global listeners: the `@` layer lives inside the existing
+  `term.onData`; the picker state lives in the UI store.
+- Round any pixel dimensions on write (sub-pixel rule), consistent with the rest
+  of the app.
+
+## Build order
+
+1. **Phase 1 (complete, usable feature):**
+   1. Extract `lib/fuzzy.ts`; repoint `FileFinderDialog`.
+   2. Rust `workspace_context_files` + shared ignore-walk helper; `lib/ipc.ts` wrapper.
+   3. `ui.ts` context-picker state.
+   4. `ContextPickerDialog.tsx` — list + multi-select + recency + preview + insertion.
+   5. `⌘I` in `useShortcuts.ts`; mount in `Dialogs.tsx`.
+2. **Phase 2 (layered enhancement):**
+   1. `prefs.ts` `contextAtTrigger` + Settings → General checkbox.
+   2. `@`-interception in `TerminalPane.tsx` (swallow / open / cancel-re-emit).
+
+## Acceptance criteria
+
+- `⌘I` in a workspace with a terminal opens the picker; with no terminal, shows
+  a toast and does not open.
+- Typing filters with the shared fuzzy matcher; empty query shows recent /
+  git-changed files first.
+- `Tab` / `Space` multi-selects; chips reflect the selection.
+- `Enter` inserts `@path` tokens (folders with trailing slash, spaces escaped,
+  one trailing space) into the resolved terminal's PTY; the picker closes.
+- Preview renders text files, flags binaries, and lists folder children, without
+  janking the picker on large repos.
+- `FileFinderDialog` (`⌘P`) behaves exactly as before.
+- With `contextAtTrigger` on, typing `@` at a word boundary in a terminal opens
+  the picker and swallows the `@`; cancelling re-emits it. With the pref off,
+  `@` types normally.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,8 @@
         "@vitejs/plugin-react": "^6.0.1",
         "tailwindcss": "^4.1.16",
         "typescript": "~5.7.0",
-        "vite": "^8.0.0"
+        "vite": "^8.0.0",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@babel/runtime": {
@@ -1630,9 +1631,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1650,9 +1648,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,9 +1665,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1690,9 +1682,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1710,9 +1699,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1730,9 +1716,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1816,6 +1799,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1952,9 +1942,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,9 +1959,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1992,9 +1976,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2012,9 +1993,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2202,9 +2180,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2222,9 +2197,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2242,9 +2214,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2262,9 +2231,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2282,9 +2248,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2400,6 +2363,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.12.4",
@@ -2705,6 +2693,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -2739,6 +2840,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/class-variance-authority": {
@@ -2776,6 +2897,13 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -2818,6 +2946,33 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -3022,9 +3177,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3046,9 +3198,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3070,9 +3219,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3094,9 +3240,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3189,6 +3332,24 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3369,6 +3530,13 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3378,6 +3546,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -3416,6 +3598,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.2.tgz",
+      "integrity": "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3431,6 +3630,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -3581,11 +3790,118 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.13",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "tailwindcss": "^4.1.16",
     "typescript": "~5.7.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "vitest": "^4.1.7"
   }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3096,6 +3096,83 @@ async fn workspace_list_files_for_finder(id: String) -> Result<Vec<String>, Stri
     .map_err(|e| e.to_string())?
 }
 
+/// One entry returned by `workspace_context_files`: a file or a synthesized
+/// directory, with its modification time for recency ranking in the context
+/// picker (⌘I). Directories carry the max mtime of their descendants.
+#[derive(serde::Serialize, Clone)]
+pub struct ContextFile {
+    pub path: String,
+    pub mtime_ms: i64,
+    pub is_dir: bool,
+}
+
+/// Synthesize directory entries from a list of file entries. Every unique
+/// ancestor directory prefix ("a/b/c.ts" → "a/b" and "a") becomes one
+/// `ContextFile { is_dir: true }` whose `mtime_ms` is the max mtime of its
+/// descendant files. Pure (no filesystem access) so it is unit-testable.
+fn context_dir_entries(files: &[ContextFile]) -> Vec<ContextFile> {
+    use std::collections::HashMap;
+    let mut dirs: HashMap<String, i64> = HashMap::new();
+    for f in files {
+        let mut idx = f.path.rfind('/');
+        while let Some(i) = idx {
+            let dir = &f.path[..i];
+            if dir.is_empty() {
+                break;
+            }
+            let e = dirs.entry(dir.to_string()).or_insert(i64::MIN);
+            if f.mtime_ms > *e {
+                *e = f.mtime_ms;
+            }
+            idx = dir.rfind('/');
+        }
+    }
+    dirs.into_iter()
+        .map(|(path, mtime_ms)| ContextFile { path, mtime_ms, is_dir: true })
+        .collect()
+}
+
+/// Like `workspace_list_files_for_finder` but enriched with per-path
+/// modification time and synthesized directory entries — the data the
+/// context picker needs for recency ranking and folder selection. Reuses the
+/// same `git ls-files` so ignore rules stay identical to the finder.
+#[tauri::command]
+async fn workspace_context_files(id: String) -> Result<Vec<ContextFile>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let w = load_workspaces().into_iter().find(|w| w.id == id).ok_or("no ws")?;
+        let out = std::process::Command::new("git")
+            .args(["ls-files", "--cached", "--others", "--exclude-standard"])
+            .current_dir(&w.path)
+            .output()
+            .map_err(|e| e.to_string())?;
+        if !out.status.success() {
+            return Err(String::from_utf8_lossy(&out.stderr).into_owned());
+        }
+        let s = String::from_utf8_lossy(&out.stdout);
+        let base = Path::new(&w.path);
+        let mut files: Vec<ContextFile> = Vec::new();
+        for line in s.lines() {
+            if line.is_empty() {
+                continue;
+            }
+            // Best-effort mtime; a stat failure (e.g. a dangling symlink)
+            // just sinks the file to the bottom of the recency sort.
+            let mtime_ms = fs::metadata(base.join(line))
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            files.push(ContextFile { path: line.to_string(), mtime_ms, is_dir: false });
+        }
+        let mut all = context_dir_entries(&files);
+        all.extend(files);
+        Ok(all)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 // ───────────────────────────── helpers ─────────────────────────────
 
 fn slugify(s: &str) -> String {
@@ -4420,7 +4497,7 @@ pub fn run() {
             repo_config_load, repo_config_save, repo_config_scaffold, repo_config_add_allowed_host, repo_config_add_allowed_path,
             workspace_delete, workspace_run_script, workspace_run_script_stream, workspace_stop_script, workspace_record_spawn, workspace_set_has_history, workspace_set_agent_session_id,
             workspace_grep_start, workspace_grep_cancel,
-            workspace_diff, workspace_files, workspace_list_files_for_finder, workspace_send_diff_to_main,
+            workspace_diff, workspace_files, workspace_list_files_for_finder, workspace_context_files, workspace_send_diff_to_main,
             workspace_changes, workspace_file_diff, workspace_file_diff_sides, workspace_file_read, workspace_file_write, workspace_dir_list,
             workspace_rename, project_rename,
             pty_spawn, pty_write, pty_resize, pty_kill,
@@ -4587,5 +4664,32 @@ mod tests {
         assert!(s.contains("secrets.env"));
         assert!(s.contains("/y"));
         assert!(!s.contains("/x"));
+    }
+
+    fn cf(path: &str, mtime_ms: i64) -> ContextFile {
+        ContextFile { path: path.into(), mtime_ms, is_dir: false }
+    }
+
+    #[test]
+    fn context_dirs_synthesizes_unique_ancestors_with_max_mtime() {
+        let files = vec![cf("a/b/c.ts", 10), cf("a/d.ts", 20)];
+        let mut dirs = context_dir_entries(&files);
+        dirs.sort_by(|x, y| x.path.cmp(&y.path));
+        let paths: Vec<&str> = dirs.iter().map(|d| d.path.as_str()).collect();
+        assert_eq!(paths, vec!["a", "a/b"]); // each ancestor once
+        assert!(dirs.iter().all(|d| d.is_dir));
+        // "a" sees both files → max(10, 20); "a/b" sees only c.ts → 10
+        assert_eq!(dirs.iter().find(|d| d.path == "a").unwrap().mtime_ms, 20);
+        assert_eq!(dirs.iter().find(|d| d.path == "a/b").unwrap().mtime_ms, 10);
+    }
+
+    #[test]
+    fn context_dirs_flat_list_yields_none() {
+        assert!(context_dir_entries(&[cf("a.ts", 1)]).is_empty());
+    }
+
+    #[test]
+    fn context_dirs_empty_input_yields_none() {
+        assert!(context_dir_entries(&[]).is_empty());
     }
 }

--- a/src/components/dialogs/ContextPickerDialog.tsx
+++ b/src/components/dialogs/ContextPickerDialog.tsx
@@ -1,0 +1,334 @@
+// ⌘I context picker — fuzzy-search workspace files/folders, multi-select, and
+// insert `@path` tokens into the active agent terminal's PTY. The advanced
+// sibling of FileFinderDialog: two panes (list + preview), recency ranking,
+// folder selection. Shares the fuzzy matcher (lib/fuzzy) and ranking/insertion
+// logic (lib/contextPicker); refetches the file list on every open like ⌘P.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Search, Check, Folder, X } from "lucide-react";
+import { useUI } from "@/store/ui";
+import {
+  workspaceContextFiles,
+  workspaceChanges,
+  workspaceFileRead,
+  ptyWrite,
+  type ContextFile,
+} from "@/lib/ipc";
+import { rankContextFiles, buildInsertion } from "@/lib/contextPicker";
+import { fileIconUrl } from "@/lib/explorer/iconResolver";
+import { cn } from "@/lib/utils";
+
+const MAX_RESULTS = 60;
+const PREVIEW_DEBOUNCE_MS = 120;
+const PREVIEW_MAX_LINES = 200;
+const PREVIEW_MAX_BYTES = 10_000;
+
+// Strip ANSI escape sequences and other control chars so a previewed file
+// can't move the cursor / inject escapes into the dialog render.
+function sanitize(text: string): string {
+  return text
+    // eslint-disable-next-line no-control-regex
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f]/g, "");
+}
+
+type Preview =
+  | { kind: "text"; path: string; lines: string[] }
+  | { kind: "dir"; path: string; lines: string[] }
+  | { kind: "binary"; path: string }
+  | { kind: "error"; path: string; msg: string }
+  | null;
+
+function Highlighted({ text, matches }: { text: string; matches: number[] }) {
+  if (!matches.length) return <>{text}</>;
+  const set = new Set(matches);
+  const out: React.ReactNode[] = [];
+  let buf = "";
+  for (let i = 0; i < text.length; i++) {
+    if (set.has(i)) {
+      if (buf) { out.push(buf); buf = ""; }
+      out.push(<b key={i} className="text-[var(--color-accent)] font-semibold">{text[i]}</b>);
+    } else {
+      buf += text[i];
+    }
+  }
+  if (buf) out.push(buf);
+  return <>{out}</>;
+}
+
+export function ContextPickerDialog() {
+  const cp = useUI(s => s.contextPicker);
+  const close = useUI(s => s.closeContextPicker);
+  const wsId = cp?.wsId ?? null;
+
+  const [files, setFiles] = useState<ContextFile[]>([]);
+  const [changed, setChanged] = useState<Set<string>>(() => new Set());
+  const [loadedAt, setLoadedAt] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [preview, setPreview] = useState<Preview>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Refetch files + git-changed set on every open (no cache — matches ⌘P).
+  useEffect(() => {
+    if (!wsId) return;
+    setQuery(""); setActiveIdx(0); setSelected(new Set()); setErr(null);
+    setPreview(null); setLoading(true);
+    let cancelled = false;
+    Promise.all([workspaceContextFiles(wsId), workspaceChanges(wsId).catch(() => null)])
+      .then(([list, changes]) => {
+        if (cancelled) return;
+        const set = new Set<string>();
+        if (changes) {
+          const groups = changes.groups ?? [];
+          if (groups.length) {
+            for (const g of groups) for (const f of g.files) set.add(f.path);
+          } else {
+            for (const f of changes.files) set.add(f.path);
+          }
+        }
+        setFiles(list); setChanged(set); setLoadedAt(Date.now()); setLoading(false);
+      })
+      .catch(e => { if (!cancelled) { setErr(String(e)); setLoading(false); } });
+    return () => { cancelled = true; };
+  }, [wsId]);
+
+  const results = useMemo(() => {
+    if (!files.length) return [];
+    return rankContextFiles(files, changed, query, loadedAt || Date.now()).slice(0, MAX_RESULTS);
+  }, [files, changed, query, loadedAt]);
+
+  const isDirMap = useMemo(() => {
+    const m = new Map<string, boolean>();
+    for (const f of files) m.set(f.path, f.is_dir);
+    return m;
+  }, [files]);
+
+  useEffect(() => { setActiveIdx(0); }, [query]);
+
+  // Keep the active row in view on keyboard nav.
+  useEffect(() => {
+    listRef.current?.querySelector<HTMLElement>(`[data-row="${activeIdx}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx]);
+
+  const active = results[activeIdx];
+
+  // Debounced, cancellable preview of the highlighted entry.
+  useEffect(() => {
+    if (!wsId || !active) { setPreview(null); return; }
+    let cancelled = false;
+    const { path, is_dir } = active;
+    const handle = window.setTimeout(async () => {
+      if (is_dir) {
+        const prefix = path + "/";
+        const kids = files
+          .filter(f => f.path.startsWith(prefix))
+          .map(f => f.path.slice(prefix.length).split("/")[0])
+          .filter((v, i, a) => a.indexOf(v) === i)
+          .slice(0, 100);
+        if (!cancelled) setPreview({ kind: "dir", path, lines: kids });
+        return;
+      }
+      try {
+        const content = await workspaceFileRead(wsId, path);
+        if (cancelled) return;
+        if (content.includes("\u0000")) { setPreview({ kind: "binary", path }); return; }
+        const lines = sanitize(content.slice(0, PREVIEW_MAX_BYTES)).split("\n").slice(0, PREVIEW_MAX_LINES);
+        setPreview({ kind: "text", path, lines });
+      } catch (e) {
+        if (!cancelled) setPreview({ kind: "error", path, msg: String(e) });
+      }
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => { cancelled = true; window.clearTimeout(handle); };
+  }, [wsId, active?.path, active?.is_dir, files]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function toggle(path: string) {
+    setSelected(prev => {
+      const n = new Set(prev);
+      if (n.has(path)) n.delete(path); else n.add(path);
+      return n;
+    });
+  }
+
+  // Close, re-emitting the literal '@' to the PTY when the picker was opened
+  // by swallowing a typed '@' and nothing was inserted. Idempotent: reads the
+  // live store, so a second close (Radix onOpenChange after our Esc handler)
+  // sees a null picker and re-emits nothing.
+  function closeMaybeReemit(inserted: boolean) {
+    const c = useUI.getState().contextPicker;
+    if (!inserted && c?.atOrigin) ptyWrite(c.ptyId, [0x40]).catch(() => {});
+    close();
+  }
+
+  function confirm() {
+    if (!cp) return;
+    let chosen: { path: string; is_dir: boolean }[];
+    if (selected.size > 0) {
+      chosen = [...selected].map(p => ({ path: p, is_dir: !!isDirMap.get(p) }));
+    } else if (active) {
+      chosen = [{ path: active.path, is_dir: active.is_dir }];
+    } else {
+      return;
+    }
+    const str = buildInsertion(chosen);
+    if (str) ptyWrite(cp.ptyId, Array.from(new TextEncoder().encode(str))).catch(() => {});
+    closeMaybeReemit(true);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault(); setActiveIdx(i => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault(); setActiveIdx(i => Math.max(i - 1, 0));
+    } else if (e.key === "Tab") {
+      // Tab toggles multi-select on the active row. (Space is NOT a toggle —
+      // it's needed for multi-term fuzzy queries in the search box.)
+      e.preventDefault();
+      if (active) toggle(active.path);
+    } else if (e.key === "Enter") {
+      e.preventDefault(); confirm();
+    } else if (e.key === "Escape") {
+      e.preventDefault(); closeMaybeReemit(false);
+    }
+  }
+
+  const selectedList = [...selected];
+
+  return (
+    <Dialog.Root open={!!cp} onOpenChange={(v) => { if (!v) closeMaybeReemit(false); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40" />
+        <Dialog.Content
+          className="fixed left-1/2 top-12 z-50 flex h-[70vh] w-[min(880px,92vw)] -translate-x-1/2 flex-col overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-1)] shadow-2xl outline-none"
+          onKeyDown={onKeyDown}
+        >
+          <Dialog.Title className="sr-only">Add context</Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Fuzzy-search files and folders to insert as @path tokens into the active terminal.
+          </Dialog.Description>
+
+          {/* Search */}
+          <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-2.5">
+            <Search className="h-4 w-4 shrink-0 text-[var(--color-fg-faint)]" />
+            <input
+              autoFocus
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+              autoComplete="off"
+              placeholder={loading ? "Loading files…" : "Add context — Tab to multi-select, Enter to insert"}
+              className="w-full bg-transparent pl-1 text-[14px] text-[var(--color-fg)] placeholder:text-[var(--color-fg-faint)] focus:outline-none"
+            />
+          </div>
+
+          {/* Selection chips */}
+          {selectedList.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 border-b border-[var(--color-border)] px-3 py-2">
+              {selectedList.map(p => {
+                const name = p.split("/").pop() || p;
+                return (
+                  <button
+                    key={p}
+                    onClick={() => toggle(p)}
+                    title={p}
+                    className="flex items-center gap-1 rounded bg-[var(--color-bg-2)] px-1.5 py-0.5 text-[12px] text-[var(--color-fg)] hover:bg-[var(--color-bg-3)]"
+                  >
+                    <span className="max-w-[180px] truncate">{name}{isDirMap.get(p) ? "/" : ""}</span>
+                    <X className="h-3 w-3 shrink-0 text-[var(--color-fg-faint)]" />
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Two panes */}
+          <div className="flex min-h-0 flex-1">
+            {/* List */}
+            <div ref={listRef} className="w-[44%] min-w-0 overflow-y-auto border-r border-[var(--color-border)] py-1">
+              {err && <div className="px-3 py-3 text-[13px] text-[var(--color-err)]">{err}</div>}
+              {!err && !loading && results.length === 0 && (
+                <div className="px-3 py-3 text-[13px] text-[var(--color-fg-faint)]">
+                  {query ? "No matches" : "No files"}
+                </div>
+              )}
+              {results.map((r, i) => {
+                const name = r.path.split("/").pop() || r.path;
+                const dir = r.path.slice(0, r.path.length - name.length);
+                const nameStart = dir.length;
+                const nameMatches = r.matches.filter(m => m >= nameStart).map(m => m - nameStart);
+                const dirMatches = r.matches.filter(m => m < nameStart);
+                const isSel = selected.has(r.path);
+                return (
+                  <button
+                    key={r.path}
+                    data-row={i}
+                    onClick={() => { setActiveIdx(i); toggle(r.path); }}
+                    onMouseMove={() => setActiveIdx(i)}
+                    className={cn(
+                      "flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px]",
+                      i === activeIdx ? "bg-[var(--color-bg-2)] text-[var(--color-fg)]" : "text-[var(--color-fg)]",
+                    )}
+                  >
+                    <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                      {isSel
+                        ? <Check className="h-3.5 w-3.5 text-[var(--color-accent)]" />
+                        : r.is_dir
+                          ? <Folder className="h-4 w-4 text-[var(--color-fg-faint)]" />
+                          : <img src={fileIconUrl(name)} alt="" className="h-4 w-4 file-icon" />}
+                    </span>
+                    <span className="truncate">
+                      <Highlighted text={name} matches={nameMatches} />{r.is_dir ? "/" : ""}
+                    </span>
+                    {dir && (
+                      <span className="ml-2 min-w-0 flex-1 truncate text-[12px] text-[var(--color-fg-faint)]">
+                        <Highlighted text={dir.replace(/\/$/, "")} matches={dirMatches} />
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Preview */}
+            <div className="min-w-0 flex-1 overflow-auto bg-[var(--color-bg)]">
+              {!preview && (
+                <div className="p-3 text-[12px] text-[var(--color-fg-faint)]">
+                  {active ? "" : "Select a file to preview"}
+                </div>
+              )}
+              {preview?.kind === "binary" && (
+                <div className="p-3 text-[12px] text-[var(--color-fg-faint)]">Binary file</div>
+              )}
+              {preview?.kind === "error" && (
+                <div className="p-3 text-[12px] text-[var(--color-err)]">{preview.msg}</div>
+              )}
+              {preview?.kind === "dir" && (
+                <div className="p-3">
+                  <div className="mb-1 text-[12px] text-[var(--color-fg-faint)]">
+                    {preview.lines.length} item{preview.lines.length === 1 ? "" : "s"}
+                  </div>
+                  <pre className="whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-[var(--color-fg-dim)]">
+                    {preview.lines.join("\n")}
+                  </pre>
+                </div>
+              )}
+              {preview?.kind === "text" && (
+                <pre className="p-3 font-mono text-[12px] leading-relaxed text-[var(--color-fg-dim)]">
+                  {preview.lines.join("\n")}
+                </pre>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/dialogs/Dialogs.tsx
+++ b/src/components/dialogs/Dialogs.tsx
@@ -14,6 +14,7 @@ import { WorkspaceSandboxDialog } from "./WorkspaceSandboxDialog";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { FileFinderDialog } from "./FileFinderDialog";
 import { FindInFilesDialog } from "./FindInFilesDialog";
+import { ContextPickerDialog } from "./ContextPickerDialog";
 import { Loader2 } from "lucide-react";
 
 export function Dialogs() {
@@ -37,6 +38,7 @@ export function Dialogs() {
       <ConfirmDialog />
       <FileFinderDialog />
       <FindInFilesDialog />
+      <ContextPickerDialog />
       {/* Blocking work overlay: shown while a slow IPC call is in flight
           (archive workspace, etc.). Click-blocks the whole window so users
           don't fire the action twice mid-wait. */}

--- a/src/components/dialogs/FileFinderDialog.tsx
+++ b/src/components/dialogs/FileFinderDialog.tsx
@@ -9,87 +9,10 @@ import { useUI } from "@/store/ui";
 import { useApp } from "@/store/app";
 import { workspaceListFilesForFinder } from "@/lib/ipc";
 import { fileIconUrl } from "@/lib/explorer/iconResolver";
+import { fuzzyScore, type Scored } from "@/lib/fuzzy";
 import { cn } from "@/lib/utils";
 
 const MAX_RESULTS = 50;
-
-interface Scored {
-  path: string;
-  score: number;
-  /** Indexes into `path` that matched a query char — for bolding. */
-  matches: number[];
-}
-
-/**
- * Single-term match. Tries substring first (so "review" highlights the
- * full contiguous "Review", not scattered r-e-v-i-e-w chars greedily
- * picked from earlier in the path) — preferring occurrences inside the
- * basename and at word boundaries. Falls back to subsequence.
- */
-function matchTerm(s: string, lower: string, term: string, slash: number): { score: number; matches: number[] } | null {
-  const t = term.toLowerCase();
-  // Substring fast path: scan all occurrences, pick the best by
-  // basename-ness + word-boundary-ness. Contiguous matches always beat
-  // scattered subsequence matches (huge consecutive bonus below).
-  let bestSubstr: { idx: number; score: number } | null = null;
-  for (let i = lower.indexOf(t); i !== -1; i = lower.indexOf(t, i + 1)) {
-    let sc = 100 + t.length * 9; // baseline: contiguous run of t.length chars
-    const prev = i > 0 ? s[i - 1] : "/";
-    if (prev === "/" || prev === "-" || prev === "_" || prev === ".") sc += 10;
-    if (i > slash) sc += 8;
-    sc -= i * 0.05; // mild earlier-is-better tiebreak
-    if (!bestSubstr || sc > bestSubstr.score) bestSubstr = { idx: i, score: sc };
-  }
-  if (bestSubstr) {
-    const matches: number[] = [];
-    for (let i = 0; i < t.length; i++) matches.push(bestSubstr.idx + i);
-    return { score: bestSubstr.score, matches };
-  }
-  // Subsequence fallback for typos / out-of-order chars.
-  const matches: number[] = [];
-  let qi = 0;
-  let prevMatch = -2;
-  let score = 0;
-  for (let i = 0; i < lower.length && qi < t.length; i++) {
-    if (lower[i] !== t[qi]) continue;
-    matches.push(i);
-    let bonus = 1;
-    if (i === prevMatch + 1) bonus += 8;
-    const prev = i > 0 ? s[i - 1] : "/";
-    if (prev === "/" || prev === "-" || prev === "_" || prev === ".") bonus += 4;
-    if (i > slash) bonus += 2;
-    if (s[i] === term[qi]) bonus += 1;
-    score += bonus;
-    prevMatch = i;
-    qi++;
-  }
-  if (qi < t.length) return null;
-  return { score, matches };
-}
-
-/**
- * Fuzzy match. Splits the query on whitespace into AND-ed terms — every
- * term must subsequence-match (Sublime / fzf convention: "components
- * broa" finds files containing both). Each term gets its own independent
- * pass so the order/positions of terms don't have to line up.
- */
-function fuzzyScore(s: string, query: string): Scored | null {
-  if (!query) return { path: s, score: 0, matches: [] };
-  const terms = query.split(/\s+/).filter(Boolean);
-  if (!terms.length) return { path: s, score: 0, matches: [] };
-  const lower = s.toLowerCase();
-  const slash = s.lastIndexOf("/");
-  const allMatches = new Set<number>();
-  let total = 0;
-  for (const t of terms) {
-    const r = matchTerm(s, lower, t, slash);
-    if (!r) return null;
-    total += r.score;
-    for (const m of r.matches) allMatches.add(m);
-  }
-  total -= s.length * 0.01;
-  return { path: s, score: total, matches: [...allMatches].sort((a, b) => a - b) };
-}
 
 function Highlighted({ text, matches }: { text: string; matches: number[] }) {
   if (!matches.length) return <>{text}</>;

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -37,6 +37,8 @@ export function GeneralSection() {
   const setSandboxBypassPermissions = usePrefs(s => s.setSandboxBypassPermissions);
   const workspaceExpandMode = usePrefs(s => s.workspaceExpandMode);
   const setWorkspaceExpandMode = usePrefs(s => s.setWorkspaceExpandMode);
+  const contextAtTrigger = usePrefs(s => s.contextAtTrigger);
+  const setContextAtTrigger = usePrefs(s => s.setContextAtTrigger);
 
   useEffect(() => {
     settingsLoad().then(s => {
@@ -148,6 +150,15 @@ export function GeneralSection() {
           hint="Notify when an inactive agent finishes or rings the bell. Clicking back in jumps to that tab."
           value={desktopNotifications}
           onChange={setDesktopNotifications}
+        />
+      </div>
+
+      <div className="border-t border-[var(--color-border-soft)] pt-6">
+        <Toggle
+          label="Open the context picker when you type @"
+          hint="In an agent terminal, typing @ at the start of a word opens the file context picker. The ⌘I shortcut always works regardless of this setting."
+          value={contextAtTrigger}
+          onChange={setContextAtTrigger}
         />
       </div>
 

--- a/src/components/workspace/TerminalPane.tsx
+++ b/src/components/workspace/TerminalPane.tsx
@@ -12,6 +12,7 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { loadTerminalRenderer } from "@/lib/terminalRenderer";
+import { isAtWordBoundary } from "@/lib/atTrigger";
 import type { TerminalTab, Workspace } from "@/lib/types";
 import * as ipc from "@/lib/ipc";
 import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg } from "@/store/prefs";
@@ -828,6 +829,20 @@ export function TerminalPane({ ws, tab, active }: Props) {
         // user actually types; matching that means clicking the tab to
         // check doesn't make the indicator vanish.
         term.onData(data => {
+          // Context picker (opt-in): typing '@' at a word boundary opens the
+          // picker and SWALLOWS the '@' (no ptyWrite). The picker re-emits the
+          // literal '@' on cancel via the atOrigin flag, or starts its first
+          // token with it on confirm — so the keystroke is never lost. ⌘I is
+          // the always-on alternative. Mid-word '@' (e.g. an email) passes
+          // through untouched.
+          if (data === "@" && usePrefs.getState().contextAtTrigger) {
+            const buf = term.buffer.active;
+            const before = buf.getLine(buf.cursorY)?.getCell(Math.max(0, buf.cursorX - 1))?.getChars() ?? "";
+            if (isAtWordBoundary(buf.cursorX, before)) {
+              useUI.getState().openContextPicker(ws.id, ptyId, true);
+              return;
+            }
+          }
           patchTab(ws.id, tab.id, { lastInputAt: Date.now() });
           settledRef.current = { lastHash: 0, unchangedCount: 0, marked: false };
           scrollbackRef.current = { lastLen: -1, stableCount: 0, marked: false };

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -17,6 +17,7 @@ import { useEffect } from "react";
 import { useApp } from "@/store/app";
 import { useUI } from "@/store/ui";
 import { requestCloseTab } from "@/lib/closeTab";
+import { resolveTargetPty } from "@/lib/activeTerminal";
 
 export function useShortcuts() {
   useEffect(() => {
@@ -91,6 +92,22 @@ export function useShortcuts() {
       if (e.shiftKey && e.key.toLowerCase() === "f" && wsId) {
         e.preventDefault();
         useUI.getState().openFindInFiles(wsId);
+        return;
+      }
+
+      // ⌘I → context picker: insert @path tokens into the active agent
+      // terminal. Cmd ONLY (e.metaKey), never Ctrl — Ctrl+I is Tab (0x09)
+      // and must reach the terminal untouched. No `isTyping` guard (same
+      // xterm hidden-textarea reason as ⌘P). Resolves the target PTY; with
+      // no spawned terminal in the workspace it toasts instead of opening.
+      if (e.metaKey && e.key.toLowerCase() === "i" && !e.shiftKey && wsId) {
+        e.preventDefault();
+        const pty = resolveTargetPty(tabs, activeTabId);
+        if (!pty) {
+          useUI.getState().pushToast("No terminal to insert into", "info");
+          return;
+        }
+        useUI.getState().openContextPicker(wsId, pty);
         return;
       }
 

--- a/src/lib/activeTerminal.test.ts
+++ b/src/lib/activeTerminal.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { resolveTargetPty } from "./activeTerminal";
+import type { Tab } from "./types";
+
+const term = (id: string, ptyId?: string): Tab =>
+  ({ id, type: "terminal", title: id, cli: "claude", ptyId } as Tab);
+const edit = (id: string): Tab => ({ id, type: "edit", title: id, path: `${id}.ts` } as Tab);
+
+describe("resolveTargetPty", () => {
+  it("returns the active terminal tab's pty", () => {
+    const tabs = [term("a", "pty-a"), term("b", "pty-b")];
+    expect(resolveTargetPty(tabs, "b")).toBe("pty-b");
+  });
+
+  it("falls back to the first terminal pty when the active tab is an editor", () => {
+    const tabs = [edit("doc"), term("t", "pty-t")];
+    expect(resolveTargetPty(tabs, "doc")).toBe("pty-t");
+  });
+
+  it("returns null when there are no terminal tabs", () => {
+    expect(resolveTargetPty([edit("a"), edit("b")], "a")).toBeNull();
+  });
+
+  it("returns null when the only terminal has not spawned a pty yet", () => {
+    expect(resolveTargetPty([term("a")], "a")).toBeNull();
+  });
+
+  it("skips an un-spawned active terminal and uses a later spawned one", () => {
+    const tabs = [term("a"), term("b", "pty-b")];
+    expect(resolveTargetPty(tabs, "a")).toBe("pty-b");
+  });
+});

--- a/src/lib/activeTerminal.ts
+++ b/src/lib/activeTerminal.ts
@@ -1,0 +1,27 @@
+// Resolve which terminal PTY a workspace-scoped action (the ⌘I context
+// picker) should write into. Pure so it's unit-testable.
+//
+// Scope: the main-area agent terminals only. Bottom-split scratch shells are
+// intentionally excluded — their PTY id lives inside the AuxTerminal component
+// (not the store), and inserting agent @context into a plain shell isn't
+// meaningful. The @-interception path (TerminalPane) targets its own PTY
+// directly and doesn't go through here.
+
+import type { Tab } from "@/lib/types";
+
+const ptyOf = (t: Tab | undefined): string | null =>
+  t && t.type === "terminal" && t.ptyId ? t.ptyId : null;
+
+/** Returns the active main terminal tab's PTY id, falling back to the first
+ *  main terminal tab that has a live PTY. Null when the workspace has no
+ *  spawned terminal (e.g. only editor/diff tabs, or a terminal that hasn't
+ *  spawned yet). */
+export function resolveTargetPty(tabs: Tab[], activeTabId: string | undefined): string | null {
+  const activePty = ptyOf(tabs.find(t => t.id === activeTabId));
+  if (activePty) return activePty;
+  for (const t of tabs) {
+    const p = ptyOf(t);
+    if (p) return p;
+  }
+  return null;
+}

--- a/src/lib/atTrigger.test.ts
+++ b/src/lib/atTrigger.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { isAtWordBoundary } from "./atTrigger";
+
+describe("isAtWordBoundary", () => {
+  it("is a boundary at column 0", () => {
+    expect(isAtWordBoundary(0, "")).toBe(true);
+    expect(isAtWordBoundary(0, "x")).toBe(true);
+  });
+  it("is a boundary when the previous cell is empty", () => {
+    expect(isAtWordBoundary(5, "")).toBe(true);
+  });
+  it("is a boundary when the previous cell is whitespace", () => {
+    expect(isAtWordBoundary(5, " ")).toBe(true);
+    expect(isAtWordBoundary(5, "\t")).toBe(true);
+  });
+  it("is NOT a boundary mid-word", () => {
+    expect(isAtWordBoundary(5, "a")).toBe(false);
+    expect(isAtWordBoundary(5, "/")).toBe(false);
+  });
+});

--- a/src/lib/atTrigger.ts
+++ b/src/lib/atTrigger.ts
@@ -1,0 +1,13 @@
+// Word-boundary check for the opt-in `@` context-picker trigger. Pure so it's
+// unit-testable without a real xterm buffer: the caller reads the cursor
+// column and the character in the cell immediately before the cursor from
+// `term.buffer.active` and passes them in.
+
+/** True when the cursor sits at a word boundary: at column 0, or the cell
+ *  immediately before it is empty (unwritten) or whitespace. Used to decide
+ *  whether a typed `@` should open the context picker (boundary) or be passed
+ *  through to the PTY as a literal `@` (mid-word, e.g. an email address). */
+export function isAtWordBoundary(cursorX: number, charBeforeCursor: string): boolean {
+  if (cursorX <= 0) return true;
+  return charBeforeCursor === "" || /\s/.test(charBeforeCursor);
+}

--- a/src/lib/contextPicker.test.ts
+++ b/src/lib/contextPicker.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { rankContextFiles, recencyScore, buildInsertion } from "./contextPicker";
+import type { ContextFile } from "./ipc";
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 1_700_000_000_000;
+const file = (path: string, mtime_ms: number, is_dir = false): ContextFile => ({ path, mtime_ms, is_dir });
+
+describe("recencyScore", () => {
+  it("is ~1 for a just-modified file and ~0.5 at one half-life (14 days)", () => {
+    expect(recencyScore(NOW, NOW)).toBeCloseTo(1, 5);
+    expect(recencyScore(NOW - 14 * DAY, NOW)).toBeCloseTo(0.5, 5);
+  });
+  it("is 0 for a missing/invalid mtime", () => {
+    expect(recencyScore(0, NOW)).toBe(0);
+  });
+});
+
+describe("rankContextFiles", () => {
+  it("orders by recency on an empty query", () => {
+    const files = [file("src/old.ts", NOW - 30 * DAY), file("src/new.ts", NOW - 1 * DAY)];
+    const ranked = rankContextFiles(files, new Set(), "", NOW);
+    expect(ranked.map((r) => r.path)).toEqual(["src/new.ts", "src/old.ts"]);
+  });
+
+  it("floats a git-changed file above an equal-recency unchanged file", () => {
+    const files = [file("src/a.ts", NOW - 5 * DAY), file("src/b.ts", NOW - 5 * DAY)];
+    const ranked = rankContextFiles(files, new Set(["src/b.ts"]), "", NOW);
+    expect(ranked[0].path).toBe("src/b.ts");
+  });
+
+  it("lets a strong name match beat a stale-but-fresher weak match", () => {
+    // Strong exact basename match, but old. Weak subsequence match, but fresh.
+    const strongOld = file("src/App.tsx", NOW - 90 * DAY);
+    const weakFresh = file("a/p/parser.ts", NOW); // a-p-p only as a scattered subsequence
+    const ranked = rankContextFiles([weakFresh, strongOld], new Set(), "app", NOW);
+    expect(ranked[0].path).toBe("src/App.tsx");
+  });
+
+  it("drops non-matching files when a query is present", () => {
+    const files = [file("src/App.tsx", NOW), file("docs/readme.md", NOW)];
+    const ranked = rankContextFiles(files, new Set(), "app", NOW);
+    expect(ranked.map((r) => r.path)).toEqual(["src/App.tsx"]);
+  });
+
+  it("carries match indexes through for highlighting", () => {
+    const ranked = rankContextFiles([file("src/App.tsx", NOW)], new Set(), "app", NOW);
+    expect(ranked[0].matches.length).toBeGreaterThan(0);
+  });
+});
+
+describe("buildInsertion", () => {
+  it("returns empty string for no selection", () => {
+    expect(buildInsertion([])).toBe("");
+  });
+  it("formats a single file with a trailing space", () => {
+    expect(buildInsertion([{ path: "src/a.ts", is_dir: false }])).toBe("@src/a.ts ");
+  });
+  it("space-joins multiple files with one trailing space", () => {
+    expect(
+      buildInsertion([
+        { path: "src/a.ts", is_dir: false },
+        { path: "src/b.ts", is_dir: false },
+      ]),
+    ).toBe("@src/a.ts @src/b.ts ");
+  });
+  it("appends a trailing slash to directories", () => {
+    expect(buildInsertion([{ path: "src/components", is_dir: true }])).toBe("@src/components/ ");
+  });
+  it("backslash-escapes spaces in paths", () => {
+    expect(buildInsertion([{ path: "my docs/a b.ts", is_dir: false }])).toBe("@my\\ docs/a\\ b.ts ");
+  });
+});

--- a/src/lib/contextPicker.ts
+++ b/src/lib/contextPicker.ts
@@ -1,0 +1,74 @@
+// Pure logic for the ⌘I context picker: recency-blended ranking and the
+// @path insertion string. Kept framework-free and clock-free (callers pass
+// `nowMs`) so it's deterministic and unit-testable.
+
+import { fuzzyScore } from "@/lib/fuzzy";
+import type { ContextFile } from "@/lib/ipc";
+
+/** Recency half-life — a file modified this long ago gets half the boost of a
+ *  just-modified one. Matches the pi-agent reference picker's 14-day model. */
+const RECENCY_HALF_LIFE_MS = 14 * 24 * 60 * 60 * 1000;
+/** Recency contributes at most this many points. Fuzzy matches score ~100-160,
+ *  so this is roughly a quarter of a match's magnitude: enough to order
+ *  similar matches by freshness, not enough to let a stale file leapfrog a
+ *  clearly stronger name match. */
+const RECENCY_WEIGHT = 30;
+/** Flat bump for git-changed files so "what I'm working on" floats up. */
+const CHANGED_BONUS = 15;
+
+export interface RankedContextFile {
+  path: string;
+  is_dir: boolean;
+  mtime_ms: number;
+  score: number;
+  /** Indexes into `path` that matched the query — for highlighting. */
+  matches: number[];
+}
+
+/** 1.0 for a just-modified file, decaying by half every `RECENCY_HALF_LIFE_MS`.
+ *  0 when mtime is missing/invalid so unstat-able files sink to the bottom. */
+export function recencyScore(mtimeMs: number, nowMs: number): number {
+  if (!mtimeMs || mtimeMs <= 0) return 0;
+  const age = Math.max(0, nowMs - mtimeMs);
+  return Math.pow(0.5, age / RECENCY_HALF_LIFE_MS);
+}
+
+/** Rank context files by fuzzy match (when a query is present) blended with
+ *  recency and a git-changed bonus. Empty/whitespace query → every file is
+ *  kept and ordered by recency (then changed, then path). */
+export function rankContextFiles(
+  files: ContextFile[],
+  changed: Set<string>,
+  query: string,
+  nowMs: number,
+): RankedContextFile[] {
+  const hasQuery = query.trim().length > 0;
+  const out: RankedContextFile[] = [];
+  for (const f of files) {
+    let base = 0;
+    let matches: number[] = [];
+    if (hasQuery) {
+      const s = fuzzyScore(f.path, query);
+      if (!s) continue; // non-matching files are dropped when filtering
+      base = s.score;
+      matches = s.matches;
+    }
+    const score =
+      base + RECENCY_WEIGHT * recencyScore(f.mtime_ms, nowMs) + (changed.has(f.path) ? CHANGED_BONUS : 0);
+    out.push({ path: f.path, is_dir: f.is_dir, mtime_ms: f.mtime_ms, score, matches });
+  }
+  out.sort(
+    (a, b) => b.score - a.score || b.mtime_ms - a.mtime_ms || a.path.localeCompare(b.path),
+  );
+  return out;
+}
+
+/** Build the string written to the PTY on confirm. Each path becomes an
+ *  `@path` token, directories get a trailing slash, spaces are backslash-
+ *  escaped, tokens are space-joined with one trailing space so the user can
+ *  keep typing. Empty selection → empty string. */
+export function buildInsertion(items: { path: string; is_dir: boolean }[]): string {
+  if (!items.length) return "";
+  const tokens = items.map((it) => "@" + it.path.replace(/ /g, "\\ ") + (it.is_dir ? "/" : ""));
+  return tokens.join(" ") + " ";
+}

--- a/src/lib/fuzzy.test.ts
+++ b/src/lib/fuzzy.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { fuzzyScore } from "./fuzzy";
+
+describe("fuzzyScore", () => {
+  it("returns a zero-score match for an empty query", () => {
+    expect(fuzzyScore("src/App.tsx", "")).toEqual({ path: "src/App.tsx", score: 0, matches: [] });
+  });
+
+  it("returns null when a term does not match", () => {
+    expect(fuzzyScore("src/App.tsx", "zzzz")).toBeNull();
+  });
+
+  it("prefers a contiguous substring over a scattered subsequence", () => {
+    // "review" appears contiguously in ReviewDialog and only as a scatter in
+    // the other path. Contiguous must win, and its matched indexes must be
+    // a contiguous run.
+    const contiguous = "src/components/dialogs/ReviewDialog.tsx";
+    const scattered = "src/r/e/v/i/e/w/other.tsx";
+    const a = fuzzyScore(contiguous, "review")!;
+    const b = fuzzyScore(scattered, "review")!;
+    expect(a).not.toBeNull();
+    expect(a.score).toBeGreaterThan(b.score);
+    // contiguous run: each matched index is one more than the previous
+    for (let i = 1; i < a.matches.length; i++) {
+      expect(a.matches[i]).toBe(a.matches[i - 1] + 1);
+    }
+  });
+
+  it("ANDs multi-term queries — every term must match", () => {
+    const path = "src/components/workspace/TabBar.tsx";
+    expect(fuzzyScore(path, "components tabbar")).not.toBeNull();
+    // second term absent → whole query fails
+    expect(fuzzyScore(path, "components zzz")).toBeNull();
+  });
+
+  it("scores a basename match above a same-text directory match", () => {
+    const inName = fuzzyScore("src/other/finder.ts", "finder")!;
+    const inDir = fuzzyScore("src/finder/other.ts", "finder")!;
+    expect(inName.score).toBeGreaterThan(inDir.score);
+  });
+
+  it("keeps matches and drops non-matches over a sample set (characterization)", () => {
+    const files = [
+      "src/components/dialogs/FileFinderDialog.tsx",
+      "src/lib/fuzzy.ts",
+      "src/components/workspace/FileTree.tsx",
+      "docs/readme.md",
+    ];
+    const matched = files
+      .map((f) => fuzzyScore(f, "file"))
+      .filter((s): s is NonNullable<typeof s> => s !== null)
+      .map((s) => s.path);
+    // "file"/"File" appears in two of the paths; fuzzy.ts and readme.md
+    // have no f-i-l-e subsequence and must be excluded.
+    expect(matched).toContain("src/components/dialogs/FileFinderDialog.tsx");
+    expect(matched).toContain("src/components/workspace/FileTree.tsx");
+    expect(matched).not.toContain("src/lib/fuzzy.ts");
+    expect(matched).not.toContain("docs/readme.md");
+  });
+});

--- a/src/lib/fuzzy.ts
+++ b/src/lib/fuzzy.ts
@@ -1,0 +1,87 @@
+// Sublime-style fuzzy matcher shared by the ⌘P file finder
+// (FileFinderDialog) and the ⌘I context picker (ContextPickerDialog).
+// Extracted verbatim so both pickers rank identically with one matcher to
+// maintain.
+
+export interface Scored {
+  path: string;
+  score: number;
+  /** Indexes into `path` that matched a query char — for bolding. */
+  matches: number[];
+}
+
+/**
+ * Single-term match. Tries substring first (so "review" highlights the
+ * full contiguous "Review", not scattered r-e-v-i-e-w chars greedily
+ * picked from earlier in the path) — preferring occurrences inside the
+ * basename and at word boundaries. Falls back to subsequence.
+ */
+export function matchTerm(
+  s: string,
+  lower: string,
+  term: string,
+  slash: number,
+): { score: number; matches: number[] } | null {
+  const t = term.toLowerCase();
+  // Substring fast path: scan all occurrences, pick the best by
+  // basename-ness + word-boundary-ness. Contiguous matches always beat
+  // scattered subsequence matches (huge consecutive bonus below).
+  let bestSubstr: { idx: number; score: number } | null = null;
+  for (let i = lower.indexOf(t); i !== -1; i = lower.indexOf(t, i + 1)) {
+    let sc = 100 + t.length * 9; // baseline: contiguous run of t.length chars
+    const prev = i > 0 ? s[i - 1] : "/";
+    if (prev === "/" || prev === "-" || prev === "_" || prev === ".") sc += 10;
+    if (i > slash) sc += 8;
+    sc -= i * 0.05; // mild earlier-is-better tiebreak
+    if (!bestSubstr || sc > bestSubstr.score) bestSubstr = { idx: i, score: sc };
+  }
+  if (bestSubstr) {
+    const matches: number[] = [];
+    for (let i = 0; i < t.length; i++) matches.push(bestSubstr.idx + i);
+    return { score: bestSubstr.score, matches };
+  }
+  // Subsequence fallback for typos / out-of-order chars.
+  const matches: number[] = [];
+  let qi = 0;
+  let prevMatch = -2;
+  let score = 0;
+  for (let i = 0; i < lower.length && qi < t.length; i++) {
+    if (lower[i] !== t[qi]) continue;
+    matches.push(i);
+    let bonus = 1;
+    if (i === prevMatch + 1) bonus += 8;
+    const prev = i > 0 ? s[i - 1] : "/";
+    if (prev === "/" || prev === "-" || prev === "_" || prev === ".") bonus += 4;
+    if (i > slash) bonus += 2;
+    if (s[i] === term[qi]) bonus += 1;
+    score += bonus;
+    prevMatch = i;
+    qi++;
+  }
+  if (qi < t.length) return null;
+  return { score, matches };
+}
+
+/**
+ * Fuzzy match. Splits the query on whitespace into AND-ed terms — every
+ * term must subsequence-match (Sublime / fzf convention: "components
+ * broa" finds files containing both). Each term gets its own independent
+ * pass so the order/positions of terms don't have to line up.
+ */
+export function fuzzyScore(s: string, query: string): Scored | null {
+  if (!query) return { path: s, score: 0, matches: [] };
+  const terms = query.split(/\s+/).filter(Boolean);
+  if (!terms.length) return { path: s, score: 0, matches: [] };
+  const lower = s.toLowerCase();
+  const slash = s.lastIndexOf("/");
+  const allMatches = new Set<number>();
+  let total = 0;
+  for (const t of terms) {
+    const r = matchTerm(s, lower, t, slash);
+    if (!r) return null;
+    total += r.score;
+    for (const m of r.matches) allMatches.add(m);
+  }
+  total -= s.length * 0.01;
+  return { path: s, score: total, matches: [...allMatches].sort((a, b) => a - b) };
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -41,6 +41,17 @@ export const workspaceSetCli   = (id: string, cli: string) => invoke<void>("work
 export const workspaceListFilesForFinder = (id: string) =>
   invoke<string[]>("workspace_list_files_for_finder", { id });
 
+/** One entry from `workspace_context_files`: a file or a synthesized
+ *  directory, with its modification time for the context picker's recency
+ *  ranking. Mirrors the Rust `ContextFile` struct. */
+export interface ContextFile { path: string; mtime_ms: number; is_dir: boolean }
+
+/** Like `workspaceListFilesForFinder` but enriched with mtime + synthesized
+ *  directory entries — the data the ⌘I context picker ranks on. Same
+ *  `git ls-files` underneath, so ignore rules match the finder exactly. */
+export const workspaceContextFiles = (id: string) =>
+  invoke<ContextFile[]>("workspace_context_files", { id });
+
 // ───────────────────────────── find in files ─────────────────────────────
 
 export interface GrepHit { path: string; line: number; col: number; preview: string }

--- a/src/store/prefs.ts
+++ b/src/store/prefs.ts
@@ -19,6 +19,7 @@ const LS_DEFAULT_SANDBOX = "globalDefaultSandbox";
 const LS_SANDBOX_BYPASS  = "sandboxBypassPermissions";
 const LS_TERMINAL_LETTERSPACING = "terminalLetterSpacing";
 const LS_WS_EXPAND_MODE = "workspaceExpandMode";
+const LS_CONTEXT_AT_TRIGGER = "contextAtTrigger";
 
 export type ThemeMode = "auto" | "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix";
 /** What `applyTheme` resolves to: a concrete palette name. `auto` is
@@ -306,6 +307,10 @@ interface PrefsState {
    *  - "always":  workspaces are always expanded by default. The chevron
    *               still collapses, and that collapsed-state sticks. */
   workspaceExpandMode: "chevron" | "click" | "always";
+  /** When on, typing `@` at a word boundary inside an agent terminal opens
+   *  the context picker (and swallows the `@`). Default off — the ⌘I
+   *  shortcut is always available; this is the opt-in inline trigger. */
+  contextAtTrigger: boolean;
 
   setEditorFontId:    (id: string) => void;
   setEditorThemeId:   (id: string) => void;
@@ -327,6 +332,7 @@ interface PrefsState {
   setGlobalDefaultSandbox: (v: boolean) => void;
   setSandboxBypassPermissions: (v: boolean) => void;
   setWorkspaceExpandMode: (m: "chevron" | "click" | "always") => void;
+  setContextAtTrigger: (v: boolean) => void;
 }
 
 const lsGet = (k: string, fallback: string) => {
@@ -380,6 +386,7 @@ const initialWsExpandMode: "chevron" | "click" | "always" = (() => {
   const raw = lsGet(LS_WS_EXPAND_MODE, "chevron");
   return raw === "click" || raw === "always" ? raw : "chevron";
 })();
+const initialContextAtTrigger = lsGetBool(LS_CONTEXT_AT_TRIGGER, false);
 
 export const usePrefs = create<PrefsState>(set => ({
   themeMode: initialTheme,
@@ -396,6 +403,7 @@ export const usePrefs = create<PrefsState>(set => ({
   editorFontSize: initialEditorSize,
   codeLigatures: initialLigatures,
   workspaceExpandMode: initialWsExpandMode,
+  contextAtTrigger: initialContextAtTrigger,
 
   setEditorFontId: (id) => {
     try { localStorage.setItem(LS_EDITOR_FONT, id); } catch {}
@@ -471,6 +479,10 @@ export const usePrefs = create<PrefsState>(set => ({
   setWorkspaceExpandMode: (m) => {
     try { localStorage.setItem(LS_WS_EXPAND_MODE, m); } catch {}
     set({ workspaceExpandMode: m });
+  },
+  setContextAtTrigger: (v) => {
+    try { localStorage.setItem(LS_CONTEXT_AT_TRIGGER, v ? "1" : "0"); } catch {}
+    set({ contextAtTrigger: v });
   },
   cycleThemeMode: () => {
     // Cycle only the original three for the keyboard shortcut - explicit

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -47,6 +47,11 @@ interface UIState {
   fileFinderWsId: string | null;
   /** ⇧⌘F find-in-files dialog — workspace id, null = closed. */
   findInFilesWsId: string | null;
+  /** ⌘I context picker — the workspace + the PTY id to insert @path tokens
+   *  into on confirm. null = closed. `atOrigin` is true when the picker was
+   *  opened by swallowing a typed `@` (so cancel re-emits the literal `@`).
+   *  Lives in the UI store so opening doesn't churn the workspace tree. */
+  contextPicker: { wsId: string; ptyId: string; atOrigin: boolean } | null;
   /** Global "blocking work in flight" message. Shows a centered loader over
    *  the whole window so the user knows the freeze is intentional. Set for
    *  unavoidably-synchronous IPC calls like `workspace_archive` that take
@@ -85,6 +90,8 @@ interface UIState {
   closeFileFinder: () => void;
   openFindInFiles: (wsId: string) => void;
   closeFindInFiles: () => void;
+  openContextPicker: (wsId: string, ptyId: string, atOrigin?: boolean) => void;
+  closeContextPicker: () => void;
   setBusy: (msg: string | null) => void;
   /** Open the global confirm modal. Returns a Promise that resolves
    *  to true (user confirmed) or false (cancelled / dismissed). Drop-in
@@ -141,6 +148,7 @@ export const useUI = create<UIState>(set => ({
   sandboxForWsId: null,
   fileFinderWsId: null,
   findInFilesWsId: null,
+  contextPicker: null,
   busyMessage: null,
   confirm: null,
   pendingSandboxRestarts: new Set<string>(),
@@ -165,6 +173,8 @@ export const useUI = create<UIState>(set => ({
   closeFileFinder:   () => set({ fileFinderWsId: null }),
   openFindInFiles:   (wsId) => set({ findInFilesWsId: wsId }),
   closeFindInFiles:  () => set({ findInFilesWsId: null }),
+  openContextPicker: (wsId, ptyId, atOrigin = false) => set({ contextPicker: { wsId, ptyId, atOrigin } }),
+  closeContextPicker: () => set({ contextPicker: null }),
   setBusy:           (msg) => set({ busyMessage: msg }),
   setNotifyRoute:    (route) => set({
     notifyRoute: route ? { ...route, firedAt: Date.now() } : null,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,5 +19,6 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+// Vitest config kept separate from vite.config.ts so test runs don't pull in
+// the React / Tailwind / Tauri dev plugins. The frontend has no UI test
+// harness by design (it's verified empirically in-app); these tests cover the
+// pure decision logic only — fuzzy matching, context-picker ranking +
+// insertion formatting, terminal target resolution, and the @-word-boundary
+// check. Node environment is enough: none of the tested functions touch the DOM.
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Two-pane fuzzy picker that inserts workspace-relative @path tokens into
the active agent terminal. Multi-select, recency ranking, folder
selection, live preview. Triggered by Cmd+I (always) and @-interception
(toggleable, off by default).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>