### PR TITLE
Korean/CJK IME input drops characters in the terminal

### DIFF
--- a/src/components/workspace/AuxTerminal.tsx
+++ b/src/components/workspace/AuxTerminal.tsx
@@ -17,6 +17,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { loadTerminalRenderer } from "@/lib/terminalRenderer";
 import { registerTerminalDropTarget } from "@/lib/terminalDrop";
+import { setupImeReplacementBridge } from "@/lib/ime";
 import * as ipc from "@/lib/ipc";
 import { loginShell } from "@/lib/loginShell";
 import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg } from "@/store/prefs";
@@ -92,6 +93,19 @@ export function AuxTerminal({ wsPath, active, onExited, onTitle }: { wsPath: str
     term.loadAddon(unicode11);
     term.unicode.activeVersion = "11";
     term.open(hostRef.current);
+    // Korean/CJK IME (WKWebView). WebKit composes via textarea `input` events
+    // (insertText + insertReplacementText), not compositionstart/end, and
+    // xterm drops the replacement events — so input gets mangled (안녕 → ㅇㄴ).
+    // setupImeReplacementBridge fills the gap; see src/lib/ime.ts. The
+    // keyCode-229 guard below keeps xterm's keydown path inert during IME so
+    // only the input-event bridge drives composition. Mirrors TerminalPane.
+    term.attachCustomKeyEventHandler((e) => {
+      if (e.type === "keydown" && (e.isComposing || e.keyCode === 229)) {
+        return false;
+      }
+      return true;
+    });
+    const disposeImeBridge = setupImeReplacementBridge(hostRef.current, () => ptyRef.current, ipc.ptyWrite);
     termRef.current = term;
     // Hold a ref to the WebGL addon so the cleanup path can dispose it BEFORE
     // term.dispose(). Without that, the addon's pending render frame fires
@@ -172,6 +186,7 @@ export function AuxTerminal({ wsPath, active, onExited, onTitle }: { wsPath: str
       cancelled = true;
       ro.disconnect();
       unregisterDrop();
+      disposeImeBridge();
       unlistenData?.(); unlistenExit?.();
       if (ptyRef.current) ipc.ptyKill(ptyRef.current).catch(() => {});
       // Dispose the renderer addon FIRST so its render loop can't fire

--- a/src/components/workspace/TerminalPane.tsx
+++ b/src/components/workspace/TerminalPane.tsx
@@ -19,6 +19,7 @@ import { SearchAddon } from "@xterm/addon-search";
 import { loadTerminalRenderer } from "@/lib/terminalRenderer";
 import { IS_MAC, bindingMatches, type ShortcutId } from "@/lib/shortcuts";
 import { registerTerminalDropTarget } from "@/lib/terminalDrop";
+import { setupImeReplacementBridge } from "@/lib/ime";
 import { sendMessageToPty } from "@/lib/agentSend";
 import type { TerminalTab, Workspace, SandboxMode } from "@/lib/types";
 import { effectiveSandboxMode } from "@/lib/types";
@@ -358,6 +359,47 @@ export function TerminalPane({ ws, tab, active }: Props) {
     termRef.current = term;
     fitRef.current = fit;
 
+    // ── Korean/CJK IME fix for WKWebView ───────────────────────────────
+    // WebKit drives CJK composition NOT through compositionstart/update/end
+    // (those never fire here; isComposing stays false, keyCode is always
+    // 229) but through `input` events on the helper textarea:
+    //   • insertText            → a fresh jamo is appended (syllable start)
+    //   • insertReplacementText → the composing syllable is refined
+    // xterm's _inputEvent only forwards inputType === 'insertText', so every
+    // replacement is DROPPED and only the leading jamo of each syllable
+    // reaches the PTY (안녕 → ㅇㄴ). We fill the gap: on a replacement event,
+    // diff the textarea against its previous value and emit backspaces + the
+    // new tail so the PTY line tracks the textarea exactly — this also
+    // handles Korean's final-consonant migration (안 + ㅏ → 아나), since the
+    // whole composing value is diffed, not just the last char. `prevTaVal`
+    // is synced on EVERY input event (including the insertText ones xterm
+    // forwards) so the diff baseline stays correct across syllable
+    // boundaries. English/control keys route through keypress/keydown and
+    // never hit the replacement branch, so they're untouched. See the
+    // keyCode-229 guard above, which keeps the keydown path inert for IME.
+    const disposeImeBridge = setupImeReplacementBridge(host, () => ptyRef.current, ipc.ptyWrite);
+
+    // ── IME diagnostic (opt-in) ────────────────────────────────────────
+    // Toggle with `localStorage.imeDebug = "1"`, type Korean, read the dev
+    // log (console.warn is forwarded by vite; console.log is not). Kept for
+    // debugging future IME regressions on other WebKit builds / layouts.
+    if ((() => { try { return localStorage.getItem("imeDebug") === "1"; } catch { return false; } })()) {
+      const ta = host.querySelector(".xterm-helper-textarea") as HTMLTextAreaElement | null;
+      const tag = `[ime ${ws.name}/${tab.cli}]`;
+      if (ta) {
+        ta.addEventListener("keydown", (e) => {
+          console.warn(`${tag} keydown key=${JSON.stringify(e.key)} code=${e.code} keyCode=${e.keyCode} isComposing=${e.isComposing} taValue=${JSON.stringify(ta.value)}`);
+        }, true);
+        ta.addEventListener("compositionstart", (e) => console.warn(`${tag} compositionstart data=${JSON.stringify((e as CompositionEvent).data)} taValue=${JSON.stringify(ta.value)}`));
+        ta.addEventListener("compositionupdate", (e) => console.warn(`${tag} compositionupdate data=${JSON.stringify((e as CompositionEvent).data)} taValue=${JSON.stringify(ta.value)}`));
+        ta.addEventListener("compositionend", (e) => console.warn(`${tag} compositionend data=${JSON.stringify((e as CompositionEvent).data)} taValue=${JSON.stringify(ta.value)}`));
+        ta.addEventListener("input", (e) => console.warn(`${tag} input inputType=${(e as InputEvent).inputType} data=${JSON.stringify((e as InputEvent).data)} isComposing=${(e as InputEvent).isComposing} taValue=${JSON.stringify(ta.value)}`));
+        console.warn(`${tag} IME diagnostic attached.`);
+      } else {
+        console.warn(`${tag} IME diagnostic: helper textarea not found.`);
+      }
+    }
+
     // Drop target: dragging a file (screenshot, etc.) onto this terminal
     // inserts the file's escaped path at the prompt — like macOS Terminal.
     // The getter reads ptyRef lazily so a Restart (fresh pty id) still works.
@@ -395,6 +437,20 @@ export function TerminalPane({ ws, tab, active }: Props) {
       "file-finder", "find-in-files", "broadcast", "open-shortcuts", "open-settings",
     ];
     term.attachCustomKeyEventHandler((e) => {
+      // IME composition guard (Korean/Japanese/Chinese). xterm's
+      // CompositionHelper.keydown() decides "still composing?" purely by
+      // `keyCode === 229`. Chromium sets that for every composition keystroke,
+      // but WKWebView (WebKit) reports the real jamo key instead, so xterm
+      // finalizes the composition on EVERY keystroke — committing the partial
+      // syllable and resetting (안녕하세요 → ㅇㄴㅎ세). Returning false here
+      // short-circuits xterm's keydown BEFORE its composition handler runs and,
+      // crucially, without preventDefault — so the native textarea + xterm's
+      // own compositionstart/update/end listeners assemble the full syllable
+      // and emit it once on compositionend. `isComposing` covers continuation
+      // keystrokes; `keyCode === 229` covers the one that starts composition.
+      if (e.type === "keydown" && (e.isComposing || e.keyCode === 229)) {
+        return false;
+      }
       if (e.type === "keydown") {
         const binds = usePrefs.getState().shortcuts;
         if (PASS_TO_APP.some(id => bindingMatches(e, binds[id]))) {
@@ -1274,6 +1330,7 @@ export function TerminalPane({ ws, tab, active }: Props) {
       cancelled = true;
       ro.disconnect();
       unregisterDrop();
+      disposeImeBridge();
       unlistenDataRef.current?.();
       unlistenExitRef.current?.();
       if (ptyRef.current) ipc.ptyKill(ptyRef.current).catch(() => {});

--- a/src/lib/ime.test.ts
+++ b/src/lib/ime.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from "vitest";
+import {
+  computeImeDelta,
+  isForwardedInputType,
+  setupImeReplacementBridge,
+} from "@/lib/ime";
+
+const DEL = 0x7f;
+const enc = (s: string) => Array.from(new TextEncoder().encode(s));
+
+// ── computeImeDelta ────────────────────────────────────────────────────
+// Diffs the textarea value (code-point aware) into DEL backspaces + the new
+// tail. This is the core of the WebKit IME fix.
+
+describe("computeImeDelta", () => {
+  it("encodes a fresh append from empty", () => {
+    expect(computeImeDelta("", "아")).toEqual(enc("아"));
+  });
+
+  it("returns nothing when unchanged", () => {
+    expect(computeImeDelta("안", "안")).toEqual([]);
+    expect(computeImeDelta("", "")).toEqual([]);
+  });
+
+  it("replaces the composing syllable (ㅇ -> 아)", () => {
+    expect(computeImeDelta("ㅇ", "아")).toEqual([DEL, ...enc("아")]);
+  });
+
+  it("keeps the common prefix and only rewrites the tail (안ㄴ -> 안녀)", () => {
+    // common prefix "안"; backspace the trailing ㄴ, send 녀.
+    expect(computeImeDelta("안ㄴ", "안녀")).toEqual([DEL, ...enc("녀")]);
+  });
+
+  it("handles Korean final-consonant migration (안 -> 아나)", () => {
+    // The trailing ㄴ of 안 migrates to start the next syllable. Diffing the
+    // whole value (not just the last char) gets this right: DEL 안, send 아나.
+    expect(computeImeDelta("안", "아나")).toEqual([DEL, ...enc("아나")]);
+  });
+
+  it("emits a bare backspace when the value shrinks", () => {
+    expect(computeImeDelta("안녕", "안")).toEqual([DEL]);
+  });
+
+  it("counts a surrogate-pair grapheme as ONE backspace", () => {
+    // 👍 and 👋 are each a single code point spanning two UTF-16 units. A
+    // naive .length diff would emit two backspaces; code-point diffing emits one.
+    expect(computeImeDelta("👍", "👋")).toEqual([DEL, ...enc("👋")]);
+  });
+});
+
+// ── isForwardedInputType ───────────────────────────────────────────────
+// xterm forwards only "insertText"; everything composition-related it drops,
+// so those are the events the bridge must forward.
+
+describe("isForwardedInputType", () => {
+  it("does NOT forward insertText (xterm handles it)", () => {
+    expect(isForwardedInputType("insertText")).toBe(false);
+  });
+
+  it("does NOT forward paste or line breaks (xterm/keydown handle them)", () => {
+    expect(isForwardedInputType("insertFromPaste")).toBe(false);
+    expect(isForwardedInputType("insertLineBreak")).toBe(false);
+    expect(isForwardedInputType("insertParagraph")).toBe(false);
+  });
+
+  it("forwards composition refinements and composition deletes", () => {
+    expect(isForwardedInputType("insertReplacementText")).toBe(true);
+    expect(isForwardedInputType("insertCompositionText")).toBe(true);
+    expect(isForwardedInputType("deleteContentBackward")).toBe(true);
+  });
+});
+
+// ── setupImeReplacementBridge (DOM) ────────────────────────────────────
+
+function mountTerminal() {
+  const host = document.createElement("div");
+  host.className = "xterm";
+  const ta = document.createElement("textarea");
+  ta.className = "xterm-helper-textarea";
+  host.appendChild(ta);
+  document.body.appendChild(host);
+  return { host, ta };
+}
+
+function fireInput(ta: HTMLTextAreaElement, inputType: string, value: string, data: string | null) {
+  ta.value = value;
+  ta.dispatchEvent(new InputEvent("input", { inputType, data, bubbles: true }));
+}
+
+describe("setupImeReplacementBridge", () => {
+  const PID = "pty-1";
+
+  it("forwards only the dropped events while typing 안녕, reconstructing it on the PTY", () => {
+    const { host, ta } = mountTerminal();
+    const write = vi.fn();
+    setupImeReplacementBridge(host, () => PID, write);
+
+    // The exact WebKit event sequence captured from the live app.
+    fireInput(ta, "insertText", "ㅇ", "ㅇ");             // xterm forwards → bridge skips
+    fireInput(ta, "insertReplacementText", "아", "아");  // dropped → bridge forwards
+    fireInput(ta, "insertReplacementText", "안", "안");
+    fireInput(ta, "insertText", "안ㄴ", "ㄴ");           // xterm forwards → bridge skips
+    fireInput(ta, "insertReplacementText", "안녀", "녀");
+    fireInput(ta, "insertReplacementText", "안녕", "녕");
+
+    // Only the 4 replacement events produce writes.
+    expect(write).toHaveBeenCalledTimes(4);
+    expect(write.mock.calls.map(c => c[1])).toEqual([
+      [DEL, ...enc("아")], // ㅇ -> 아
+      [DEL, ...enc("안")], // 아 -> 안
+      [DEL, ...enc("녀")], // 안ㄴ -> 안녀
+      [DEL, ...enc("녕")], // 안녀 -> 안녕
+    ]);
+
+    // Replaying xterm's insertText sends + the bridge's writes onto a model
+    // PTY line yields exactly "안녕".
+    const xtermSends = ["ㅇ", "ㄴ"]; // what xterm forwards for the insertText events
+    let line = [...Array.from(xtermSends[0])];
+    // Apply: bridge(아), bridge(안), xterm(ㄴ), bridge(녀), bridge(녕)
+    const apply = (bytes: number[]) => {
+      const text = new TextDecoder().decode(Uint8Array.from(bytes.filter(b => b !== DEL)));
+      const backs = bytes.filter(b => b === DEL).length;
+      for (let i = 0; i < backs; i++) line.pop();
+      line.push(...Array.from(text));
+    };
+    apply([DEL, ...enc("아")]);
+    apply([DEL, ...enc("안")]);
+    line.push(...Array.from("ㄴ")); // xterm insertText
+    apply([DEL, ...enc("녀")]);
+    apply([DEL, ...enc("녕")]);
+    expect(line.join("")).toBe("안녕");
+
+    host.remove();
+  });
+
+  it("resets its baseline on Enter so the next composition does not backspace the old line", () => {
+    const { host, ta } = mountTerminal();
+    const write = vi.fn();
+    setupImeReplacementBridge(host, () => PID, write);
+
+    fireInput(ta, "insertText", "안녕", "녕"); // baseline := "안녕"
+    write.mockClear();
+
+    // Enter: xterm sends \r and clears the textarea WITHOUT an input event.
+    ta.value = "";
+    ta.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+
+    // Next composition starts fresh.
+    fireInput(ta, "insertReplacementText", "하", "하");
+    // No DEL for the (gone) old line — just the new char.
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write.mock.calls[0][1]).toEqual([...enc("하")]);
+
+    host.remove();
+  });
+
+  it("stops forwarding after cleanup", () => {
+    const { host, ta } = mountTerminal();
+    const write = vi.fn();
+    const dispose = setupImeReplacementBridge(host, () => PID, write);
+
+    dispose();
+    fireInput(ta, "insertReplacementText", "아", "아");
+    expect(write).not.toHaveBeenCalled();
+
+    host.remove();
+  });
+
+  it("does not write when there is no PTY yet", () => {
+    const { host, ta } = mountTerminal();
+    const write = vi.fn();
+    setupImeReplacementBridge(host, () => null, write);
+
+    fireInput(ta, "insertReplacementText", "아", "아");
+    expect(write).not.toHaveBeenCalled();
+
+    host.remove();
+  });
+});

--- a/src/lib/ime.ts
+++ b/src/lib/ime.ts
@@ -53,8 +53,30 @@ const FORWARDED_INPUT_TYPES = new Set([
   "deleteContentForward",
 ]);
 
-function isReplacement(inputType: string): boolean {
+/** True for input events xterm drops and whose delta we must forward. */
+export function isForwardedInputType(inputType: string): boolean {
   return FORWARDED_INPUT_TYPES.has(inputType);
+}
+
+/**
+ * Compute the bytes that turn the PTY line from `prevVal` into `newVal`:
+ * code-point-aware backspaces (DEL) for the changed suffix, then the new tail.
+ * Returns an empty array when the values are identical. Diffing the whole
+ * value (not just the trailing char) is what makes Korean final-consonant
+ * migration work (안 + ㅏ -> 아나: prev "안" vs new "아나" -> DEL + "아나").
+ */
+export function computeImeDelta(prevVal: string, newVal: string): number[] {
+  const a = Array.from(prevVal); // code-point aware (handles surrogate pairs)
+  const b = Array.from(newVal);
+  let common = 0;
+  while (common < a.length && common < b.length && a[common] === b[common]) common++;
+  const back = a.length - common;
+  const tail = b.slice(common).join("");
+  if (back === 0 && tail.length === 0) return [];
+  const bytes: number[] = [];
+  for (let i = 0; i < back; i++) bytes.push(DEL);
+  if (tail.length > 0) bytes.push(...new TextEncoder().encode(tail));
+  return bytes;
 }
 
 /**
@@ -75,26 +97,14 @@ export function setupImeReplacementBridge(
   if (!ta) return () => {};
 
   let prevVal = "";
-  const enc = new TextEncoder();
 
   const onInput = (ev: Event) => {
     const e = ev as InputEvent;
     const newVal = ta.value;
-    if (isReplacement(e.inputType)) {
-      // Code-point aware diff so multi-byte syllables count as one unit.
-      const a = Array.from(prevVal);
-      const b = Array.from(newVal);
-      let common = 0;
-      while (common < a.length && common < b.length && a[common] === b[common]) common++;
-      const back = a.length - common;
-      const tail = b.slice(common).join("");
+    if (isForwardedInputType(e.inputType)) {
+      const bytes = computeImeDelta(prevVal, newVal);
       const pid = getPty();
-      if (pid && (back > 0 || tail.length > 0)) {
-        const bytes: number[] = [];
-        for (let i = 0; i < back; i++) bytes.push(DEL);
-        if (tail.length > 0) bytes.push(...enc.encode(tail));
-        write(pid, bytes);
-      }
+      if (pid && bytes.length > 0) write(pid, bytes);
     }
     // Always resync the baseline (insertText is forwarded by xterm itself; we
     // only need its value to keep the diff anchored).

--- a/src/lib/ime.ts
+++ b/src/lib/ime.ts
@@ -1,0 +1,118 @@
+// Korean/CJK IME bridge for WKWebView terminals.
+//
+// In WKWebView (WebKit), xterm.js loses CJK input. WebKit does NOT drive
+// composition through compositionstart/update/end (those never fire; the
+// keydown's `isComposing` stays false and `keyCode` is always 229). Instead
+// it composes directly in the helper textarea via `input` events:
+//
+//   • inputType "insertText"            → a fresh jamo is appended (the start
+//                                          of a new syllable). xterm's
+//                                          _inputEvent forwards these to the
+//                                          PTY on its own.
+//   • inputType "insertReplacementText" → the in-progress syllable is refined
+//                                          (e.g. ㅇ → 아 → 안). xterm only
+//                                          forwards inputType === "insertText",
+//                                          so EVERY refinement is dropped and
+//                                          only the leading jamo of each
+//                                          syllable reaches the PTY: 안녕 → ㅇㄴ.
+//
+// We fill the gap. On a replacement event we diff the textarea's current value
+// against its previous value (code-point aware) and send backspaces (DEL,
+// 0x7f) for the removed suffix followed by the new tail, so the PTY line
+// always mirrors the textarea. Diffing the whole composing value — not just
+// the last char — also handles Korean's final-consonant migration (typing a
+// vowel after a closed syllable moves the trailing consonant onto the next
+// syllable, e.g. 안 + ㅏ → 아나).
+//
+// `prevVal` is resynced on EVERY input event, including the "insertText" ones
+// xterm forwards itself, so the diff baseline stays correct across syllable
+// boundaries. xterm clears the textarea on Enter / Ctrl+C without firing an
+// input event, so we also reset the baseline on those keys.
+//
+// English and control keys route through keypress / keydown (keyCode is not
+// 229), never hitting the replacement branch, so they are untouched.
+
+const DEL = 0x7f;
+
+// inputTypes that refine/delete the composing text and that xterm's
+// _inputEvent drops (it forwards ONLY "insertText"). We must forward their
+// delta ourselves. Deliberately EXCLUDES:
+//   • insertText                  → xterm forwards it; we'd double-send.
+//   • insertFromPaste             → xterm's own paste handler covers it.
+//   • insertLineBreak/Paragraph   → Enter; xterm's keydown handles it.
+// During IME a Backspace decomposes the syllable and arrives as a
+// deleteContent*/deleteComposition* input event (xterm's keydown only
+// preventDefaults Backspace OUTSIDE composition, so these only fire for IME).
+const FORWARDED_INPUT_TYPES = new Set([
+  "insertReplacementText",
+  "insertCompositionText",
+  "insertFromComposition",
+  "deleteCompositionText",
+  "deleteByComposition",
+  "deleteContentBackward",
+  "deleteContentForward",
+]);
+
+function isReplacement(inputType: string): boolean {
+  return FORWARDED_INPUT_TYPES.has(inputType);
+}
+
+/**
+ * Wire the IME replacement bridge onto a terminal's helper textarea.
+ *
+ * @param host    The `.xterm` container element (term.open target).
+ * @param getPty  Lazy getter for the current PTY id (survives Restart, which
+ *                spawns a fresh pty while reusing the same DOM).
+ * @param write   Sends bytes to the PTY (e.g. ipc.ptyWrite).
+ * @returns       A cleanup function that removes the listeners.
+ */
+export function setupImeReplacementBridge(
+  host: HTMLElement,
+  getPty: () => string | null,
+  write: (ptyId: string, data: number[]) => void,
+): () => void {
+  const ta = host.querySelector(".xterm-helper-textarea") as HTMLTextAreaElement | null;
+  if (!ta) return () => {};
+
+  let prevVal = "";
+  const enc = new TextEncoder();
+
+  const onInput = (ev: Event) => {
+    const e = ev as InputEvent;
+    const newVal = ta.value;
+    if (isReplacement(e.inputType)) {
+      // Code-point aware diff so multi-byte syllables count as one unit.
+      const a = Array.from(prevVal);
+      const b = Array.from(newVal);
+      let common = 0;
+      while (common < a.length && common < b.length && a[common] === b[common]) common++;
+      const back = a.length - common;
+      const tail = b.slice(common).join("");
+      const pid = getPty();
+      if (pid && (back > 0 || tail.length > 0)) {
+        const bytes: number[] = [];
+        for (let i = 0; i < back; i++) bytes.push(DEL);
+        if (tail.length > 0) bytes.push(...enc.encode(tail));
+        write(pid, bytes);
+      }
+    }
+    // Always resync the baseline (insertText is forwarded by xterm itself; we
+    // only need its value to keep the diff anchored).
+    prevVal = newVal;
+  };
+
+  const onKeydown = (ev: Event) => {
+    const e = ev as KeyboardEvent;
+    const isEnter = e.key === "Enter" || e.code === "Enter" || e.code === "NumpadEnter";
+    const isCtrlC = e.ctrlKey && (e.key === "c" || e.key === "C");
+    // xterm wipes the textarea on these (Terminal.ts) without an input event.
+    if (isEnter || isCtrlC) prevVal = "";
+  };
+
+  ta.addEventListener("input", onInput, true);
+  ta.addEventListener("keydown", onKeydown, true);
+  return () => {
+    ta.removeEventListener("input", onInput, true);
+    ta.removeEventListener("keydown", onKeydown, true);
+  };
+}


### PR DESCRIPTION
## Summary

Typing Korean (and other IME-composed CJK) into any terminal pane dropped characters: each syllable collapsed to its leading jamo, so `안녕하세요` came out as `ㅇㄴㅎ세`. ASCII input was unaffected. This bridges the gap WebKit leaves in xterm.js's IME handling so composed input reaches the PTY intact.

fix issue #29 


### AS-IS

<img width="921" height="685" alt="image" src="https://github.com/user-attachments/assets/c0e4f388-0b4e-4026-b1a3-7e04ca191b28" />

### TO-BE

<img width="712" height="589" alt="image" src="https://github.com/user-attachments/assets/7d8442a6-fb3e-49e1-94e0-fba3e127bba2" />

## Root cause

WebKit (WKWebView) does **not** drive CJK composition through the standard `compositionstart` / `update` / `end` events. Those never fire; on every keystroke `isComposing` stays `false` and `keyCode` is always `229`. Instead WebKit composes directly in xterm's helper textarea via `input` events:

- `inputType: "insertText"`: a fresh jamo is appended (syllable start)
- `inputType: "insertReplacementText"`: the in-progress syllable is refined

xterm's `_inputEvent` forwards only `insertText` and ignores everything else, so every refinement is dropped and only the leading jamo of each syllable reaches the PTY.

Event trace from the live app (`localStorage.imeDebug=1`), typing `안녕`:

input    insertText            data="ㅇ"  taValue="ㅇ"     → forwarded ✓
input    insertReplacementText data="아"  taValue="아"     → DROPPED ✗
input    insertReplacementText data="안"  taValue="안"     → DROPPED ✗
input    insertText            data="ㄴ"  taValue="안ㄴ"   → forwarded ✓
input    insertReplacementText data="녀"  taValue="안녀"   → DROPPED ✗
input    insertReplacementText data="녕"  taValue="안녕"   → DROPPED ✗

PTY receives `ㅇ` + `ㄴ` = `ㅇㄴ`, matching the symptom.

## Fix

New `src/lib/ime.ts` (`setupImeReplacementBridge`): for every `input` event xterm drops (replacement + composition-delete types), diff the textarea value (code-point aware) against its previous value and send backspaces (DEL, `0x7f`) for the removed suffix plus the new tail, so the PTY line mirrors the textarea exactly. `insertText` stays handled by xterm; the bridge only resyncs its diff baseline. Diffing the whole composing value also handles Korean final-consonant migration (`안` + `ㅏ` → `아나`). A `keyCode === 229` keydown guard keeps xterm's keydown path inert during IME, and an opt-in `imeDebug` logger is left in for future WebKit regressions.

Wired into `TerminalPane` (agent/right-split tabs) and `AuxTerminal` (bottom-split shells). English/control keys route through keypress/keydown and never hit the bridge.

## Testing

- `src/lib/ime.test.ts` (14 cases, happy-dom): delta math (append, replace, final-consonant migration, shrink, surrogate-pair backspaces), input-type gating, the full `안녕` WebKit sequence reconstructing on a model PTY, plus Enter baseline reset, cleanup, and the no-PTY case.
- Full suite green (139 tests), `tsc -b` clean.
- Manually verified in the live app: agent tabs + bottom split, `안녕하세요`, final-consonant migration, mid-composition backspace, mixed English, and Enter to submit.

## Affected surfaces

- [x] Agent tabs (main pane)
- [x] Right split shells
- [x] Bottom split shells (AuxTerminal)