### PR TITLE
Add ⌘J shortcut to toggle the bottom terminal panel

### DIFF
--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -9,7 +9,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import {
   Search, Plus, FileText, Pencil, GitBranch, Archive, Zap, ShieldCheck,
-  PanelLeft, PanelRight, Palette, Keyboard, Settings as SettingsIcon,
+  PanelLeft, PanelRight, PanelBottom, Palette, Keyboard, Settings as SettingsIcon,
   FolderCog, RefreshCw, ScrollText, Bug, SlidersHorizontal, Bot, BookText,
   Check, ChevronLeft, type LucideIcon,
 } from "lucide-react";
@@ -216,6 +216,13 @@ export function CommandPalette() {
       icon: PanelRight, shortcutId: "toggle-right-sidebar", keywords: "panel diff changes hide",
       run: act(() => useApp.getState().toggleRightPanel()),
     });
+    if (ws) {
+      cmds.push({
+        id: "toggle-terminal", section: "View", label: "Toggle terminal panel",
+        icon: PanelBottom, shortcutId: "toggle-terminal", keywords: "bottom split shell console hide show",
+        run: act(() => useApp.getState().toggleBottomTerminal(ws.id)),
+      });
+    }
     cmds.push({
       id: "change-theme", section: "View", label: "Change theme…",
       suffix: THEME_LABELS[themeMode], icon: Palette, keywords: "appearance color dark light",

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -195,6 +195,7 @@ export function WorkspaceView({ ws }: { ws: Workspace }) {
             {tabs.filter(t => t.panel !== "right").map(t => (
               <div
                 key={t.id}
+                data-main-tab-id={t.id}
                 className="absolute inset-0"
                 style={{ visibility: t.id === activeId ? "visible" : "hidden", zIndex: t.id === activeId ? 1 : 0 }}
               >

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -13,6 +13,7 @@
 //   ⌘W       → close the active tab
 //   ⌘D       → open a new right-split terminal in the active workspace
 //   ⇧⌘D      → open a new bottom-split terminal in the active workspace
+//   ⌘J       → toggle the bottom split: show + focus it, or hide + refocus agent
 //   ⌘T       → new tab · ⌘K → clear terminal · ⌘P → file finder
 //   ⇧⌘F      → find in files · ⇧⌘B → broadcast · ⌘, → settings
 import { useEffect } from "react";
@@ -20,6 +21,7 @@ import { useApp } from "@/store/app";
 import { useUI } from "@/store/ui";
 import { usePrefs } from "@/store/prefs";
 import { requestCloseTab } from "@/lib/closeTab";
+import { focusTerminalTab } from "@/lib/tabFocus";
 import { bindingMatches, IS_MAC, SHORTCUT_DEFS, type ShortcutId } from "@/lib/shortcuts";
 import type { TerminalTab } from "@/lib/types";
 
@@ -237,13 +239,9 @@ export function useShortcuts() {
               // AuxTerminal deliberately doesn't grab focus when it becomes
               // active (so opening the split / switching workspaces doesn't
               // steal focus from the agent). An explicit keyboard tab-switch
-              // SHOULD move focus, so focus the newly-active shell's textarea
-              // once the re-render makes it visible.
-              requestAnimationFrame(() => {
-                (document.querySelector(
-                  `[data-tab-id="${CSS.escape(nextId)}"] .xterm-helper-textarea`,
-                ) as HTMLElement | null)?.focus();
-              });
+              // SHOULD move focus, so focus the newly-active shell once the
+              // re-render makes it visible.
+              focusTerminalTab(nextId);
             }
             return;
           }
@@ -279,18 +277,22 @@ export function useShortcuts() {
           const splitOpen = !!state.terminalSplit[wsId];
           const hasTabs = (state.bottomTabs[wsId]?.length ?? 0) > 0;
           if (!splitOpen) state.toggleTerminalSplit(wsId);
+          // addBottomTab focuses the new shell itself; otherwise focus the one
+          // that's already active (it may need a few frames to mount).
           if (!hasTabs) state.addBottomTab(wsId);
-          // Poll briefly — the freshly-opened split needs a few frames before
-          // its xterm helper-textarea is in the DOM.
-          const tryFocus = (tries = 20) => {
-            const split = document.querySelector("[data-bottom-split]");
-            const active = split?.querySelector(".xterm-helper-textarea") as HTMLTextAreaElement | null;
-            if (active) { active.focus(); return; }
-            if (tries > 0) setTimeout(() => tryFocus(tries - 1), 25);
-          };
-          tryFocus();
+          else focusTerminalTab(state.activeBottomTab[wsId]);
           return;
         }
+
+        // ⌘J → toggle the bottom-split terminal, VS Code-style (issue #45).
+        // The whole show/hide + focus dance lives in the store so the command
+        // palette can share it. NO `isTyping` guard — must fire from inside any
+        // terminal (xterm's hidden textarea) and the editor (CodeMirror).
+        case "toggle-terminal":
+          if (!wsId) return;
+          e.preventDefault();
+          state.toggleBottomTerminal(wsId);
+          return;
 
         // ⌘D → open right split (if closed) or focus the active right terminal.
         case "new-right-split-terminal": {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -39,6 +39,7 @@ export type ShortcutId =
   | "clear-terminal"
   | "new-split-terminal"
   | "new-right-split-terminal"
+  | "toggle-terminal"
   | "terminal-copy"
   | "terminal-paste"
   | "new-workspace-quick"
@@ -113,6 +114,9 @@ export const SHORTCUT_DEFS: ShortcutDef[] = [
     defaultBinding: B("d", { cmd: true, shift: true }) },
   { id: "new-right-split-terminal", group: "Terminal", label: "New right-split terminal",
     defaultBinding: B("d", { cmd: true }) },
+  { id: "toggle-terminal", group: "Terminal", label: "Toggle terminal panel",
+    hint: "Show + focus the bottom split, or hide it and return to the agent",
+    defaultBinding: B("j", { cmd: true }) },
   // Copy / paste are LINUX/WINDOWS ONLY and handled locally in the terminal
   // panes (TerminalPane / AuxTerminal `attachCustomKeyEventHandler`), gated to
   // !IS_MAC, NOT by the global useShortcuts handler (like the Git ids below,

--- a/src/lib/tabFocus.ts
+++ b/src/lib/tabFocus.ts
@@ -1,28 +1,45 @@
-// Move keyboard focus to a tab's terminal. xterm captures input through
-// a hidden `.xterm-helper-textarea`; every terminal-tab host carries a
-// `data-tab-id` — the TerminalPane root up top, and the bottom-split
-// AuxTerminal wrappers down below. Used after a tab close (focus
-// follows to the tab that takes over) and after a new tab is spawned
-// (focus lands in it so the user can type immediately) — instead of
-// focus falling to <body>, or jumping to the wrong pane.
-//
-// Two reasons a single attempt isn't enough, both handled by retrying
-// across animation frames:
-//   1. The host may not be in the DOM yet — React has a re-render
-//      pending right after the store update that triggered this.
-//   2. The tab that takes over is mounted but still `visibility:hidden`
-//      for one frame (panes stay mounted, visibility-toggled). focus()
-//      on a hidden element is a no-op, so we verify it actually landed.
-// tries ≈ frames: a fresh tab's xterm helper-textarea isn't in the DOM
-// until TerminalPane / AuxTerminal mounts and runs `term.open()` — a
-// few frames out — so retry generously before giving up.
-export function focusTerminalTab(tabId: string | undefined | null, tries = 30): void {
-  if (!tabId) return;
-  const host = document.querySelector(`[data-tab-id="${tabId}"]`);
-  const el = host?.querySelector(".xterm-helper-textarea") as HTMLTextAreaElement | null;
+// Keyboard-focus helpers for tabs. xterm captures input through a hidden
+// `.xterm-helper-textarea`, CodeMirror through `.cm-content`. Used after a tab
+// close (focus follows the tab that takes over), after a new tab spawns (focus
+// lands in it so the user can type immediately), and when toggling the bottom
+// split (⌘J) — instead of focus falling to <body>, or jumping to the wrong pane.
+
+// Focus the first element matching `selector`, retrying across animation frames
+// until focus actually lands. Two reasons a single attempt isn't enough:
+//   1. The host may not be in the DOM yet — React has a re-render pending right
+//      after the store update that triggered this.
+//   2. The tab that takes over is mounted but still `visibility:hidden` for one
+//      frame (panes stay mounted, visibility-toggled). focus() on a hidden
+//      element is a no-op, so we verify it actually landed.
+// tries ≈ frames: a fresh tab's textarea isn't in the DOM until TerminalPane /
+// AuxTerminal mounts and runs `term.open()`, a few frames out — so retry
+// generously. Always match the target as a DESCENDANT of its tab host, never
+// via a two-step host-then-child lookup: TabBar pills also carry `data-tab-id`
+// and sit earlier in the DOM, so resolving the host first can land on a pill
+// (no terminal inside) and focus would never take.
+function focusBySelector(selector: string, tries: number): void {
+  const el = document.querySelector(selector) as HTMLElement | null;
   if (el) {
     el.focus();
     if (document.activeElement === el) return; // focus actually took
   }
-  if (tries > 0) requestAnimationFrame(() => focusTerminalTab(tabId, tries - 1));
+  if (tries > 0) requestAnimationFrame(() => focusBySelector(selector, tries - 1));
+}
+
+// Focus a terminal tab's xterm — a main-pane TerminalPane or a bottom-split
+// AuxTerminal, both of which tag their host with `data-tab-id`.
+export function focusTerminalTab(tabId: string | undefined | null, tries = 30): void {
+  if (!tabId) return;
+  focusBySelector(`[data-tab-id="${CSS.escape(tabId)}"] .xterm-helper-textarea`, tries);
+}
+
+// Move focus back into a MAIN-pane tab — a terminal (xterm) or an editor
+// (CodeMirror). Used when hiding the bottom split (⌘J) so focus returns to the
+// agent / file the user was in, rather than falling to <body>. Scoped to
+// `data-main-tab-id` (the WorkspaceView content wrapper) so it can't match a
+// bottom-split AuxTerminal or a TabBar pill.
+export function focusMainTab(tabId: string | undefined | null, tries = 30): void {
+  if (!tabId) return;
+  const host = `[data-main-tab-id="${CSS.escape(tabId)}"]`;
+  focusBySelector(`${host} .xterm-helper-textarea, ${host} .cm-content`, tries);
 }

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -4,7 +4,7 @@
 import { create } from "zustand";
 import type { Project, Workspace, Tab, TerminalTab, PersistedTab } from "@/lib/types";
 import * as ipc from "@/lib/ipc";
-import { focusTerminalTab } from "@/lib/tabFocus";
+import { focusTerminalTab, focusMainTab } from "@/lib/tabFocus";
 import { agentDisplayName } from "@/lib/agents";
 
 interface View {
@@ -128,6 +128,7 @@ interface AppState {
   setAllWorkspacesCollapsed: (collapsed: boolean) => void;
   setTerminalSplitHeight: (wsId: string, px: number) => void;
   toggleTerminalSplitCollapsed: (wsId: string) => void;
+  toggleBottomTerminal: (wsId: string) => void;
   /** Returns the id of the new bottom tab. `focus` (default true) marks the
    *  fresh shell to grab focus once it spawns; pass false for the auto-seed
    *  on split-open / launch-restore so it can't yank focus off the agent. */
@@ -522,6 +523,29 @@ export const useApp = create<AppState>((set, get) => ({
     try { localStorage.setItem(LS_SPLITC, JSON.stringify(next)); } catch {}
     return { terminalSplitCollapsed: next };
   }),
+  // ⌘J / command palette: toggle the bottom-split terminal, VS Code-style.
+  // "Visible" = split open AND not collapsed. Hidden/collapsed → show, expand,
+  // seed a shell if empty, and focus it. Visible → collapse (not full close, so
+  // shells + PTYs stay mounted) and return focus to whichever pane was active —
+  // the right split or the main pane — rather than letting it fall to <body>.
+  toggleBottomTerminal: (wsId) => {
+    const s = get();
+    const splitOpen = !!s.terminalSplit[wsId];
+    const isCollapsed = !!s.terminalSplitCollapsed[wsId];
+    if (splitOpen && !isCollapsed) {
+      get().toggleTerminalSplitCollapsed(wsId);
+      const rightActive = !!s.rightSplit[wsId] && s.activePane[wsId] === "right";
+      if (rightActive) focusTerminalTab(s.activeRightTab[wsId]);
+      else focusMainTab(s.activeTab[wsId]);
+      return;
+    }
+    if (!splitOpen) get().toggleTerminalSplit(wsId);
+    if (isCollapsed) get().toggleTerminalSplitCollapsed(wsId);
+    // addBottomTab focuses the new shell itself; WorkspaceView's seed effect
+    // sees the non-empty list and won't double-add.
+    if ((get().bottomTabs[wsId]?.length ?? 0) === 0) get().addBottomTab(wsId);
+    else focusTerminalTab(get().activeBottomTab[wsId]);
+  },
   enableFooterTerm:  (wsId) => set(s => ({ footerTerm: { ...s.footerTerm, [wsId]: true } })),
   disableFooterTerm: (wsId) => set(s => {
     const { [wsId]: _, ...rest } = s.footerTerm; void _;


### PR DESCRIPTION
Closes #45.

Adds a VS Code-style toggle for the bottom-split terminal, bound to **⌘J** by default (rebindable via ⌘/ → Edit or Settings → Shortcuts) and also available from the **⌘K command palette** ("Toggle terminal panel").

### Behavior
- **Hidden / collapsed** → opens + expands the split, seeds a shell if there is none, and focuses it.
- **Visible** → collapses the split and returns focus to whichever pane was active before: the right split if that is where you were, otherwise the main pane (its agent terminal, or the editor if a file tab is active).

Collapse (not full close) keeps the shells and their PTYs mounted, and mirrors the strip's existing Expand/Collapse chevron. This gives the mouse-less round-trip the issue asked for: one press to drop into a scratch shell, another to pop back to where you were.

### Implementation notes
- New `toggle-terminal` command in `shortcuts.ts` (the help modal and settings editor are data-driven, so it shows up automatically).
- The whole show/hide + focus logic lives in a single store action (`toggleBottomTerminal`) so the keybinding and the command palette share one implementation. Focus return is pane-aware via the existing `activePane` state.
- `focusMainTab` helper returns focus to the active main-pane tab (xterm or CodeMirror), scoped via a new `data-main-tab-id` so it can't collide with TabBar pills.
- Also fixes a latent bug in `focusTerminalTab`: it resolved the host via a bare `[data-tab-id]` query, which could match a TabBar pill (same attribute, earlier in the DOM) instead of the terminal. It now matches the textarea as a descendant. This affected focusing new agent tabs too.
- Refactored the shared retry loop into one helper and replaced the old `setTimeout`-poll in the `new-split-terminal` case with it.

Rebased on current `main` (v0.15.1). Type-checks clean (`tsc -b`), full unit suite passes (`npm test`, 146/146), and verified manually that ⌘J round-trips focus for terminal, editor, and right-split panes, plus the command-palette entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)