### PR TITLE
feat: Rosé Pine built-in theme

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -3,6 +3,7 @@
 ## Conventions
 
 - Colors are `@theme` CSS vars in `index.css`. Accent terracotta `#d97757`, dark surfaces `#0a0a0a`-`#181818`. Never hard-code hex outside `@theme`.
+- Text on a solid `--color-accent` fill (count badges, filled CTAs, toggle knobs on a filled track) must use `--color-accent-fg`, never `text-white`. The accent is not guaranteed dark: cobalt sky, matrix green, and any light-accent theme make white text unreadable (1.9-2.5:1). Themes with a light accent override `--color-accent-fg` to a dark ink. `--color-accent-deep` stays dark in every theme, so white text on it is fine.
 - `CliIcon cli={...}` + `CLI_BRAND_COLOR[cli]` for claude/gemini/codex (orange/blue/green).
 - Tooltips default `delay: 0`. Override per-call.
 - `cn()` from `@/lib/utils` for class composition.

--- a/src/components/UnifiedBar.tsx
+++ b/src/components/UnifiedBar.tsx
@@ -526,7 +526,7 @@ function ThemePicker({
             // explicit user choice. Outline matches button bg so it
             // reads as a sticker on top of the icon, not part of it.
             <span
-              className="absolute -bottom-1 -right-1 flex h-[10px] w-[10px] items-center justify-center rounded-full bg-[var(--color-accent)] text-[7px] font-bold leading-none text-white ring-1 ring-[var(--color-bg)]"
+              className="absolute -bottom-1 -right-1 flex h-[10px] w-[10px] items-center justify-center rounded-full bg-[var(--color-accent)] text-[7px] font-bold leading-none text-[var(--color-accent-fg)] ring-1 ring-[var(--color-bg)]"
               aria-label="auto"
             >A</span>
           )}

--- a/src/components/UnifiedBar.tsx
+++ b/src/components/UnifiedBar.tsx
@@ -13,7 +13,7 @@ import * as HoverCard from "@radix-ui/react-hover-card";
 import { Check } from "lucide-react";
 import {
   PanelLeft, PanelRight, FolderOpen, Archive,
-  Sun, Moon, Monitor, ArrowUpToLine, Sunrise, Droplet, Binary, Code2, Eye,
+  Sun, Moon, Monitor, ArrowUpToLine, Sunrise, Droplet, Binary, Code2, Eye, Flower2,
   MessageSquareText, Library, Plus,
 } from "lucide-react";
 import { CliIcon, CLI_BRAND_COLOR, resolveIconId } from "@/icons/cli";
