### PR TITLE
feat: breathing dot for the working-agent indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Termic, newest first. This file is the human-authored
 source of truth: the in-app Update card and the /changelog page on termic.dev
 are generated from it. See the `release` skill for how entries are added.
 
+## [Unreleased]
+
+### Features
+- The "agent working" indicator is now a gentle breathing dot in the agent's accent color, matching the done and attention glyphs, and it is shown by default. Turn it off in Settings, General.
+
+### Bug fixes
+- The working and done indicators are no longer both blue in the Cobalt theme, so you can tell them apart at a glance (including with reduced motion on).
+
 ## [0.19.0] - 2026-07-09
 
 Bring your own theme, and the font you picked is finally the font you get.

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -216,7 +216,7 @@ export function GeneralSection() {
       <div className="border-t border-[var(--color-border-soft)] pt-6">
         <Toggle
           label="Work-in-progress indicator"
-          hint="Show a spinner on an agent's tab and sidebar icon while it's working. Experimental: it relies on work detection, which can occasionally misfire. A stuck spinner auto-clears after a few minutes."
+          hint="Show a breathing dot on an agent's tab and sidebar icon while it's working. It relies on work detection, which can occasionally misfire; a stuck indicator auto-clears after a few minutes."
           value={workingIndicator}
           onChange={setWorkingIndicator}
         />

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -6,7 +6,7 @@ import { useApp, useWorkspaceTabs, useActiveTabId } from "@/store/app";
 import { usePrefs } from "@/store/prefs";
 import { Button } from "@/components/ui/Button";
 import { Tip } from "@/components/ui/Tooltip";
-import { LayoutGrid, History, FolderPlus, Settings, Plus, Archive, Layers, Moon, Cog, MoreVertical, GitBranchPlus, FolderGit2, ChevronRight, ChevronDown, Bell, Bug, Mail, Zap, X, Pencil, Copy, ChevronsDownUp, ChevronsUpDown, Check, AudioWaveform, Radio, SquareChevronRight, Loader2, EyeOff, Trash2, FolderOpen, Megaphone, Keyboard } from "lucide-react";
+import { LayoutGrid, History, FolderPlus, Settings, Plus, Archive, Layers, Moon, Cog, MoreVertical, GitBranchPlus, FolderGit2, ChevronRight, ChevronDown, Bell, Bug, Mail, Zap, X, Pencil, Copy, ChevronsDownUp, ChevronsUpDown, Check, AudioWaveform, Radio, SquareChevronRight, EyeOff, Trash2, FolderOpen, Megaphone, Keyboard } from "lucide-react";
 import { DropdownRoot, DropdownTrigger, DropdownMenu, DropdownItem, DropdownSeparator, DropdownLabel } from "@/components/ui/Dropdown";
 import { ContextMenuRoot, ContextMenuTrigger, ContextMenuContent, ContextMenuItem, ContextMenuSeparator, ContextMenuLabel } from "@/components/ui/ContextMenu";
 import { ProjectActionsMenuItems } from "./ProjectActionsMenuItems";
@@ -885,16 +885,20 @@ function iconSize(compact: boolean) {
 // collapsed) and on each tab child row.
 //   done      → solid blue bullet (work finished, untouched until input)
 //   attention → orange bell (agent explicitly blocked on user)
-// The "working" spinner is opt-in (Settings → General → Work-in-progress
-// indicator) and OFF by default — it can misfire on noisy TUIs (Claude
-// Code's continuous redraws, Codex's status counter). The internal
+//   working   → breathing accent dot (agent thinking)
+// The "working" dot is ON by default but can be turned off (Settings →
+// General → Work-in-progress indicator) — it can misfire on noisy TUIs
+// (Claude Code's continuous redraws, Codex's status counter). The internal
 // workState=="working" is always tracked so the done detector fires on
 // busy→idle transitions; this badge just surfaces it when enabled.
 function TabBadge({ reason }: { reason: "attention" | "done" | "working" }) {
   if (reason === "working") {
     return (
-      <span className="shrink-0 text-[var(--color-fg-faint)]" title="Agent working" aria-label="Working">
-        <Loader2 className="h-3 w-3 animate-spin" />
+      <span className="shrink-0 flex items-center justify-center" title="Agent working" aria-label="Working">
+        <span
+          className="termic-working-breathe block h-2 w-2 rounded-full"
+          style={{ backgroundColor: "var(--color-working)" }}
+        />
       </span>
     );
   }
@@ -906,7 +910,7 @@ function TabBadge({ reason }: { reason: "attention" | "done" | "working" }) {
     );
   }
   // done — solid blue bullet, iTerm2-style. Uses --color-info if defined,
-  // falls back to a literal blue. h-3.5 visually matches the bell + spinner.
+  // falls back to a literal blue. Sized h-2 to match the working dot.
   return (
     <span
       className="shrink-0 flex items-center justify-center"
@@ -1092,10 +1096,12 @@ function WorkspaceRow({ w, compact }: { w: Workspace; compact: boolean }) {
               style={{ backgroundColor: hasAttention ? "var(--color-warn)" : "var(--color-info, #4aa3ff)" }}
             />
           ) : hasWorking ? (
-            // No room for a full spinner on the rail; a faint pulsing dot
-            // carries "still working" without competing with the bold
-            // attention/done colors.
-            <span className="absolute -right-0.5 -top-0.5 block h-2.5 w-2.5 animate-pulse rounded-full bg-[var(--color-fg-faint)] ring-2 ring-[var(--color-bg-1)]" />
+            // No room for a full glyph on the rail; a breathing accent dot
+            // carries "still working", tying to the full-row working badge.
+            <span
+              className="termic-working-breathe absolute -right-0.5 -top-0.5 block h-2.5 w-2.5 rounded-full ring-2 ring-[var(--color-bg-1)]"
+              style={{ backgroundColor: "var(--color-working)" }}
+            />
           ) : null}
         </div>
       </Tip>

--- a/src/components/workspace/TabBar.tsx
+++ b/src/components/workspace/TabBar.tsx
@@ -8,7 +8,7 @@ import { useTabStripDrag } from "./useTabStripDrag";
 import { Button } from "@/components/ui/Button";
 import { DropdownRoot, DropdownTrigger, DropdownMenu, DropdownItem, DropdownLabel, DropdownSeparator } from "@/components/ui/Dropdown";
 import { CliIcon, CLI_BRAND_COLOR, CLI_LABEL, resolveIconId } from "@/icons/cli";
-import { Plus, X, GitCompare, FileText, SquareSplitVertical, SquareSplitHorizontal, TerminalSquare, Bell, Megaphone, Repeat, Loader2, RotateCw, Square, Play } from "lucide-react";
+import { Plus, X, GitCompare, FileText, SquareSplitVertical, SquareSplitHorizontal, TerminalSquare, Bell, Megaphone, Repeat, RotateCw, Square, Play } from "lucide-react";
 import { ptyKill } from "@/lib/ipc";
 import { usePrefs } from "@/store/prefs";
 import { Tip } from "@/components/ui/Tooltip";
@@ -477,8 +477,11 @@ export function TabPill({ ws, tab, active, paneFocused, compact, onSelect, onClo
                 </span>
               )}
               {showWorking && (
-                <span className="text-[var(--color-fg-faint)]" title="Agent working" aria-label="Working">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span title="Agent working" aria-label="Working">
+                  <span
+                    className="termic-working-breathe block h-2 w-2 rounded-full"
+                    style={{ backgroundColor: "var(--color-working)" }}
+                  />
                 </span>
               )}
             </span>

--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,10 @@
   --color-sel:       rgba(217, 119, 87, 0.20);
   --color-accent:    #d97757;
   --color-accent-soft: rgba(217, 119, 87, 0.22);
+  /* "Agent working" dot. Defaults to the accent so each theme keeps its
+     accent-colored working glyph; themes whose accent collides with the
+     done dot (--color-info blue) override this to stay legible. */
+  --color-working:   var(--color-accent);
   /* Darker accent for button surfaces. Pure accent looks fine on
      small icons + 1px borders but reads thin/light when used as a
      button background - especially on the brighter themes (cobalt).
@@ -199,6 +203,10 @@
     --color-sel:         rgba(102, 196, 255, 0.22);
     --color-accent:      #66c4ff;   /* bright cobalt sky */
     --color-accent-soft: rgba(102, 196, 255, 0.22);
+    /* Cobalt's sky-blue accent is too close to the done dot (#4aa3ff blue),
+       so the working and done glyphs would read alike, worse under
+       reduced-motion. Use a violet so working stays distinct here. */
+    --color-working:     #b58bff;
     /* Cobalt's bright sky-blue looks washed-out as a button bg
        against the navy panels. Drop down a couple of stops into
        a deep azure that still reads cobalt-family. */
@@ -402,6 +410,20 @@ html.termic-mod-held .xterm .xterm-cursor-pointer { cursor: pointer; }
 }
 .termic-spotlight-wave {
   animation: termic-spotlight-wave 2s ease-in-out infinite;
+}
+
+/* Agent-working indicator — a brand-accent dot that gently breathes
+   (opacity + scale) to read as "thinking" without the spin of a loader.
+   Rhymes with the static blue done dot. Calm under reduced-motion. */
+@keyframes termic-working-breathe {
+  0%, 100% { opacity: 1;   transform: scale(1); }
+  50%      { opacity: 0.4; transform: scale(0.72); }
+}
+.termic-working-breathe {
+  animation: termic-working-breathe 1.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .termic-working-breathe { animation: none; opacity: 0.7; }
 }
 
 /* Pending review-comments pill (ReviewCommentsBar). Comments are HELD until

--- a/src/store/prefs.ts
+++ b/src/store/prefs.ts
@@ -350,12 +350,12 @@ interface PrefsState {
    *  in-app "done" signal. Some users find it distracting and want
    *  the sidebar to stay calm regardless. */
   settledHighlight: boolean;
-  /** Show a spinner on an agent's tab (and sidebar icon) WHILE it's
-   *  working. OFF by default — experimental. The "working" workState is
-   *  always tracked internally to drive work-done detection; this pref only
-   *  controls whether it's surfaced. Work detection can occasionally get a
-   *  signal stuck, so TerminalPane has an absolute ceiling that force-clears
-   *  a stale "working" state regardless of sender signals. */
+  /** Show a breathing dot on an agent's tab (and sidebar icon) WHILE it's
+   *  working. ON by default. The "working" workState is always tracked
+   *  internally to drive work-done detection; this pref only controls
+   *  whether it's surfaced. Work detection can occasionally get a signal
+   *  stuck, so TerminalPane has an absolute ceiling that force-clears a
+   *  stale "working" state regardless of sender signals. */
   workingIndicator: boolean;
   /** Default for the NewWorkspaceDialog's Sandbox toggle when neither
    *  the project's `default_sandbox` nor an explicit user pick is in
@@ -589,9 +589,9 @@ const initialCompletionSoundId = readCompletionSoundId();
 // users who toggled it OFF keep their setting (lsGetBool returns the
 // stored value when present).
 const initialSettledHighlight = lsGetBool(LS_SETTLED_HIGHLIGHT, true);
-// OFF by default — experimental re-introduction of the work-in-progress
-// spinner. Opt in via Settings → General.
-const initialWorkingIndicator = lsGetBool(LS_WORKING_INDICATOR, false);
+// ON by default — the breathing accent dot is the in-app "working" signal,
+// matching the always-on done/attention glyphs. Opt out in Settings → General.
+const initialWorkingIndicator = lsGetBool(LS_WORKING_INDICATOR, true);
 const initialDefaultSandbox = lsGetBool(LS_DEFAULT_SANDBOX, false);
 // ON by default — sandboxed agents bypass their own permission prompts
 // because the seatbelt is the real boundary. Users can opt out.


### PR DESCRIPTION
## What
Replaces the "agent working" indicator (a faint gray Loader2 spinner) with a gentle breathing dot in the agent's accent color, so a working agent reads as clearly as the existing done (blue dot) and attention (bell) glyphs. Surfaces the indicator by default.

## Why
The done and attention states already have polished glyphs. "Working" was a plain spinner gated OFF by default, so with several agents running you could not tell which one was still thinking. This makes the working agent obvious at a glance.

## What changed
- New `@keyframes termic-working-breathe` (opacity + scale), with a `prefers-reduced-motion` guard.
- The dot replaces the spinner in three places: the sidebar `TabBadge`, the `TabBar` working badge, and the compact-rail corner dot.
- A dedicated `--color-working` token, defaulting to `var(--color-accent)` so every theme keeps its accent-colored dot. Cobalt's sky-blue accent collided with the blue done dot, so Cobalt overrides `--color-working` to a violet that stays distinct, including under reduced motion. Checked against all seven built-in themes, including the new Rosé Pine.
- `workingIndicator` now defaults ON. Explicit opt-outs are preserved via `lsGetBool`, and the Settings > General toggle still turns it off.
- Refreshed the now-stale "spinner / OFF / experimental" copy and dropped the unused `Loader2` imports.

## Notes for review
- Performance: the animation is compositor-only (opacity + transform) and adds no React re-renders. `workState === "working"` was already tracked to drive done-detection, so this only surfaces an existing conditional.
- Reduced motion: the keyframe is disabled under `prefers-reduced-motion` (static dot at 0.7 opacity).
- Default flip (heads-up): turning the indicator ON by default is a behavior change for users who never touched the toggle. Work-detection can misfire on noisy TUIs (noted in the code; `TerminalPane` force-clears a stuck state). Happy to land the icon + Cobalt fix first and make default-on a separate PR if you would rather decide that independently.

## Testing
- `make check-all`: pass (cargo check + tsc).
- `npm run test`: 166/166 pass.
- Rebased on `main` (v0.19.0); diff is 6 files.
- Verified live in a dev build across every theme and the toggle (demo below).

## Demo

https://github.com/user-attachments/assets/9faa327e-7962-4fb1-9271-3c5f34ae4722



I have read and agree to the Termic CLA (CLA.md).
