### PR TITLE
feat: support for custom themes 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ Deeper references — read when working in that area:
 - [docs/performance.md](docs/performance.md) — perf traps, sub-pixel/rendering hardening
 - [docs/sandbox.md](docs/sandbox.md) — sandbox-exec + CONNECT proxy, YOLO interaction, deny debugging
 - [docs/shortcuts.md](docs/shortcuts.md) — shortcut system architecture, adding shortcuts, glyph rendering
+- [docs/themes.md](docs/themes.md) — custom theme file format (`~/.config/termic/themes/*.json`), ui/terminal key reference
 - [docs/ui.md](docs/ui.md) — UI conventions, window chrome/drag, right-panel footer, settled detection
 - [docs/gotchas.md](docs/gotchas.md) — common bugs (encountered + fixed), React/Zustand traps
 - [docs/automation.md](docs/automation.md) — automation bridge, E2E testing (use the `e2e` skill, don't improvise)

--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ no metered markup, no backend daemon. Here's what the window gives you on top:
   bottom, ⌘T spawns a new tab, ⌘W closes one. Every shortcut is rebindable in
   Settings → Shortcuts (⌘/ for the searchable cheat sheet). Seven themes
   (System, Light, Claude, Dark+, Solarized Dark, Cobalt, Matrix), each
-  re-themes both chrome and the terminal pane.
+  re-themes both chrome and the terminal pane. Or bring your own: drop a
+  JSON file in the themes folder and it appears in the picker as a
+  first-class theme — see [docs/themes.md](docs/themes.md).
 - **Terminal niceties.** xterm.js + WebGL, OSC 52 clipboard (copy out of a
   container or over SSH), optional copy-on-select, inline images, clickable
   links, and drag-and-drop file paths.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -2,9 +2,10 @@
 
 ## Directories
 
-Two directories, different owners:
+Three directories, different owners:
 - `~/Library/Application Support/termic/` — app-owned: `projects.json`, `workspaces/`, `settings.json`. Path via `dirs::data_local_dir().join("termic")` in `lib.rs#data_dir()`.
 - `~/Library/Application Support/com.simion.termic/` — tauri-plugin-window-state owned (window position/size). Path from `tauri.conf.json#identifier`.
+- `~/.config/termic/themes/` — user-owned, hand-authored custom theme files ([docs/themes.md](themes.md)). `$XDG_CONFIG_HOME` respected; shared by release + dev builds (no `termic_dev` split). Path via `lib.rs#themes_dir_path()`.
 
 ## Entities
 

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,0 +1,145 @@
+# Custom themes
+
+Drop a JSON file in termic's themes folder and it shows up in the theme
+picker as a first-class theme: chrome and terminal, coupled, exactly like
+the built-ins. There is no theme editor UI. The files are the interface,
+which makes themes trivially shareable and stowable from dotfiles.
+
+## Where
+
+```
+~/.config/termic/themes/
+```
+
+(`$XDG_CONFIG_HOME/termic/themes/` if you set that variable. Same path on
+every platform; release and dev builds share it.)
+
+Themes are hand-authored, shareable config, so they live under `.config`
+like other terminal tools (wezterm, starship, kitty), not in the app-owned
+Application Support data dir, which makes them trivially stowable from
+dotfiles.
+
+One JSON file per theme. The picker's "Open themes folder" row opens this
+directory (and creates it if needed). Themes are read at startup and
+re-read every time the picker opens, so the edit loop is: save the file,
+hover the picker, done. No restart, no watcher.
+
+## Picking a theme
+
+Two ways, same as the built-ins:
+
+- Hover the theme icon (sun/moon) in the title bar. Custom themes list
+  below the built-ins, with an "Open themes folder" row at the bottom.
+- ⌘K, then "Change theme…". Arrow keys live-preview each theme; Enter
+  commits, Escape rolls back to what you had.
+
+The keyboard theme-cycle shortcut only cycles System / Light / Dark, so a
+custom theme sticks until you explicitly pick something else.
+
+The theme's id is its file name (a file named `rose-pine-moon.json` becomes
+`custom:rose-pine-moon` internally), so a file named `claude.json` can
+never shadow the built-in Claude theme.
+
+## File format
+
+```json
+{
+  "name": "Rosé Pine Moon",
+  "colorScheme": "dark",
+  "ui": {
+    "bg": "#232136", "bg-1": "#2a273f", "bg-2": "#393552", "bg-3": "#44415a",
+    "fg": "#e0def4", "fg-dim": "#908caa", "fg-faint": "#6e6a86",
+    "border": "#56526e", "border-soft": "#393552",
+    "hover": "rgba(224,222,244,0.05)", "sel": "rgba(196,167,231,0.22)",
+    "accent": "#c4a7e7", "accent-soft": "rgba(196,167,231,0.22)", "accent-deep": "#6f5b9e",
+    "accent-fg": "#232136",
+    "ok": "#9ccfd8", "warn": "#f6c177", "err": "#eb6f92"
+  },
+  "terminal": {
+    "background": "#232136", "foreground": "#e0def4",
+    "cursor": "#c4a7e7", "selectionBackground": "#44415a",
+    "black": "#393552", "red": "#eb6f92", "green": "#3e8fb0", "yellow": "#f6c177",
+    "blue": "#9ccfd8", "magenta": "#c4a7e7", "cyan": "#ea9a97", "white": "#e0def4",
+    "brightBlack": "#6e6a86", "brightRed": "#eb6f92", "brightGreen": "#3e8fb0",
+    "brightYellow": "#f6c177", "brightBlue": "#9ccfd8", "brightMagenta": "#c4a7e7",
+    "brightCyan": "#ea9a97", "brightWhite": "#e0def4"
+  }
+}
+```
+
+### Top-level fields
+
+| Field | Required | Values | Notes |
+| --- | --- | --- | --- |
+| `name` | yes | string | Picker label. Falls back to the file name if empty. |
+| `colorScheme` | yes | `"dark"` or `"light"` | Drives form controls, the editor's auto syntax theme, and the `COLORFGBG` env var agents use to pick their TUI theme. Anything other than `"light"` is treated as `"dark"`. |
+| `ui` | no | object | Chrome colors, see below. |
+| `terminal` | no | object | xterm palette, see below. |
+
+Unknown top-level fields are ignored (forward compatibility).
+
+### `ui` keys
+
+Every key is optional and maps to the `--color-<key>` CSS variable. Missing
+keys fall back to the Dark+ defaults, so a minimal theme can override just
+`bg` and `accent` and still look coherent.
+
+| Key | What it paints |
+| --- | --- |
+| `bg` | main content area |
+| `bg-1` | chrome: sidebar, title bar, tabs |
+| `bg-2` | nested cards, badges |
+| `bg-3` | hover and active surfaces |
+| `fg` | primary text |
+| `fg-dim` | muted text |
+| `fg-faint` | faint icons, secondary text |
+| `border` | standard borders |
+| `border-soft` | hairline borders |
+| `hover` | hover overlay (usually a low-alpha rgba) |
+| `sel` | selection tint |
+| `accent` | brand accent (buttons, active states) |
+| `accent-soft` | accent-tinted backgrounds (usually low-alpha rgba) |
+| `accent-deep` | accent for filled buttons |
+| `accent-fg` | ink on a solid `accent` fill (count badges, filled CTAs). Defaults to white; set a dark ink if your accent is light |
+| `ok` | success green |
+| `ok-fg` | ink on a solid `ok` fill (toggle knobs). Defaults to white |
+| `warn` | warning yellow |
+| `err` | error red |
+
+The `--color-cli-*` agent tint variables are not themeable in v1; they keep
+their defaults.
+
+### `terminal` keys
+
+Standard xterm.js `ITheme` keys, all optional: `background`, `foreground`,
+`cursor`, `cursorAccent`, `selectionBackground`, `selectionForeground`,
+`selectionInactiveBackground`, the ANSI 8 (`black` through `white`), and
+the bright ANSI 8 (`brightBlack` through `brightWhite`).
+
+Missing keys fall back to the built-in palette matching your `colorScheme`
+(Dark+ for dark themes, Light for light ones), so a partial block still
+yields a complete, readable ANSI 16.
+
+### Color values
+
+Hex (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) and `rgb()` / `rgba()` /
+`hsl()` / `hsla()` notation. Named CSS colors are not accepted.
+
+## Error handling
+
+Nothing about a theme file can break the app:
+
+- A file that fails to parse is skipped (the rest still list). Check the
+  dev console / stderr for a `[themes] skipping ...` line.
+- An unknown key or a malformed color value is dropped; the key falls back
+  to its default.
+- Deleting the active theme's file falls back to the Claude theme on the
+  next picker open or launch.
+
+## Notes
+
+- Two files with the same `name` both list (their ids differ). The picker
+  shows whatever the files say.
+- The active custom theme's payload is cached in localStorage so the first
+  paint after launch uses it directly. The folder is re-read right after
+  startup and reconciled (edits re-apply, deletions fall back).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6892,6 +6892,93 @@ fn agents_save(agents: Vec<Agent>) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+// ───────────────────────────── custom themes ─────────────────────────────
+
+/// One custom theme file from the themes config dir (see
+/// `themes_dir_path`). `id` is the file stem (the frontend namespaces it
+/// as `custom:<id>`); `ui` / `terminal` are passed through as raw string
+/// maps — the frontend allowlist-validates keys and color values, so a
+/// bad entry degrades per-key instead of failing the file. Unknown
+/// top-level JSON fields are ignored (forward compat). Serialized
+/// camelCase to match the on-disk file format.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomThemeFile {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub color_scheme: String,
+    #[serde(default)]
+    pub ui: HashMap<String, String>,
+    #[serde(default)]
+    pub terminal: HashMap<String, String>,
+}
+
+/// `$XDG_CONFIG_HOME/termic/themes`, defaulting to `~/.config/termic/themes`
+/// — the same path shape on every platform (wezterm/starship convention;
+/// on Windows `~` is the user profile dir). Themes are hand-authored,
+/// stowable config, unlike the app-owned JSON in `data_dir()`, so they
+/// live under `.config` and deliberately skip the `termic_dev` split
+/// (dev builds should see your real themes; the files are inert and
+/// validated, so they can't destabilize a dev run).
+fn themes_dir_path() -> Result<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
+        .ok_or_else(|| anyhow!("no home"))?;
+    let p = base.join("termic").join("themes");
+    fs::create_dir_all(&p)?;
+    Ok(p)
+}
+
+/// List every parseable custom theme file in the themes dir. A file
+/// that fails to read or parse is skipped with a log line — one bad JSON
+/// must never blank the theme picker. Sorted by file stem for stable order.
+#[tauri::command]
+async fn themes_list() -> Result<Vec<CustomThemeFile>, String> {
+    let dir = themes_dir_path().map_err(|e| e.to_string())?;
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&dir).map_err(|e| e.to_string())?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
+        let raw = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[themes] skipping {}: {e}", path.display());
+                continue;
+            }
+        };
+        match serde_json::from_str::<CustomThemeFile>(&raw) {
+            Ok(mut theme) => {
+                theme.id = stem.to_string();
+                if theme.name.trim().is_empty() {
+                    theme.name = stem.to_string();
+                }
+                out.push(theme);
+            }
+            Err(e) => eprintln!("[themes] skipping {}: {e}", path.display()),
+        }
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(out)
+}
+
+/// Ensure the themes directory exists and return its absolute path.
+/// Backs the picker's "Open themes folder" row.
+#[tauri::command]
+async fn themes_dir() -> Result<String, String> {
+    Ok(themes_dir_path()
+        .map_err(|e| e.to_string())?
+        .to_string_lossy()
+        .into_owned())
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct DiscoveredRepo {
     pub path: String,
@@ -7322,6 +7409,7 @@ pub fn run() {
             automation::automation_result,
             automation::automation_armed,
             list_monospace_fonts,
+            themes_list, themes_dir,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { useShortcuts } from "@/hooks/useShortcuts";
 import { useAttentionNotifier } from "@/hooks/useAttentionNotifier";
 import { useIsFullscreen } from "@/hooks/useIsFullscreen";
 import { useUpdate } from "@/store/update";
+import { usePrefs } from "@/store/prefs";
 import { focusMainTab } from "@/lib/tabFocus";
 
 export function App() {
@@ -63,6 +64,11 @@ export function App() {
     useApp.getState().refreshClis();
     // Kick off the update check + changelog fetch (idempotent).
     useUpdate.getState().init();
+
+    // Custom theme files: the first-paint cache already painted the active
+    // one at module load — this fetch populates the picker list and
+    // reconciles the selection against the folder (edited / deleted file).
+    usePrefs.getState().loadCustomThemes();
 
     // Hydrate spotlight state from Rust (survives hot-reloads).
     workspaceSpotlightStatus().then(map => {

--- a/src/components/UnifiedBar.tsx
+++ b/src/components/UnifiedBar.tsx
@@ -14,7 +14,7 @@ import { Check } from "lucide-react";
 import {
   PanelLeft, PanelRight, FolderOpen, Archive,
   Sun, Moon, Monitor, ArrowUpToLine, Sunrise, Droplet, Binary, Code2, Eye, Flower2,
-  MessageSquareText, Library, Plus,
+  MessageSquareText, Library, Plus, Palette,
 } from "lucide-react";
 import { CliIcon, CLI_BRAND_COLOR, resolveIconId } from "@/icons/cli";
 import { effectiveSandboxMode } from "@/lib/types";
@@ -23,7 +23,7 @@ import type { TerminalTab } from "@/lib/types";
 import { findLeaf } from "@/lib/splitTree";
 import { UpdaterBanner } from "@/components/UpdaterBanner";
 import { WaitingAgentsPill } from "@/components/WaitingAgentsPill";
-import { openPath, workspaceSendDiffToMain } from "@/lib/ipc";
+import { openPath, themesDir, workspaceSendDiffToMain } from "@/lib/ipc";
 import { archiveAndRefresh } from "@/lib/archiveWorkspace";
 import { visibleCliIds, isTerminalEntry, tabLabel } from "@/lib/agents";
 import { AppDialog } from "@/components/ui/Dialog";
@@ -495,6 +495,9 @@ function ThemePicker({
   const [open, setOpen] = useState(false);
   const closeTimerRef = useRef<number | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  // Custom theme files (~/.config/termic/themes/*.json). Refetched on every
+  // trigger hover — that's the "hot reload": edit file, reopen picker.
+  const customThemes = usePrefs(s => s.customThemes);
   const cancelClose = () => {
     if (closeTimerRef.current) { window.clearTimeout(closeTimerRef.current); closeTimerRef.current = null; }
   };
@@ -515,7 +518,10 @@ function ThemePicker({
     <div
       ref={wrapperRef}
       className="relative"
-      onMouseEnter={() => { cancelClose(); setOpen(true); }}
+      onMouseEnter={() => {
+        cancelClose(); setOpen(true);
+        void usePrefs.getState().loadCustomThemes();
+      }}
       onMouseLeave={scheduleClose}
     >
       <Button size="icon" variant="icon" onClick={() => setOpen(v => !v)}>
@@ -557,6 +563,40 @@ function ThemePicker({
               </button>
             );
           })}
+          {customThemes.length > 0 && (
+            <div className="my-1 border-t border-[var(--color-border-soft)]" />
+          )}
+          {customThemes.map(t => {
+            const active = t.id === themeMode;
+            return (
+              <button
+                key={t.id}
+                onClick={() => setThemeMode(t.id)}
+                className={cn(
+                  "flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[13.5px] text-[var(--color-fg)]",
+                  "hover:bg-[var(--color-hover)]",
+                )}
+              >
+                <Check className={cn("h-3.5 w-3.5 text-[var(--color-accent)]", active ? "opacity-100" : "opacity-0")} />
+                <Palette className="h-4 w-4 text-[var(--color-fg-dim)]" />
+                <span className="truncate">{t.name}</span>
+              </button>
+            );
+          })}
+          <div className="my-1 border-t border-[var(--color-border-soft)]" />
+          {/* Doubles as the discovery affordance when no custom theme files
+              exist yet — drop a JSON here, hover the picker again, done. */}
+          <button
+            onClick={() => { themesDir().then(openPath).catch(() => {}); }}
+            className={cn(
+              "flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-left text-[13.5px] text-[var(--color-fg)]",
+              "hover:bg-[var(--color-hover)]",
+            )}
+          >
+            <span className="h-3.5 w-3.5" />
+            <FolderOpen className="h-4 w-4 text-[var(--color-fg-dim)]" />
+            <span>Open themes folder</span>
+          </button>
           {/* One-time tip: agent CLIs persist their own theme. We set
               COLORFGBG on spawn so most TUIs auto-pick, but claude /
               gemini / codex also expose a `/theme` slash command that

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -15,12 +15,13 @@ import {
 } from "lucide-react";
 import { useUI } from "@/store/ui";
 import { useApp } from "@/store/app";
-import { usePrefs, type ThemeMode } from "@/store/prefs";
+import { usePrefs, type BuiltinThemeMode, type ThemeMode } from "@/store/prefs";
 import { useUpdate } from "@/store/update";
 import { fuzzyMatch, Highlighted } from "@/lib/fuzzy";
 import { bindingGlyphs, type ShortcutId } from "@/lib/shortcuts";
 import { confirmAndArchive } from "@/lib/archiveWorkspace";
 import { workspaceSetYolo, openPath } from "@/lib/ipc";
+import { isCustomId } from "@/lib/customTheme";
 import { effectiveSandboxMode, isSandboxEnforced } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -48,7 +49,7 @@ interface Cmd {
   run: () => void;
 }
 
-const THEME_LABELS: Record<ThemeMode, string> = {
+const THEME_LABELS: Record<BuiltinThemeMode, string> = {
   auto: "System (auto)",
   light: "Light",
   dark: "Dark",
@@ -58,7 +59,7 @@ const THEME_LABELS: Record<ThemeMode, string> = {
   matrix: "Matrix",
   rosepine: "Rosé Pine",
 };
-const THEME_ORDER: ThemeMode[] = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix", "rosepine"];
+const THEME_ORDER: BuiltinThemeMode[] = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix", "rosepine"];
 
 export function CommandPalette() {
   const open = useUI(s => s.commandPaletteOpen);
@@ -67,7 +68,19 @@ export function CommandPalette() {
   const workspaces = useApp(s => s.workspaces);
   const projects = useApp(s => s.projects);
   const themeMode = usePrefs(s => s.themeMode);
+  const customThemes = usePrefs(s => s.customThemes);
   const binds = usePrefs(s => s.shortcuts);
+
+  // Built-ins first, then the custom theme files — the submenu's order.
+  const themeEntries = useMemo<{ id: ThemeMode; label: string }[]>(
+    () => [
+      ...THEME_ORDER.map(m => ({ id: m as ThemeMode, label: THEME_LABELS[m] })),
+      ...customThemes.map(t => ({ id: t.id as ThemeMode, label: t.name })),
+    ],
+    [customThemes],
+  );
+  const themeLabel = (m: ThemeMode) =>
+    themeEntries.find(e => e.id === m)?.label ?? (isCustomId(m) ? m.slice("custom:".length) : m);
 
   const [query, setQuery] = useState("");
   const [activeIdx, setActiveIdx] = useState(0);
@@ -111,9 +124,9 @@ export function CommandPalette() {
   useEffect(() => {
     if (view === "theme") {
       const cur = themeOriginalRef.current ?? usePrefs.getState().themeMode;
-      setActiveIdx(Math.max(0, THEME_ORDER.indexOf(cur)));
+      setActiveIdx(Math.max(0, themeEntries.findIndex(e => e.id === cur)));
     } else setActiveIdx(0);
-  }, [view]);
+  }, [view]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /** Wrap an action so it closes the palette, then runs on the NEXT frame.
    *  The defer matters when the action opens another dialog (Archive → confirm,
@@ -127,10 +140,10 @@ export function CommandPalette() {
   // workspace is active. Everything reads live store state at build time.
   const commands = useMemo<Cmd[]>(() => {
     if (view === "theme") {
-      return THEME_ORDER.map<Cmd>(m => ({
+      return themeEntries.map<Cmd>(({ id: m, label }) => ({
         id: `theme:${m}`,
         section: "View",
-        label: THEME_LABELS[m],
+        label,
         icon: m === themeMode ? Check : Palette,
         keywords: "theme appearance color",
         // Commit: the live preview already applied it; clear the rollback
@@ -226,8 +239,11 @@ export function CommandPalette() {
     }
     cmds.push({
       id: "change-theme", section: "View", label: "Change theme…",
-      suffix: THEME_LABELS[themeMode], icon: Palette, keywords: "appearance color dark light",
+      suffix: themeLabel(themeMode), icon: Palette, keywords: "appearance color dark light",
       run: () => {
+        // Refresh the custom theme files so the submenu reflects the folder
+        // (same refetch-on-open the picker does on trigger hover).
+        void usePrefs.getState().loadCustomThemes();
         // Enter the submenu and start a live preview — arrowing through the
         // themes applies each one; cancelling restores this captured original.
         themeOriginalRef.current = usePrefs.getState().themeMode;
@@ -291,7 +307,7 @@ export function CommandPalette() {
     }
 
     return cmds;
-  }, [view, ws, proj, themeMode]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [view, ws, proj, themeMode, themeEntries]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Filter + score against the query, preserving section order. Each command
   // matches on "<label> <keywords>"; only label-range hits are highlighted.

--- a/src/components/workspace/AuxTerminal.tsx
+++ b/src/components/workspace/AuxTerminal.tsx
@@ -294,13 +294,14 @@ export function AuxTerminal({ wsId, wsPath, active, autoFocus, onExited, onTitle
 
   // Live theme swap mirrors TerminalPane's effect; see the comment there.
   const themeMode = usePrefs(s => s.themeMode);
+  const customThemeRev = usePrefs(s => s.customThemeRev);
   const firstThemeRun = useRef(true);
   useEffect(() => {
     if (firstThemeRun.current) { firstThemeRun.current = false; return; }
     const t = termRef.current;
     if (!t) return;
     t.options.theme = currentTerminalTheme() as any;
-  }, [themeMode]);
+  }, [themeMode, customThemeRev]);
 
   return (
     <div className="relative flex h-full w-full flex-col">

--- a/src/components/workspace/TerminalPane.tsx
+++ b/src/components/workspace/TerminalPane.tsx
@@ -1625,13 +1625,16 @@ const captureArmedRef = useRef(false);
   // xterm's `options.theme` setter triggers an internal repaint so we
   // don't need to touch the WebGL atlas explicitly.
   const themeMode = usePrefs(s => s.themeMode);
+  // customThemeRev bumps when the active custom theme's FILE was edited
+  // (same themeMode string, new palette) — see prefs.loadCustomThemes.
+  const customThemeRev = usePrefs(s => s.customThemeRev);
   const firstThemeRun = useRef(true);
   useEffect(() => {
     if (firstThemeRun.current) { firstThemeRun.current = false; return; }
     const t = termRef.current;
     if (!t) return;
     t.options.theme = currentTerminalTheme() as any;
-  }, [themeMode]);
+  }, [themeMode, customThemeRev]);
 
   // YOLO live toggle — for agents that support runtime mode switching (only
   // gemini today), send the appropriate slash command. For claude/codex this

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -123,9 +123,10 @@ export function WorkspaceView({ ws }: { ws: Workspace }) {
   const setActiveBottom = useApp(s => s.setActiveBottomTab);
   const setBottomLiveTitle = useApp(s => s.setBottomTabLiveTitle);
 
-  // Subscribe to themeMode so the terminals-area bg recomputes when the
-  // user switches themes.
+  // Subscribe to themeMode (and the custom-theme edit counter) so the
+  // terminals-area bg recomputes when the user switches or edits themes.
   usePrefs(s => s.themeMode);
+  usePrefs(s => s.customThemeRev);
   const xtermBg = currentTerminalTheme().background as string;
 
   // Workspace split tree: the main pane is an ordinary leaf (isMain flag) that

--- a/src/lib/customTheme.test.ts
+++ b/src/lib/customTheme.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  UI_KEYS,
+  isValidColor,
+  isCustomId,
+  sanitizeTheme,
+  applyCustomVars,
+  clearCustomVars,
+  mergeTerminal,
+  readThemeCache,
+  writeThemeCache,
+  clearThemeCache,
+  type CustomThemeFile,
+} from "@/lib/customTheme";
+
+// ── isValidColor ──────────────────────────────────────────────────────
+
+describe("isValidColor", () => {
+  it("accepts hex in all four lengths", () => {
+    expect(isValidColor("#abc")).toBe(true);
+    expect(isValidColor("#abcd")).toBe(true);
+    expect(isValidColor("#aabbcc")).toBe(true);
+    expect(isValidColor("#aabbccdd")).toBe(true);
+  });
+
+  it("accepts rgb()/rgba()/hsl()/hsla() functional notation", () => {
+    expect(isValidColor("rgb(1, 2, 3)")).toBe(true);
+    expect(isValidColor("rgba(224,222,244,0.05)")).toBe(true);
+    expect(isValidColor("hsl(210 50% 40%)")).toBe(true);
+    expect(isValidColor("hsla(210, 50%, 40%, 0.5)")).toBe(true);
+  });
+
+  it("tolerates surrounding whitespace", () => {
+    expect(isValidColor("  #aabbcc  ")).toBe(true);
+  });
+
+  it("rejects named colors, CSS injection shapes, and non-strings", () => {
+    // Values land in inline styles / xterm options, so only shapes we
+    // can reason about get through.
+    expect(isValidColor("red")).toBe(false);
+    expect(isValidColor("var(--color-bg)")).toBe(false);
+    expect(isValidColor("url(javascript:alert(1))")).toBe(false);
+    expect(isValidColor("#aabbcc; background: red")).toBe(false);
+    expect(isValidColor("")).toBe(false);
+    expect(isValidColor(42)).toBe(false);
+    expect(isValidColor(null)).toBe(false);
+  });
+});
+
+// ── isCustomId ────────────────────────────────────────────────────────
+
+describe("isCustomId", () => {
+  it("matches only the custom: namespace", () => {
+    expect(isCustomId("custom:rose-pine-moon")).toBe(true);
+    expect(isCustomId("claude")).toBe(false);
+    expect(isCustomId("rosepine")).toBe(false);
+  });
+});
+
+// ── sanitizeTheme ─────────────────────────────────────────────────────
+
+function rawFile(overrides: Partial<CustomThemeFile> = {}): CustomThemeFile {
+  return {
+    id: "tokyo-night",
+    name: "Tokyo Night",
+    colorScheme: "dark",
+    ui: {},
+    terminal: {},
+    ...overrides,
+  };
+}
+
+describe("sanitizeTheme", () => {
+  it("namespaces the id and keeps the name", () => {
+    const t = sanitizeTheme(rawFile());
+    expect(t.id).toBe("custom:tokyo-night");
+    expect(t.name).toBe("Tokyo Night");
+  });
+
+  it("falls back name → slug and slug → 'theme'", () => {
+    expect(sanitizeTheme(rawFile({ name: "  " })).name).toBe("tokyo-night");
+    const empty = sanitizeTheme(rawFile({ id: "", name: "" }));
+    expect(empty.id).toBe("custom:theme");
+    expect(empty.name).toBe("theme");
+  });
+
+  it("treats anything but 'light' as dark", () => {
+    expect(sanitizeTheme(rawFile({ colorScheme: "light" })).colorScheme).toBe("light");
+    expect(sanitizeTheme(rawFile({ colorScheme: "DARK" })).colorScheme).toBe("dark");
+    expect(sanitizeTheme(rawFile({ colorScheme: "" })).colorScheme).toBe("dark");
+  });
+
+  it("keeps allowlisted keys with valid colors, drops everything else", () => {
+    const t = sanitizeTheme(rawFile({
+      ui: {
+        bg: "#1a1b26",
+        accent: " #7aa2f7 ",          // trimmed on the way in
+        "accent-fg": "#1a1b26",       // new ink token is themeable
+        "ok-fg": "#1a1b26",
+        fg: "red",                    // invalid value → dropped
+        "not-a-key": "#ffffff",       // unknown key → dropped
+      },
+      terminal: {
+        background: "#1a1b26",
+        cursor: "blink",              // invalid value → dropped
+        bogus: "#fff",                // unknown key → dropped
+      },
+    }));
+    expect(t.ui).toEqual({
+      bg: "#1a1b26",
+      accent: "#7aa2f7",
+      "accent-fg": "#1a1b26",
+      "ok-fg": "#1a1b26",
+    });
+    expect(t.terminal).toEqual({ background: "#1a1b26" });
+  });
+
+  it("survives non-object ui/terminal blocks", () => {
+    const t = sanitizeTheme(rawFile({
+      ui: "nope" as unknown as Record<string, string>,
+      terminal: null as unknown as Record<string, string>,
+    }));
+    expect(t.ui).toEqual({});
+    expect(t.terminal).toEqual({});
+  });
+});
+
+// ── applyCustomVars / clearCustomVars ─────────────────────────────────
+
+function fakeHtml() {
+  const vars = new Map<string, string>();
+  const html = {
+    style: {
+      setProperty: (k: string, v: string) => { vars.set(k, v); },
+      removeProperty: (k: string) => { vars.delete(k); },
+    },
+  } as unknown as HTMLElement;
+  return { html, vars };
+}
+
+describe("applyCustomVars", () => {
+  it("sets provided keys and removes the rest (no stale vars across switches)", () => {
+    const { html, vars } = fakeHtml();
+    applyCustomVars(html, { bg: "#111111", accent: "#222222" });
+    expect(vars.get("--color-bg")).toBe("#111111");
+    expect(vars.get("--color-accent")).toBe("#222222");
+
+    // Switch to a theme that only sets bg: accent must be cleared.
+    applyCustomVars(html, { bg: "#333333" });
+    expect(vars.get("--color-bg")).toBe("#333333");
+    expect(vars.has("--color-accent")).toBe(false);
+  });
+
+  it("clearCustomVars removes every allowlisted var", () => {
+    const { html, vars } = fakeHtml();
+    const ui = Object.fromEntries(UI_KEYS.map(k => [k, "#123456"]));
+    applyCustomVars(html, ui);
+    expect(vars.size).toBe(UI_KEYS.length);
+    clearCustomVars(html);
+    expect(vars.size).toBe(0);
+  });
+});
+
+// ── mergeTerminal ─────────────────────────────────────────────────────
+
+describe("mergeTerminal", () => {
+  it("overrides win, base fills the gaps", () => {
+    const merged = mergeTerminal(
+      { background: "#000000", red: "#ff0000" },
+      { background: "#1a1b26" },
+    );
+    expect(merged).toEqual({ background: "#1a1b26", red: "#ff0000" });
+  });
+});
+
+// ── first-paint cache ─────────────────────────────────────────────────
+
+describe("theme cache", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = new Map();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+    });
+  });
+
+  it("round-trips a sanitized theme", () => {
+    writeThemeCache(sanitizeTheme(rawFile({ ui: { bg: "#1a1b26" } })));
+    const back = readThemeCache();
+    expect(back?.id).toBe("custom:tokyo-night");
+    expect(back?.ui).toEqual({ bg: "#1a1b26" });
+  });
+
+  it("re-sanitizes on read: a tampered cache can't smuggle bad values", () => {
+    store.set("customThemeCache", JSON.stringify({
+      id: "custom:evil",
+      name: "Evil",
+      colorScheme: "dark",
+      ui: { bg: "url(javascript:alert(1))", accent: "#7aa2f7", nope: "#fff" },
+      terminal: {},
+    }));
+    const back = readThemeCache();
+    expect(back?.ui).toEqual({ accent: "#7aa2f7" });
+  });
+
+  it("returns null for a non-custom id, garbage JSON, or an empty cache", () => {
+    store.set("customThemeCache", JSON.stringify({ id: "claude" }));
+    expect(readThemeCache()).toBeNull();
+    store.set("customThemeCache", "{not json");
+    expect(readThemeCache()).toBeNull();
+    store.delete("customThemeCache");
+    expect(readThemeCache()).toBeNull();
+  });
+
+  it("clearThemeCache removes the entry", () => {
+    writeThemeCache(sanitizeTheme(rawFile()));
+    clearThemeCache();
+    expect(readThemeCache()).toBeNull();
+  });
+});

--- a/src/lib/customTheme.ts
+++ b/src/lib/customTheme.ts
@@ -1,0 +1,160 @@
+// Custom theme files — one JSON per theme in `~/.config/termic/themes/`
+// ($XDG_CONFIG_HOME/termic/themes when set; shared by release + dev builds).
+// Files are the whole interface: drop a JSON in the folder and it shows up
+// in the theme picker as a first-class theme (chrome + terminal, coupled).
+// This module is pure logic (no store / IPC imports): schema types, the
+// key allowlists, validation, the inline-CSS-var apply/clear, the terminal
+// palette merge, and the first-paint localStorage cache. See docs/themes.md
+// for the file format reference.
+
+export type ColorScheme = "dark" | "light";
+
+/** Raw shape returned by the Rust `themes_list` command. Parsed JSON but
+ *  NOT yet validated — keys and color values may be arbitrary strings. */
+export interface CustomThemeFile {
+  /** File stem (e.g. "rose-pine-moon" for rose-pine-moon.json). */
+  id: string;
+  name: string;
+  colorScheme: string;
+  ui: Record<string, string>;
+  terminal: Record<string, string>;
+}
+
+/** Sanitized in-app representation. `id` carries the `custom:` namespace
+ *  prefix so a user file named claude.json (→ `custom:claude`) can never
+ *  shadow the built-in theme ids. */
+export interface CustomTheme {
+  id: `custom:${string}`;
+  name: string;
+  colorScheme: ColorScheme;
+  /** Allowlisted `--color-<key>` overrides. Partial — missing keys fall
+   *  back to the @theme defaults (Dark+). */
+  ui: Record<string, string>;
+  /** Allowlisted xterm ITheme overrides, merged over the built-in base
+   *  palette matching `colorScheme`. */
+  terminal: Record<string, string>;
+}
+
+/** UI keys map 1:1 to the `--color-<key>` vars declared in index.css's
+ *  @theme block. The `--color-cli-*` agent tints are deliberately excluded
+ *  from v1 (they inherit defaults). */
+export const UI_KEYS = [
+  "bg", "bg-1", "bg-2", "bg-3",
+  "fg", "fg-dim", "fg-faint",
+  "border", "border-soft",
+  "hover", "sel",
+  "accent", "accent-soft", "accent-deep", "accent-fg",
+  "ok", "ok-fg", "warn", "err",
+] as const;
+
+/** xterm ITheme color keys (see TERMINAL_THEMES in store/prefs.ts). */
+export const TERMINAL_KEYS = [
+  "background", "foreground",
+  "cursor", "cursorAccent",
+  "selectionBackground", "selectionForeground", "selectionInactiveBackground",
+  "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+  "brightBlack", "brightRed", "brightGreen", "brightYellow",
+  "brightBlue", "brightMagenta", "brightCyan", "brightWhite",
+] as const;
+
+/** Accepts hex (#rgb #rgba #rrggbb #rrggbbaa) and rgb/rgba/hsl/hsla()
+ *  functional notation. Deliberately NOT a full CSS <color> grammar —
+ *  these values land in inline styles and xterm options, so we only let
+ *  through shapes we can reason about. Invalid values are skipped, not
+ *  fatal (the key falls back to its default). */
+const COLOR_RE = /^(#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})|(?:rgb|rgba|hsl|hsla)\(\s*[\d.,%\s/deg-]+\))$/i;
+
+export function isValidColor(value: unknown): value is string {
+  return typeof value === "string" && COLOR_RE.test(value.trim());
+}
+
+export function isCustomId(id: string): id is `custom:${string}` {
+  return id.startsWith("custom:");
+}
+
+function pickAllowlisted(
+  raw: unknown,
+  keys: readonly string[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!raw || typeof raw !== "object") return out;
+  for (const key of keys) {
+    const value = (raw as Record<string, unknown>)[key];
+    if (isValidColor(value)) out[key] = value.trim();
+  }
+  return out;
+}
+
+/** Validate a raw theme file into the in-app shape. Never throws: unknown
+ *  keys and malformed color values are dropped, a missing/odd colorScheme
+ *  falls back to "dark", a missing name falls back to the file stem. */
+export function sanitizeTheme(file: CustomThemeFile): CustomTheme {
+  const slug = String(file.id ?? "").trim() || "theme";
+  const name = typeof file.name === "string" && file.name.trim() ? file.name.trim() : slug;
+  return {
+    id: `custom:${slug}`,
+    name,
+    colorScheme: file.colorScheme === "light" ? "light" : "dark",
+    ui: pickAllowlisted(file.ui, UI_KEYS),
+    terminal: pickAllowlisted(file.terminal, TERMINAL_KEYS),
+  };
+}
+
+/** Push a custom theme's UI colors as inline vars on <html>. Inline style
+ *  beats the @theme defaults in the cascade, so a partial theme falls back
+ *  to Dark+ per-key automatically. Iterates the full allowlist (set or
+ *  remove) so switching between two custom themes can't leave a stale var
+ *  from the previous one. */
+export function applyCustomVars(html: HTMLElement, ui: Record<string, string>) {
+  for (const key of UI_KEYS) {
+    if (ui[key]) html.style.setProperty(`--color-${key}`, ui[key]);
+    else html.style.removeProperty(`--color-${key}`);
+  }
+}
+
+/** Deterministic clear: remove every var we could have set. Called when
+ *  switching back to a built-in theme (the likeliest regression path). */
+export function clearCustomVars(html: HTMLElement) {
+  for (const key of UI_KEYS) html.style.removeProperty(`--color-${key}`);
+}
+
+/** Custom terminal palette = built-in base with the theme's (already
+ *  sanitized) overrides on top, so a partial `terminal` block still yields
+ *  a complete, readable ANSI 16. */
+export function mergeTerminal(
+  base: Record<string, string>,
+  overrides: Record<string, string>,
+): Record<string, string> {
+  return { ...base, ...overrides };
+}
+
+// ── First-paint cache ────────────────────────────────────────────────────
+// applyTheme runs synchronously at module load, before any IPC can answer.
+// The active custom theme's full payload lives in localStorage so the first
+// paint applies it directly; the async themes_list fetch reconciles after
+// (file edited → re-apply, file deleted → fall back to the default theme).
+// Without this every launch would flash Dark+ → custom.
+
+const LS_CUSTOM_THEME_CACHE = "customThemeCache";
+
+export function readThemeCache(): CustomTheme | null {
+  try {
+    const raw = localStorage.getItem(LS_CUSTOM_THEME_CACHE);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { id?: unknown } & CustomThemeFile;
+    if (typeof parsed?.id !== "string" || !isCustomId(parsed.id)) return null;
+    // Re-sanitize on read: the cache is just localStorage, treat it as
+    // untrusted input like the files themselves.
+    return sanitizeTheme({ ...parsed, id: parsed.id.slice("custom:".length) });
+  } catch {
+    return null;
+  }
+}
+
+export function writeThemeCache(theme: CustomTheme) {
+  try { localStorage.setItem(LS_CUSTOM_THEME_CACHE, JSON.stringify(theme)); } catch {}
+}
+
+export function clearThemeCache() {
+  try { localStorage.removeItem(LS_CUSTOM_THEME_CACHE); } catch {}
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -9,6 +9,7 @@ import type {
   ImportableWorktree, CliInfo, ChangeFile, Changes, GitStatus, FileEntry, Agent, RepoConfig,
   SandboxMode,
 } from "./types";
+import type { CustomThemeFile } from "./customTheme";
 import {
   COMPLETION_SOUND_SUPPORTED,
   MACOS_DEFAULT_SOUND,
@@ -402,6 +403,12 @@ export function onPtyExit(ptyId: string, cb: (code: number | null) => void): Pro
 // ───────────────────────────── settings & discovery ─────────────────────────────
 
 export const settingsLoad  = () => invoke<Settings>("settings_load");
+/** Raw custom theme files from `~/.config/termic/themes/*.json`. Unvalidated —
+ *  run each through customTheme.ts's sanitizeTheme before use. */
+export const themesList = () => invoke<CustomThemeFile[]>("themes_list");
+/** Ensure + return the custom themes directory (absolute path), for the
+ *  picker's "Open themes folder" row. */
+export const themesDir  = () => invoke<string>("themes_dir");
 export const settingsSave  = (s: Settings) => invoke<void>("settings_save", { s });
 export const agentsSave    = (agents: Agent[]) => invoke<void>("agents_save", { agents });
 export const discoverRepos = (dir: string) => invoke<DiscoveredRepo[]>("discover_repos", { dir });

--- a/src/store/prefs.ts
+++ b/src/store/prefs.ts
@@ -3,7 +3,11 @@
 // font, but built for future things (themes, terminal opacity, etc.).
 
 import { create } from "zustand";
-import { listMonospaceFonts } from "@/lib/ipc";
+import { listMonospaceFonts, themesList } from "@/lib/ipc";
+import {
+  applyCustomVars, clearCustomVars, clearThemeCache, isCustomId, mergeTerminal,
+  readThemeCache, sanitizeTheme, writeThemeCache, type CustomTheme,
+} from "@/lib/customTheme";
 import {
   DEFAULT_BINDINGS,
   type Binding,
@@ -50,20 +54,30 @@ const LS_PANE_DIM_AMT  = "splitPaneDimAmount";
 /** Markdown edit-tab view: source editor, rendered preview, or both. */
 export type MarkdownView = "source" | "preview" | "split";
 
-export type ThemeMode = "auto" | "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix" | "rosepine";
-/** What `applyTheme` resolves to: a concrete palette name. `auto` is
- *  never returned; it gets mapped to light/dark based on OS preference. */
+export type BuiltinThemeMode = "auto" | "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix" | "rosepine";
+/** The user's selection: a built-in mode, or a custom theme file id
+ *  (`custom:<file-stem>`, see lib/customTheme.ts). */
+export type ThemeMode = BuiltinThemeMode | `custom:${string}`;
+/** What `applyTheme` resolves a BUILT-IN mode to: a concrete palette name.
+ *  `auto` is never returned; it gets mapped to light/dark based on OS
+ *  preference. Custom ids resolve to themselves (see resolveThemeFull). */
 export type ResolvedTheme = "light" | "dark" | "claude" | "solarized" | "cobalt" | "matrix" | "rosepine";
 
-const VALID_MODES: ReadonlyArray<ThemeMode> = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix", "rosepine"];
+const VALID_MODES: ReadonlyArray<BuiltinThemeMode> = ["auto", "light", "dark", "claude", "solarized", "cobalt", "matrix", "rosepine"];
 /** Defensive parse: localStorage may hold a theme id that's been
  *  removed in a later version. Fall back to "claude" (the default
  *  theme) instead of letting the unknown string flow through and
  *  silently land on the @theme default. NOTE: this also migrates the
  *  old "vscode" id for free — that theme was renamed to "claude", and
- *  any stale "vscode" string lands here and resolves to it. */
+ *  any stale "vscode" string lands here and resolves to it. A custom id
+ *  is only trusted when the first-paint cache holds its payload (the
+ *  cache is written on every custom pick, so a cache miss means the
+ *  theme can't be painted anyway — the startup refetch would just
+ *  bounce it back to the fallback). */
 function parseThemeMode(raw: string): ThemeMode {
-  return (VALID_MODES as readonly string[]).includes(raw) ? (raw as ThemeMode) : "claude";
+  if ((VALID_MODES as readonly string[]).includes(raw)) return raw as ThemeMode;
+  if (isCustomId(raw) && readThemeCache()?.id === raw) return raw;
+  return "claude";
 }
 
 /** xterm theme objects keyed by resolved palette. Each must define enough
@@ -165,11 +179,27 @@ export const TERMINAL_THEMES: Record<ResolvedTheme, Record<string, string>> = {
   },
 };
 
-/** Resolve the user's chosen theme to a concrete palette name. Used by
- *  both `applyTheme` (to pick which html class to toggle) and the
- *  terminal panes (to pick the matching xterm theme). */
+/** Look up a custom theme's payload by its `custom:<slug>` id. The store's
+ *  fetched list wins; before the first themes_list answer (module load,
+ *  first paint) we fall back to the localStorage cache of the active theme. */
+function customThemeById(id: string): CustomTheme | null {
+  const fromStore = usePrefs.getState().customThemes.find(t => t.id === id);
+  if (fromStore) return fromStore;
+  const cached = readThemeCache();
+  return cached && cached.id === id ? cached : null;
+}
+
+/** Resolve the user's chosen theme to a concrete xterm palette. Custom
+ *  themes merge their (sanitized) terminal overrides onto the built-in
+ *  base matching their colorScheme, so a partial block stays readable. */
 export function currentTerminalTheme(): Record<string, string> {
   const resolved = resolveThemeFull(usePrefs.getState().themeMode);
+  if (isCustomId(resolved)) {
+    const theme = customThemeById(resolved);
+    if (!theme) return TERMINAL_THEMES.dark;
+    const base = TERMINAL_THEMES[theme.colorScheme === "light" ? "light" : "dark"];
+    return mergeTerminal(base, theme.terminal);
+  }
   return TERMINAL_THEMES[resolved];
 }
 
@@ -181,8 +211,7 @@ export function currentTerminalTheme(): Record<string, string> {
  *  (white on black) for any dark-family palette. Set this on every
  *  PTY spawn alongside TERMIC_PORT etc. */
 export function currentColorFgBg(): string {
-  const resolved = resolveThemeFull(usePrefs.getState().themeMode);
-  return resolved === "light" ? "0;15" : "15;0";
+  return resolveTheme(usePrefs.getState().themeMode) === "light" ? "0;15" : "15;0";
 }
 
 // Curated list of monospace fonts we probe for. JetBrains Mono ships
@@ -336,8 +365,19 @@ interface PrefsState {
    *  - "project" → this project's personal defaults (projects.json)
    *  - "repo"    → the committed `.termic.yaml` (team-shared) */
   allowScope: "agent" | "project" | "repo" | null;
-  /** Color scheme: explicit dark/light, or auto = follow system. */
+  /** Color scheme: explicit dark/light, auto = follow system, or a
+   *  `custom:<slug>` theme file id. */
   themeMode: ThemeMode;
+  /** Sanitized custom themes from `<data_dir>/themes/*.json`. Fetched at
+   *  startup and re-fetched every time the theme picker opens (no fs
+   *  watcher — the dir is tiny and the command is async). The reference
+   *  only changes when the on-disk content actually changed, so
+   *  subscribers don't re-render on every picker hover. */
+  customThemes: CustomTheme[];
+  /** Bumped when the ACTIVE custom theme's payload changed on a refetch
+   *  (file edited while selected). Terminal panes key their live-swap
+   *  effect on this so an edit updates xterm without a theme re-pick. */
+  customThemeRev: number;
   /** Font for the CodeMirror editor + diff viewer. */
   editorFontId: string;
   /** Syntax theme for the editor + diff viewer (atomone, tokyo-night, …).
@@ -430,6 +470,10 @@ interface PrefsState {
   setThemeMode:       (m: ThemeMode) => void;
   /** Convenience: cycle auto → light → dark → auto. */
   cycleThemeMode:     () => void;
+  /** Fetch + sanitize the custom theme files, then reconcile the active
+   *  selection: file deleted → fall back to "claude" (persisted), file
+   *  edited → re-apply vars + bump customThemeRev. Safe to fire often. */
+  loadCustomThemes:   () => Promise<void>;
   setDesktopNotifications: (v: boolean) => void;
   setCompletionSound: (v: boolean) => void;
   setCompletionSoundId: (id: CompletionSoundId) => void;
@@ -562,6 +606,8 @@ const initialQueueMinInterval = Math.max(0, Math.min(120000, Math.round(lsGetNum
 
 export const usePrefs = create<PrefsState>(set => ({
   themeMode: initialTheme,
+  customThemes: [],
+  customThemeRev: 0,
   desktopNotifications: initialDesktopNotif,
   completionSound: initialCompletionSound,
   completionSoundId: initialCompletionSoundId,
@@ -657,9 +703,41 @@ export const usePrefs = create<PrefsState>(set => ({
     s.setCodeLigatures(d.codeLigatures);
   },
   setThemeMode: (m) => {
+    // Picking a custom theme refreshes the first-paint cache so applyTheme
+    // (and the next launch's module-load paint) has the payload at hand.
+    if (isCustomId(m)) {
+      const theme = usePrefs.getState().customThemes.find(t => t.id === m);
+      if (theme) writeThemeCache(theme);
+    }
     try { localStorage.setItem(LS_THEME, m); } catch {}
     applyTheme(m);
     set({ themeMode: m });
+  },
+  loadCustomThemes: async () => {
+    let files;
+    try { files = await themesList(); } catch { return; }
+    const themes = files.map(sanitizeTheme);
+    const prev = usePrefs.getState().customThemes;
+    // Only publish a new array when the content changed — subscribers
+    // (picker, terminal panes) shouldn't re-render on a no-op refetch.
+    if (JSON.stringify(prev) !== JSON.stringify(themes)) set({ customThemes: themes });
+    const mode = usePrefs.getState().themeMode;
+    if (!isCustomId(mode)) return;
+    const active = themes.find(t => t.id === mode);
+    if (!active) {
+      // The active theme's file was deleted — fall back to the default
+      // theme and persist so the pref doesn't dangle on a dead id.
+      clearThemeCache();
+      usePrefs.getState().setThemeMode("claude");
+      return;
+    }
+    const cached = readThemeCache();
+    if (!cached || JSON.stringify(cached) !== JSON.stringify(active)) {
+      // The active theme's file was edited — re-apply live.
+      writeThemeCache(active);
+      applyTheme(mode);
+      set(s => ({ customThemeRev: s.customThemeRev + 1 }));
+    }
   },
   setDesktopNotifications: (v) => {
     try { localStorage.setItem(LS_DESKTOPNOTIF, v ? "1" : "0"); } catch {}
@@ -755,28 +833,36 @@ export const usePrefs = create<PrefsState>(set => ({
 }));
 
 /** Legacy resolver kept for callers that only care about light-vs-dark
- *  (toolbar icon swap, system colorScheme hint). Espresso + Solarized
- *  both collapse to "dark" for those binary purposes. */
+ *  (toolbar icon swap, editor auto, COLORFGBG, system colorScheme hint).
+ *  Espresso + Solarized both collapse to "dark"; a custom theme collapses
+ *  to its declared colorScheme. This single mapping is why editor-auto
+ *  and COLORFGBG need zero custom-theme awareness of their own. */
 export function resolveTheme(mode: ThemeMode): "light" | "dark" {
   const full = resolveThemeFull(mode);
+  if (isCustomId(full)) return customThemeById(full)?.colorScheme ?? "dark";
   return full === "light" ? "light" : "dark";
 }
 
 /** Resolve to the concrete palette name (light / dark / espresso /
  *  solarized). `auto` only ever maps to light or dark - the OS doesn't
- *  speak espresso/solarized; those require an explicit user pick. */
-export function resolveThemeFull(mode: ThemeMode): ResolvedTheme {
+ *  speak espresso/solarized; those require an explicit user pick.
+ *  Custom ids pass through as-is. */
+export function resolveThemeFull(mode: ThemeMode): ResolvedTheme | `custom:${string}` {
   if (mode === "auto") {
     return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
   }
   return mode;
 }
 
-/** Set the html element's class so the CSS palette swap kicks in.
- *  We toggle ALL palette classes so a stale class from a previous
- *  theme can't bleed through after a switch. */
+/** Swap the html element's palette. Built-ins toggle their CSS class;
+ *  custom themes clear ALL theme classes and push their colors as inline
+ *  vars (inline beats the @theme defaults in the cascade, so a partial
+ *  theme falls back to Dark+ per-key). We always toggle every class AND
+ *  reconcile the inline vars so nothing from the previous theme bleeds
+ *  through after a switch in either direction. */
 export function applyTheme(mode: ThemeMode) {
   const resolved = resolveThemeFull(mode);
+  const custom = isCustomId(resolved) ? customThemeById(resolved) : null;
   const html = document.documentElement;
   html.classList.toggle("light",     resolved === "light");
   html.classList.toggle("dark",      resolved === "dark");
@@ -785,9 +871,17 @@ export function applyTheme(mode: ThemeMode) {
   html.classList.toggle("cobalt",    resolved === "cobalt");
   html.classList.toggle("matrix",    resolved === "matrix");
   html.classList.toggle("rosepine",  resolved === "rosepine");
-  // Color-scheme tells the browser to use light/dark form controls +
-  // scrollbars. Espresso + Solarized both want dark widgets.
-  html.style.colorScheme = resolved === "light" ? "light" : "dark";
+  if (custom) {
+    applyCustomVars(html, custom.ui);
+    // Color-scheme tells the browser to use light/dark form controls +
+    // scrollbars; the theme file declares which family it belongs to.
+    html.style.colorScheme = custom.colorScheme;
+  } else {
+    // Built-in (or a custom id whose payload is gone — every class is
+    // off, so this degrades to the @theme Dark+ defaults).
+    clearCustomVars(html);
+    html.style.colorScheme = resolved === "light" ? "light" : "dark";
+  }
 }
 
 // Apply at module load so the first paint matches the user's preference.


### PR DESCRIPTION
Drop a JSON file in `~/.config/termic/themes/` and it appears in the theme picker as a first-class theme (chrome + terminal, coupled). Files are the whole interface: no in-app editor, no new settings surface.

## How it works

- Rust gains a `themes_list` command that reads and parses the themes folder (created on demand). No fs watcher: themes are re-read on every picker open, so the edit loop is save, hover, done.
- The frontend validates against allowlisted keys (the `--color-<key>` UI vars, including the new `accent-fg` / `ok-fg` ink tokens, and xterm `ITheme` colors). Unknown keys and malformed colors are dropped, never fatal.
- Ids are namespaced `custom:<file-stem>` so a user file named `claude.json` can never shadow a built-in theme.
- Partial themes fall back per-key: UI vars to the Dark+ defaults (inline vars beat `@theme` in the cascade), terminal palettes merge over the built-in base matching the file's `colorScheme`.
- The active custom theme's payload is cached in localStorage so first paint matches before the async list returns (no Dark+ flash), re-sanitized on read.

Format reference in `docs/themes.md`; linked from CLAUDE.md and README.

## Why `~/.config/termic/themes` and not Application Support

Theme files are hand-authored config, not app-managed state, so they live where terminal tools keep hand-edited config (wezterm, starship, kitty all read `~/.config`, on every platform):

- A stable XDG path makes themes automatable: a dotfiles repo can stow/symlink `.config/termic/` and bootstrap a new machine with the rest of its tool configs, no clicking through the app.
- `$XDG_CONFIG_HOME` is respected when set; otherwise `<home>/.config/termic/themes` on every OS.
- App-owned state (`settings.json`, `projects.json`, `workspaces/`) stays in Application Support, untouched.
- Release and dev builds currently share the dir (no `termic_dev` split): one dotfiles target, and dev builds see your real themes while iterating. The trade-off is schema evolution: a dev build that adds, removes, or renames a theme key reads the same files as your release install. Per-key validation makes that degrade gracefully (unknown keys ignored, missing keys fall back), but it is a judgment call, not a free lunch.

This is the one opinionated call in the PR, so consider it a proposal. If it does not fit your vision for where termic keeps its files, easy alternatives: add a `.config/termic_dev` split to restore dev isolation, or move it back to `<data_dir>/themes/` entirely. The location is isolated in `themes_dir_path()`, so either is a one-function change and I am happy to do it.

## Testing

- `make check-all`, `npm test`, and `cargo test --lib` all pass. New `customTheme.test.ts` unit tests cover allowlist validation, the color regex, stale-var reconciliation on theme switches, and cache re-sanitization.
- Exercised with Rosé Pine Moon and Tokyo Night files: picker listing, live preview from ⌘K, partial-theme fallback, delete-active-file fallback, first-paint cache.

<img width="179" height="490" alt="Screenshot 2026-07-09 at 4 11 39 PM" src="https://github.com/user-attachments/assets/d2880629-51b0-436e-9e94-6ffe463a703f" />

<img width="913" height="423" alt="Screenshot 2026-07-09 at 4 12 33 PM" src="https://github.com/user-attachments/assets/4253d3f9-b530-402d-83f8-3be2b984fbd1" />

Example File: 

```
{
  "name": "Tokyo Night",
  "colorScheme": "dark",
  "ui": {
    "bg": "#1a1b26", "bg-1": "#16161e", "bg-2": "#1f2335", "bg-3": "#292e42",
    "fg": "#c0caf5", "fg-dim": "#a9b1d6", "fg-faint": "#565f89",
    "border": "#3b4261", "border-soft": "#1f2335",
    "hover": "rgba(192,202,245,0.05)", "sel": "rgba(122,162,247,0.22)",
    "accent": "#7aa2f7", "accent-soft": "rgba(122,162,247,0.22)", "accent-deep": "#3d59a1",
    "accent-fg": "#1a1b26",
    "ok": "#9ece6a", "ok-fg": "#1a1b26", "warn": "#e0af68", "err": "#f7768e"
  },
  "terminal": {
    "background": "#1a1b26", "foreground": "#c0caf5",
    "cursor": "#c0caf5", "cursorAccent": "#1a1b26", "selectionBackground": "#33467c",
    "black": "#15161e", "red": "#f7768e", "green": "#9ece6a", "yellow": "#e0af68",
    "blue": "#7aa2f7", "magenta": "#bb9af7", "cyan": "#7dcfff", "white": "#a9b1d6",
    "brightBlack": "#414868", "brightRed": "#f7768e", "brightGreen": "#9ece6a",
    "brightYellow": "#e0af68", "brightBlue": "#7aa2f7", "brightMagenta": "#bb9af7",
    "brightCyan": "#7dcfff", "brightWhite": "#c0caf5"
  }
}

```
