### PR TITLE
fix: system-enumerated font picks never applied (Nerd Font glyphs boxed out)

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -11,6 +11,8 @@
 - **`pty_spawn` "invalid length 0".** Payload wrap forgotten — wrap SpawnArgs in `{ args: ... }`.
 - **Right-click contextmenu.** `window.addEventListener("contextmenu", e => e.preventDefault())` in `main.tsx`.
 - **App icon missing in dev.** Dev runs raw binary, not `.app` bundle. Icon appears after `npm run tauri:build`.
+- **Picked system font ignored, Nerd Font glyphs box out.** `system:<family>` font ids (from the Rust enumeration) must go through the prefix branch in `stackFor()` (prefs.ts) — they're not in `MONO_FONT_OPTIONS`, and falling back silently uses bundled JetBrains Mono (latin subset, zero PUA glyphs). Confusingly partial symptom: Powerline U+E0A0–E0BF still render because xterm's WebGL renderer custom-draws them without a font.
+- **Font picker incomplete on first open.** The macOS native `<select>` popup snapshots its options when opened — options React adds mid-open don't appear, and a value with no matching option renders blank. Hence: warm `availableMonoFontsAsync()` at prefs module load, and seed selected `system:` ids into the picker's initial list (AppearanceSection).
 
 ## React/Zustand traps
 

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -2,7 +2,7 @@
 // Mirrors Termic's split: "Mono Font" governs the editor; "Terminal Font"
 // governs xterm. Sizes are independent.
 