@@ -483,6 +483,7 @@ function ThemePicker({
     { id: "solarized", label: "Solarized Dark", icon: Sunrise },
     { id: "cobalt",    label: "Cobalt",         icon: Droplet },
     { id: "matrix",    label: "Matrix",         icon: Binary },
+    { id: "rosepine",  label: "Rosé Pine",      icon: Flower2 },
   ];
   // Plain DOM dropdown — Radix HoverCard's pointer-tracking kept
   // closing on item click (the theme-change re-render storm triggers

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -56,8 +56,9 @@ const THEME_LABELS: Record<ThemeMode, string> = {
   solarized: "Solarized",
   cobalt: "Cobalt",
   matrix: "Matrix",
+  rosepine: "Rosé Pine",
 };
-const THEME_ORDER: ThemeMode[] = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix"];
+const THEME_ORDER: ThemeMode[] = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix", "rosepine"];
 
 export function CommandPalette() {
   const open = useUI(s => s.commandPaletteOpen);

--- a/src/components/dialogs/WelcomeDialog.tsx
+++ b/src/components/dialogs/WelcomeDialog.tsx
@@ -24,7 +24,7 @@ import { CliIcon, CLI_LABEL } from "@/icons/cli";
 import { TermicMark } from "@/icons/TermicLogo";
 import { cn } from "@/lib/utils";
 import { usePrefs, applyTheme, type ThemeMode } from "@/store/prefs";
-import { Sun, Moon, Monitor, Sunrise, Droplet, Binary, Code2 } from "lucide-react";
+import { Sun, Moon, Monitor, Sunrise, Droplet, Binary, Code2, Flower2 } from "lucide-react";
 
 type Step = 0 | 1 | 2;
 
@@ -317,6 +317,7 @@ const THEME_ITEMS: { id: ThemeMode; label: string; icon: typeof Sun; swatch: [st
   { id: "solarized", label: "Solarized Dark", icon: Sunrise, swatch: ["#002b36", "#93a1a1", "#cb4b16"] },
   { id: "cobalt",    label: "Cobalt",         icon: Droplet, swatch: ["#193549", "#e1efff", "#66c4ff"] },
   { id: "matrix",    label: "Matrix",         icon: Binary,  swatch: ["#000800", "#00ff41", "#00ff41"] },
+  { id: "rosepine",  label: "Rosé Pine",      icon: Flower2, swatch: ["#191724", "#e0def4", "#ebbcba"] },
 ];
 function StepTheme() {
   const themeMode = usePrefs(s => s.themeMode);
@@ -363,6 +364,7 @@ function StepTheme() {
                   {t.id === "solarized" && "Schoonover palette"}
                   {t.id === "cobalt" && "deep navy + sky blue"}
                   {t.id === "matrix" && "phosphor green CRT"}
+                  {t.id === "rosepine" && "dusky purple + rose"}
                 </span>
               </div>
             </button>

--- a/src/components/settings/AgentsSection.tsx
+++ b/src/components/settings/AgentsSection.tsx
@@ -640,8 +640,8 @@ function AgentCard({ agent, detected, onPatch, onCommitId, onPatchCaps, onRemove
           >
             <span
               className={cn(
-                "pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
-                !agent.disabled ? "translate-x-4" : "translate-x-0"
+                "pointer-events-none inline-block h-4 w-4 transform rounded-full shadow ring-0 transition duration-200 ease-in-out",
+                !agent.disabled ? "translate-x-4 bg-[var(--color-accent-fg)]" : "translate-x-0 bg-white"
               )}
             />
           </button>
@@ -783,8 +783,8 @@ function AgentCard({ agent, detected, onPatch, onCommitId, onPatchCaps, onRemove
             >
               <span
                 className={cn(
-                  "pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out",
-                  agent.work_done !== false ? "translate-x-4" : "translate-x-0"
+                  "pointer-events-none inline-block h-4 w-4 transform rounded-full shadow ring-0 transition duration-200 ease-in-out",
+                  agent.work_done !== false ? "translate-x-4 bg-[var(--color-accent-fg)]" : "translate-x-0 bg-white"
                 )}
               />
             </button>

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -348,9 +348,10 @@ function Toggle({ label, hint, value, onChange }: { label: string; hint?: string
             left: value ? 18 : 2,
             width: 16, height: 16,
             borderRadius: 999,
-            background: "#ffffff",
+            /* Dark ink knob on a filled track (see GeneralSection Toggle). */
+            background: value ? "var(--color-accent-fg)" : "#ffffff",
             boxShadow: "0 1px 2px rgba(0,0,0,0.25)",
-            transition: "left 150ms",
+            transition: "left 150ms, background-color 150ms",
           }}
         />
       </button>

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -438,8 +438,14 @@ function Toggle({ label, hint, value, onChange }: {
           style={{
             position: "absolute", top: 2, left: value ? 18 : 2,
             width: 16, height: 16, borderRadius: 999,
-            background: "#fff", boxShadow: "0 1px 2px rgba(0,0,0,0.25)",
-            transition: "left 150ms",
+            /* Knob picks up the on-accent ink when the track is filled —
+               themes with a light accent (rosepine gold) need a dark knob
+               there or knob and track melt together. */
+            background: value ? "var(--color-accent-fg)" : "#fff",
+            boxShadow: "0 1px 2px rgba(0,0,0,0.25)",
+            /* Color cross-fades with the slide so the knob doesn't snap
+               between its on/off inks mid-travel. */
+            transition: "left 150ms, background-color 150ms",
           }}
         />
       </button>

--- a/src/components/workspace/EditorPane.tsx
+++ b/src/components/workspace/EditorPane.tsx
@@ -402,7 +402,7 @@ export function EditorPane({ ws, tab, active, onContent }: {
           <span>This file changed on disk. Reload discards your edits.</span>
           <button
             onClick={acceptDiskReload}
-            className="rounded bg-[var(--color-accent)] px-2 py-[3px] font-medium text-white hover:opacity-90"
+            className="rounded bg-[var(--color-accent)] px-2 py-[3px] font-medium text-[var(--color-accent-fg)] hover:opacity-90"
           >
             Reload
           </button>

--- a/src/components/workspace/GitPanel.tsx
+++ b/src/components/workspace/GitPanel.tsx
@@ -512,7 +512,7 @@ export function GitPanel({ ws, status, refresh, onOpenDiff, onDoubleClickDiff }:
             disabled={commitDisabled}
             onClick={() => doCommit(pushDefault)}
             className={cn(
-              "flex h-7 items-center rounded-l-md bg-[var(--color-accent)] px-3 text-[12.5px] font-medium text-white transition-colors",
+              "flex h-7 items-center rounded-l-md bg-[var(--color-accent)] px-3 text-[12.5px] font-medium text-[var(--color-accent-fg)] transition-colors",
               commitDisabled ? "cursor-not-allowed opacity-40" : "hover:brightness-110",
             )}
           >
@@ -524,7 +524,7 @@ export function GitPanel({ ws, status, refresh, onOpenDiff, onDoubleClickDiff }:
                 disabled={commitDisabled}
                 title="Commit options"
                 className={cn(
-                  "flex h-7 w-6 items-center justify-center rounded-r-md border-l border-black/15 bg-[var(--color-accent)] text-white transition-colors",
+                  "flex h-7 w-6 items-center justify-center rounded-r-md border-l border-black/15 bg-[var(--color-accent)] text-[var(--color-accent-fg)] transition-colors",
                   commitDisabled ? "cursor-not-allowed opacity-40" : "hover:brightness-110",
                 )}
               >

--- a/src/components/workspace/ReviewCommentsBar.tsx
+++ b/src/components/workspace/ReviewCommentsBar.tsx
@@ -129,7 +129,7 @@ export function ReviewCommentsBar({ wsId, compact = false, className }: {
                 "flex shrink-0 items-center gap-1.5 rounded-md whitespace-nowrap font-medium text-[12.5px] transition-colors",
                 compact ? "h-7 px-2.5" : "px-2.5 py-1",
                 // Loud filled-accent CTA so pending comments can't be missed.
-                "bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-deep)]",
+                "bg-[var(--color-accent)] text-[var(--color-accent-fg)] hover:bg-[var(--color-accent-deep)] hover:text-white",
                 // Pulse only while closed — once the popover is open the user
                 // is already acting on them, no need to keep shouting.
                 !open && "termic-review-pending",

--- a/src/components/workspace/RightPanel.tsx
+++ b/src/components/workspace/RightPanel.tsx
@@ -944,7 +944,7 @@ function RTab({ label, active, badge, repoBadge, onClick }: { label: string; act
       {badge !== undefined && (
         <span
           title={`${badge} files changed`}
-          className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[var(--color-accent)] px-1.5 text-[11px] font-semibold leading-none text-white tabular-nums"
+          className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[var(--color-accent)] px-1.5 text-[11px] font-semibold leading-none text-[var(--color-accent-fg)] tabular-nums"
         >
           {badge}
         </span>

--- a/src/index.css
+++ b/src/index.css
@@ -247,6 +247,38 @@
     color-scheme: dark;
   }
 
+  /* Rosé Pine (main) — rosepinetheme.com. Chrome ladder: base → surface →
+     overlay → highlightMed; borders bumped to highlightHigh so they read
+     above bg-3. Iris-only chrome read as monochrome purple, so the accent
+     is rose (the palette's namesake, used by official ports for buttons)
+     — warm against the purple, ~10.4:1 on base — with deep iris for
+     white-text button surfaces where rose is too light. Selection stays
+     an iris tint so highlights read calm next to the rose marks. Status
+     trio uses the palette's own semantics: foam/gold/love, and gold
+     stays reserved for warnings. */
+  html.rosepine {
+    --color-bg:          #191724;       /* base — main content */
+    --color-bg-1:        #1f1d2e;       /* surface — sidebar / title bar / tabs */
+    --color-bg-2:        #26233a;       /* overlay — nested cards / badges */
+    --color-bg-3:        #403d52;       /* highlightMed — hover + active surfaces */
+    --color-fg:          #e0def4;       /* text */
+    --color-fg-dim:      #908caa;       /* subtle */
+    --color-fg-faint:    #6e6a86;       /* muted */
+    --color-border:      #524f67;       /* highlightHigh */
+    --color-border-soft: #26233a;       /* overlay as hairline */
+    --color-hover:       rgba(224, 222, 244, 0.05);
+    --color-sel:         rgba(196, 167, 231, 0.22);  /* iris-tinted */
+    --color-accent:      #ebbcba;       /* rose */
+    --color-accent-soft: rgba(235, 188, 186, 0.22);
+    --color-accent-deep: #6f5b9e;       /* deep iris, ~5.7:1 with white text */
+    --color-accent-fg:   #26233a;       /* overlay ink on rose, ~9:1 — NOT base,
+                                           which made filled knobs/badges read
+                                           as holes punched to the page bg */
+    --color-ok:          #9ccfd8;       /* foam — additions/info */
+    --color-warn:        #f6c177;       /* gold */
+    --color-err:         #eb6f92;       /* love */
+    color-scheme: dark;
+  }
   ::-webkit-scrollbar { width: 10px; height: 10px; }
   ::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 6px; }
   ::-webkit-scrollbar-thumb:hover { background: var(--color-border-soft); }

--- a/src/index.css
+++ b/src/index.css
@@ -50,6 +50,11 @@
      button background - especially on the brighter themes (cobalt).
      White text + accent-deep should hit ≥4.5:1 contrast. */
   --color-accent-deep: #b35e3f;
+  /* Text painted ON a solid --color-accent fill (count badges, filled
+     CTAs). White works for the dark terracotta/orange accents; themes
+     with a LIGHT accent (rosepine gold, cobalt sky, matrix green)
+     override this to a dark ink or the text is unreadable. */
+  --color-accent-fg: #ffffff;
   --color-ok:        #4caf50;
   --color-warn:      #f0b13a;
   --color-err:       #ef5350;
@@ -191,6 +196,7 @@
        against the navy panels. Drop down a couple of stops into
        a deep azure that still reads cobalt-family. */
     --color-accent-deep: #1f6fa8;
+    --color-accent-fg:   #193549;   /* navy ink on the sky accent (white was ~1.9:1) */
     color-scheme: dark;
   }
 
@@ -215,6 +221,7 @@
     --color-accent:      #3fb950;       /* calmer green - reads matrix without burning the retina */
     --color-accent-soft: rgba(63, 185, 80, 0.20);
     --color-accent-deep: #2a7a36;       /* deeper phosphor for button surfaces */
+    --color-accent-fg:   #050905;       /* near-black ink on phosphor green (white was ~2.5:1) */
     color-scheme: dark;
   }
 
@@ -239,6 +246,7 @@
     --color-accent-deep: #9d3a11;       /* deeper solarized orange for buttons */
     color-scheme: dark;
   }
+
   ::-webkit-scrollbar { width: 10px; height: 10px; }
   ::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 6px; }
   ::-webkit-scrollbar-thumb:hover { background: var(--color-border-soft); }

--- a/src/store/prefs.ts
+++ b/src/store/prefs.ts
@@ -50,12 +50,12 @@ const LS_PANE_DIM_AMT  = "splitPaneDimAmount";
 /** Markdown edit-tab view: source editor, rendered preview, or both. */
 export type MarkdownView = "source" | "preview" | "split";
 
-export type ThemeMode = "auto" | "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix";
+export type ThemeMode = "auto" | "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix" | "rosepine";
 /** What `applyTheme` resolves to: a concrete palette name. `auto` is
  *  never returned; it gets mapped to light/dark based on OS preference. */
-export type ResolvedTheme = "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix";
+export type ResolvedTheme = "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix" | "rosepine";
 
-const VALID_MODES: ReadonlyArray<ThemeMode> = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix"];
+const VALID_MODES: ReadonlyArray<ThemeMode> = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix", "rosepine"];
 /** Defensive parse: localStorage may hold a theme id that's been
  *  removed in a later version. Fall back to "claude" (the default
  *  theme) instead of letting the unknown string flow through and
@@ -145,6 +145,23 @@ export const TERMINAL_THEMES: Record<ResolvedTheme, Record<string, string>> = {
     blue:    "#5a9fd6", magenta: "#c075c0", cyan:    "#50b0a8", white:   "#c8e1c0",
     brightBlack:   "#5a6058", brightRed:     "#e88a8a", brightGreen:   "#5fd06e", brightYellow:  "#e0d670",
     brightBlue:    "#7eb5e6", brightMagenta: "#d090d0", brightCyan:    "#70c8c0", brightWhite:   "#e8f0e0",
+  },
+  rosepine: {
+    // Rosé Pine (main) — official ANSI mapping (matches Ghostty's built-in),
+    // so agent TUIs look identical in termic and Ghostty. Brights stay equal
+    // to normals except brightBlack=muted, per the official spec. Cursor
+    // follows the termic convention of accent-colored cursors (rose, same
+    // as the chrome accent); the official spec uses highlightHigh #524f67
+    // if rose feels loud.
+    background: "#191724",           // base
+    foreground: "#e0def4",           // text
+    cursor: "#ebbcba",               // rose — matches chrome accent
+    cursorAccent: "#191724",
+    selectionBackground: "#403d52",  // highlightMed (matches Ghostty)
+    black: "#26233a",  red: "#eb6f92",     green: "#31748f",  yellow: "#f6c177",
+    blue: "#9ccfd8",   magenta: "#c4a7e7", cyan: "#ebbcba",   white: "#e0def4",
+    brightBlack: "#6e6a86", brightRed: "#eb6f92", brightGreen: "#31748f", brightYellow: "#f6c177",
+    brightBlue: "#9ccfd8",  brightMagenta: "#c4a7e7", brightCyan: "#ebbcba", brightWhite: "#e0def4",
   },
 };
 
@@ -767,6 +784,7 @@ export function applyTheme(mode: ThemeMode) {
   html.classList.toggle("solarized", resolved === "solarized");
   html.classList.toggle("cobalt",    resolved === "cobalt");
   html.classList.toggle("matrix",    resolved === "matrix");
+  html.classList.toggle("rosepine",  resolved === "rosepine");
   // Color-scheme tells the browser to use light/dark form controls +
   // scrollbars. Espresso + Solarized both want dark widgets.
   html.style.colorScheme = resolved === "light" ? "light" : "dark";


### PR DESCRIPTION
> Stacked on #60 (the first commit here is that PR). Review only after #60 lands; 

## What

Adds Rosé Pine (main variant, rosepinetheme.com) as a built-in theme: coupled chrome + terminal palettes, per the "new themes" contribution path (palette in `src/store/prefs.ts` + class in `src/index.css`, plus the three picker registrations).

- Terminal ANSI 16 uses the official Rosé Pine mapping, identical to Ghostty's built-in Rose Pine, so agent TUIs render the same in both terminals.
- Chrome ladder maps the palette's surfaces (base, surface, overlay, highlightMed) with borders bumped to highlightHigh so panel edges read (the Cobalt lesson).
- Accent is rose with deep iris for white-text button surfaces, and an overlay ink for text on rose fills (via `--color-accent-fg` from #60, which is why this stacks on it).
- Status colors follow the palette's own semantics: foam for ok, gold for warnings, love for errors.

## Testing

`make check-all` passes. Manual pass: chrome elevation and borders, terminal ANSI + rose cursor + COLORFGBG dark detection on fresh PTYs, badge/toggle contrast, theme persistence across relaunch, and no regressions switching through the other seven themes.

Screenshots: 

<img width="925" height="904" alt="Screenshot 2026-07-09 at 2 33 31 PM" src="https://github.com/user-attachments/assets/01bf0d1c-9585-4fb9-a4be-afddcf7ba5aa" />
<img width="157" height="322" alt="Screenshot 2026-07-09 at 2 33 20 PM" src="https://github.com/user-attachments/assets/df1a1e30-9071-4613-a568-c4d2f47722a1" />
<img width="1858" height="295" alt="Screenshot 2026-07-09 at 2 33 10 PM" src="https://github.com/user-attachments/assets/23fa7877-bcda-46ce-9fd0-9af43d7f11b2" />