-import { usePrefs, resolveTheme, MONO_FONT_OPTIONS, APPEARANCE_DEFAULTS, availableMonoFonts, availableMonoFontsAsync } from "@/store/prefs";
+import { usePrefs, resolveTheme, MONO_FONT_OPTIONS, APPEARANCE_DEFAULTS, availableMonoFonts, availableMonoFontsAsync, stackFor } from "@/store/prefs";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { EDITOR_THEMES, resolveEditorTheme, editorSurfaceTheme } from "@/lib/editorTheme";
@@ -166,7 +166,7 @@ export function AppearanceSection() {
       {/* Legacy static preview (kept off behind the `false` gate so
           a future revert is a one-flag change). */}
       {false && (<div className="rounded-lg border border-[var(--color-border-soft)] bg-[var(--color-bg)] p-3 font-mono text-[var(--color-fg)]"
-           style={{ fontFamily: stackById(terminalFontId), fontSize: `${terminalFontSize}px`, lineHeight: 1.4 }}>
+           style={{ fontFamily: stackFor(terminalFontId), fontSize: `${terminalFontSize}px`, lineHeight: 1.4 }}>
         <span className="text-[#7cd57e]">~/project</span> <span className="text-[#d97757]">main</span> <span className="text-[#f0b13a]">±3</span><br/>
         <span className="text-[#d97757]">{"〉"}</span> npm test <span className="text-[#7cd57e]">✓</span><br/>
         <span className="text-[#a7f3a0]">└─▶ All tests passed!</span>
@@ -222,10 +222,6 @@ function TerminalPreview() {
       <AuxTerminal wsPath={home} active={true} />
     </div>
   );
-}
-
-function stackById(id: string) {
-  return (MONO_FONT_OPTIONS.find(o => o.id === id) || MONO_FONT_OPTIONS[0]).stack;
 }
 
 function Field({ label, hint, control }: { label: string; hint?: string; control: React.ReactNode }) {

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -39,8 +39,18 @@ export function AppearanceSection() {
 
   // Start with the curated subset so the picker is usable instantly, then
   // upgrade to the full system list when font-kit comes back (~50–200ms).
-  const [fonts, setFonts] = useState(() => availableMonoFonts());
-  useEffect(() => { availableMonoFontsAsync().then(setFonts).catch(() => {}); }, []);
+  // The currently-selected system: fonts are seeded into the initial list —
+  // a <select> whose value has no matching <option> renders blank, and the
+  // native popup won't take options added while it's open.
+  const [fonts, setFonts] = useState(() =>
+    withSelectedFonts(availableMonoFonts(), [editorFontId, terminalFontId]));
+  useEffect(() => {
+    availableMonoFontsAsync()
+      .then(list => setFonts(withSelectedFonts(list, [editorFontId, terminalFontId])))
+      .catch(() => {});
+    // Mount-time ids are enough: later picks can only come FROM the list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Disable the reset button when every appearance pref already matches
   // the factory defaults — nothing to undo.
@@ -234,6 +244,17 @@ function Field({ label, hint, control }: { label: string; hint?: string; control
       <div className="shrink-0">{control}</div>
     </div>
   );
+}
+
+/** Ensure every selected `system:` font id has an entry in the option list,
+ *  synthesizing one from the id itself (the family name lives in the id, so
+ *  no enumeration is needed). Keeps the pick visible even if the system scan
+ *  hasn't finished, or the font was uninstalled since it was chosen. */
+function withSelectedFonts(list: typeof MONO_FONT_OPTIONS, ids: string[]) {
+  const extras = [...new Set(ids)]
+    .filter(id => id.startsWith("system:") && !list.some(o => o.id === id))
+    .map(id => ({ id, label: id.slice(7), stack: stackFor(id) }));
+  return extras.length ? [...list, ...extras] : list;
 }
 
 function FontSelect({ value, onChange, fonts }: {

--- a/src/store/prefs.ts
+++ b/src/store/prefs.ts
@@ -270,9 +270,13 @@ let _systemFontsCache: string[] | null = null;
  *  entry (id = "system:<name>", label = family name, stack = family). */
 export async function availableMonoFontsAsync(): Promise<typeof MONO_FONT_OPTIONS> {
   const curated = availableMonoFonts();
-  if (!_systemFontsCache) {
-    try { _systemFontsCache = await listMonospaceFonts(); }
-    catch { _systemFontsCache = []; }
+  let system = _systemFontsCache;
+  if (!system) {
+    // Failures are NOT cached: an enumeration that dies (e.g. fired before
+    // the IPC bridge settles) must retry on the next call, not permanently
+    // hide every system font behind an empty cached list.
+    try { system = _systemFontsCache = await listMonospaceFonts(); }
+    catch { system = []; }
   }
   // Names already covered by curated (case-insensitive match against the
   // first family in each stack) — we keep the curated entry so the brand
@@ -280,7 +284,7 @@ export async function availableMonoFontsAsync(): Promise<typeof MONO_FONT_OPTION
   const covered = new Set(curated.map(o =>
     o.stack.split(",")[0].trim().replace(/^"|"$/g, "").toLowerCase()
   ));
-  const extras = _systemFontsCache
+  const extras = system
     .filter(name => !covered.has(name.toLowerCase()))
     .map(name => ({
       id: `system:${name}`,
@@ -826,3 +830,9 @@ export const currentTerminalStack = () => {
 
 // Apply editor font at module load so the first paint uses the right font.
 applyEditorFont(initialEditorFont);
+
+// Warm the system font enumeration at startup so the Settings font pickers
+// have the full list by the time one first mounts. Without this the first
+// dropdown open raced the scan and only showed the curated subset (the
+// native select popup won't take options added while it's open).
+availableMonoFontsAsync().catch(() => {});

--- a/src/store/prefs.ts
+++ b/src/store/prefs.ts
@@ -290,8 +290,14 @@ export async function availableMonoFontsAsync(): Promise<typeof MONO_FONT_OPTION
   return [...curated, ...extras];
 }
 
-/** Resolve a font id → CSS font-family stack, defaulting to JetBrains. */
-function stackFor(id: string) {
+/** Resolve a font id → CSS font-family stack, defaulting to JetBrains.
+ *  Handles both curated ids and the `system:<family>` ids produced by
+ *  availableMonoFontsAsync() — those never appear in MONO_FONT_OPTIONS,
+ *  so without the prefix branch every system-enumerated pick silently
+ *  fell back to the bundled JetBrains Mono (latin subset, no Nerd Font
+ *  glyphs). */
+export function stackFor(id: string) {
+  if (id.startsWith("system:")) return `"${id.slice(7)}", monospace`;
   const opt = MONO_FONT_OPTIONS.find(o => o.id === id) || MONO_FONT_OPTIONS[0];
   return opt.stack;
 }


### PR DESCRIPTION
## Problem

Picking any font from the system-enumerated portion of the Settings font dropdown (e.g. "JetBrainsMono Nerd Font Mono") looked applied but was never used. Terminals silently rendered the bundled JetBrains Mono (latin subset), so Nerd Font prompt glyphs (oh-my-posh, starship, p10k) showed as missing-glyph boxes. The editor font pick was equally ignored.

The symptom was confusingly partial: Powerline glyphs (U+E0A0-E0BF) still rendered because xterm's WebGL renderer custom-draws that range without a font, masking the fallback.

## Root cause

The dropdown stores system-enumerated fonts as `system:<family>` ids (from `availableMonoFontsAsync()`), but `stackFor()` only resolved ids against the curated `MONO_FONT_OPTIONS` list. Any `system:` id fell through to `MONO_FONT_OPTIONS[0]`, the bundled JetBrains Mono.

Verified the full chain outside the app: the installed font's cmap has all the glyphs, and a standalone WKWebView harness (DOM + canvas `fillText`, the same path xterm's WebGL atlas uses) renders every glyph once the correct family string is supplied. The only broken link was the id resolution.

## Fixes

- `stackFor()` resolves `system:<family>` ids directly to the family name (terminal + editor + settings preview all share it now; the duplicate `stackById` is gone).
- Font picker first-open race: the system font scan now warms at prefs module load instead of Settings mount, and a failed scan is no longer cached as a permanent empty list. The macOS native select popup snapshots its options when opened, so the list arriving mid-open was invisible until reopen.
- The currently selected `system:` ids are seeded into the picker's initial option list (synthesized from the id itself), so the select always contains its own value even if the scan has not finished.
- Both gotchas documented in `docs/gotchas.md`.

## Testing

- `make check-all` passes.
- Reproduced the original boxes with a Nerd Font prompt, rebuilt, confirmed nix/folder/aws/clock glyphs render and the picker is fully populated on first open.


Before:
<img width="961" height="99" alt="Screenshot 2026-07-09 at 3 33 26 PM" src="https://github.com/user-attachments/assets/39157d3d-049f-4297-b1c4-1134e3fce28f" />
<img width="593" height="87" alt="Screenshot 2026-07-09 at 3 33 08 PM" src="https://github.com/user-attachments/assets/e104c35e-6847-48c5-9380-76e0c354c8de" />

After:
<img width="603" height="108" alt="Screenshot 2026-07-09 at 3 40 56 PM" src="https://github.com/user-attachments/assets/3568feef-6bb3-40c1-8031-599630ee3245" />

