### PR TITLE
feat: keyboard shortcuts for prompts

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -16,3 +16,16 @@
 ## Glyphs
 
 `bindingGlyphs(b)` returns `["⌥","⇧","⌘", key]`. Help modal uses raw glyphs (⌘ ⌥ ⇧); settings editor uses `glyphLabel` (Cmd/Ctrl, Option/Alt). `isValidBinding` requires Cmd/Ctrl or Option to prevent swallowing normal typing.
+
+## Leader-key shortcuts (⌘R prompt quick-fire)
+
+`prompt-quick-fire` (default ⌘R) is the first shortcut that doesn't fit the plain `SHORTCUT_DEFS` + `case` recipe above: it's a two-key LEADER sequence, not a single simultaneous chord. Pressing it doesn't fire anything by itself — it arms a transient "press a key" mode (`useUI().promptLeaderActive`, shown as a hint pill mounted in `Dialogs.tsx`) and installs a one-shot, capture-phase `keydown` listener (`armPromptLeader` in `src/hooks/useShortcuts.ts`) that:
+
+- matches the next keystroke against each enabled prompt's EFFECTIVE trigger key (`effectiveTriggerKeys` in `src/store/prompts.ts` — a manual per-prompt override, else the next free slot in the default `1-9, a-z` sequence) and fires it at the focused agent tab (`fireOrPickDestination` in `src/lib/promptFire.ts`, falling back to the shared destination-picker dialog when there's no focused live agent)
+- cancels on `Escape`, an unmapped key, or a ~2s idle timeout
+
+The follow-up key MUST be captured before a focused terminal/xterm or editor/CodeMirror sees it, hence capture-phase + `stopImmediatePropagation` — same technique the Settings → Shortcuts key recorder uses, just re-armed after the leader key instead of after a click.
+
+`prompt-palette` (default ⇧⌘R) is a plain single-chord shortcut (fits the normal recipe) that opens `PromptPalette.tsx`: a searchable list of prompts (fuzzy-filtered by title only), Enter runs the highlighted one via the same `fireOrPickDestination` path.
+
+Per-prompt trigger keys are configurable in Settings → Prompts (`PromptLibrarySection.tsx`) and shown as badges in the Prompts dropdown (`UnifiedBar.tsx`) and the palette — NOT in `SHORTCUT_DEFS` (they're prompt data, not app shortcuts), so they don't show up in the Shortcuts help modal or settings editor.

--- a/src/components/UnifiedBar.tsx
+++ b/src/components/UnifiedBar.tsx
@@ -4,7 +4,7 @@
 // The whole strip is a drag region so the user can move the window from any
 // empty space, with `no-drag` opted-in on every interactive child.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useApp, useActiveTask } from "@/store/app";
 import { Button } from "@/components/ui/Button";
@@ -14,25 +14,20 @@ import { Check } from "lucide-react";
 import {
   PanelLeft, PanelRight, FolderOpen, Archive,
   Sun, Moon, Monitor, ArrowUpToLine, Sunrise, Droplet, Binary, Code2, Eye, Flower2,
-  MessageSquareText, Library, Plus, Palette,
+  MessageSquareText, Library, Palette,
 } from "lucide-react";
 import { CliIcon, CLI_BRAND_COLOR, resolveIconId } from "@/icons/cli";
 import { TaskLocationIcon } from "@/components/TaskLocationIcon";
 import { effectiveSandboxMode } from "@/lib/types";
 import { SandboxIcon } from "@/components/SandboxIcon";
-import type { TerminalTab } from "@/lib/types";
-import { findLeaf } from "@/lib/splitTree";
 import { UpdaterBanner } from "@/components/UpdaterBanner";
 import { WaitingAgentsPill } from "@/components/WaitingAgentsPill";
 import { openPath, themesDir, taskSendDiffToMain } from "@/lib/ipc";
 import { archiveAndRefresh } from "@/lib/archiveTask";
-import { visibleCliIds, isTerminalEntry, tabLabel } from "@/lib/agents";
-import { AppDialog } from "@/components/ui/Dialog";
 import {
   DropdownRoot, DropdownTrigger, DropdownMenu, DropdownItem, DropdownSeparator,
 } from "@/components/ui/Dropdown";
-import { usePromptLibrary, type Prompt } from "@/store/prompts";
-import { runPrompt } from "@/lib/runPrompt";
+import { usePromptLibrary, effectiveTriggerKeys } from "@/store/prompts";
 import { useUI } from "@/store/ui";
 import { usePrefs, resolveTheme } from "@/store/prefs";
 import { useIsFullscreen } from "@/hooks/useIsFullscreen";
@@ -53,37 +48,14 @@ export function UnifiedBar() {
   const task = useActiveTask();
   const proj = useApp(s => task ? s.projects.find(p => p.id === task.project_id) : null);
   const openSettings = useApp(s => s.openSettings);
-  const enabledPrompts = usePromptLibrary(s => s.prompts).filter(p => p.enabled);
-  // Live agents in the active task = the prompt destinations (+ New agent).
-  // Run/Setup tabs are terminals with live PTYs too, but a dev server is not
-  // a prompt destination — exclude them.
-  const taskTabs = useApp(s => (task ? s.tabs[task.id] : undefined));
-  const liveAgents = (taskTabs ?? []).filter(
-    (t): t is TerminalTab => t.type === "terminal" && !!t.ptyId && !(t as TerminalTab).runTab,
-  );
-  const focusedAgentId = useApp(s => {
-    if (!task) return undefined;
-    const tree = s.splitTree[task.id];
-    if (tree) {
-      const leaf = findLeaf(tree, s.activePaneId[task.id] ?? "");
-      if (leaf?.activeTabId) return leaf.activeTabId;
-    }
-    return s.activeTab[task.id];
-  });
-  // Picking a prompt opens a destination modal (running agents + new-agent
-  // CLIs) instead of a submenu, which flipped to the wrong side near the edge.
-  const [firingPrompt, setFiringPrompt] = useState<Prompt | null>(null);
-  // Editable copy of the prompt body for this send only (does not touch the
-  // saved library prompt). Seeded when a prompt is picked.
-  const [firingBody, setFiringBody] = useState("");
-  const detectedClis = useApp(s => s.detectedClis);
-  // Spawnable agents for "start a new agent" — installed + enabled, no plain
-  // terminal entries. Same list the new-tab (+) menu offers. Memoized so the
-  // always-mounted bar doesn't rebuild the visibility Set per-agent each render.
-  const newAgentChoices = useMemo(() => {
-    const vis = visibleCliIds(agents.map(x => x.id), agents, detectedClis);
-    return agents.filter(a => vis.has(a.id) && !isTerminalEntry(a));
-  }, [agents, detectedClis]);
+  const allPrompts = usePromptLibrary(s => s.prompts);
+  const enabledPrompts = allPrompts.filter(p => p.enabled);
+  const triggerKeys = effectiveTriggerKeys(allPrompts);
+  // Picking a prompt opens the shared destination modal (running agents +
+  // new-agent CLIs) — a modal, not a submenu, which flipped to the wrong
+  // side near the window edge. Shared (not local state) so the ⌘R
+  // quick-fire / ⇧⌘R palette fallback paths can open the same dialog.
+  const openPromptFire = useUI(s => s.openPromptFire);
   const themeMode = usePrefs(s => s.themeMode);
   const setThemeMode = usePrefs(s => s.setThemeMode);
   // When the user picked an explicit theme, show that theme's icon.
@@ -239,8 +211,16 @@ export function UnifiedBar() {
                   <div className="px-2 py-1.5 text-[13px] text-[var(--color-fg-faint)]">No prompts yet.</div>
                 )}
                 {enabledPrompts.map(p => (
-                  <DropdownItem key={p.id} onSelect={() => { setFiringPrompt(p); setFiringBody(p.body); }}>
-                    <span className="truncate">{p.title}</span>
+                  <DropdownItem key={p.id} onSelect={() => openPromptFire(p)}>
+                    <span className="min-w-0 flex-1 truncate">{p.title}</span>
+                    {triggerKeys.get(p.id) && (
+                      <kbd
+                        title="⌘R quick-fire key"
+                        className="ml-2 shrink-0 rounded border border-[var(--color-border-soft)] px-1 font-mono text-[10.5px] uppercase leading-[16px] text-[var(--color-fg-faint)]"
+                      >
+                        {triggerKeys.get(p.id)}
+                      </kbd>
+                    )}
                   </DropdownItem>
                 ))}
                 <DropdownSeparator />
@@ -251,94 +231,6 @@ export function UnifiedBar() {
               </DropdownMenu>
             </DropdownRoot>
 
-            {/* Destination picker: where should this prompt run? A running
-                agent (send / queue), or a new agent with the CLI of your
-                choice. A modal, not a submenu (which flipped to the wrong
-                side near the window edge). */}
-            {firingPrompt && (
-              <AppDialog
-                open
-                onOpenChange={(v) => { if (!v) setFiringPrompt(null); }}
-                title={`Run "${firingPrompt.title}"`}
-                description="Tweak the prompt if needed, then pick where it runs."
-                className="max-w-5xl"
-              >
-                <div className="mt-1 flex h-[58vh] gap-4">
-                  {/* Left: editable prompt for THIS send (does not change the
-                      saved library prompt). */}
-                  <textarea
-                    value={firingBody}
-                    onChange={(e) => setFiringBody(e.target.value)}
-                    spellCheck={false}
-                    autoCorrect="off"
-                    autoCapitalize="off"
-                    autoComplete="off"
-                    className="h-full min-w-0 flex-1 resize-none rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2.5 font-mono text-[12.5px] leading-relaxed text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
-                  />
-
-                  {/* Right: where to run it. */}
-                  <div className="flex w-[260px] shrink-0 flex-col gap-3 overflow-y-auto pr-0.5">
-                    {liveAgents.length > 0 && (
-                      <div className="flex flex-col gap-1.5">
-                        <div className="px-0.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-fg-faint)]">Send to a running agent</div>
-                        {liveAgents.map(a => {
-                          const current = a.id === focusedAgentId;
-                          const busy = a.workState === "working";
-                          return (
-                            <button
-                              key={a.id}
-                              onClick={() => { runPrompt(task.id, { ...firingPrompt, body: firingBody }, { kind: "agent", tabId: a.id }); setFiringPrompt(null); }}
-                              className={cn(
-                                "flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
-                                current
-                                  ? "border-[var(--color-border)] bg-[var(--color-bg-2)]"
-                                  : "border-[var(--color-border)] hover:border-[var(--color-accent-soft)] hover:bg-[var(--color-hover)]",
-                              )}
-                            >
-                              <span className={cn("shrink-0", CLI_BRAND_COLOR[resolveIconId(a.cli, agents)])}>
-                                <CliIcon cli={resolveIconId(a.cli, agents)} className="h-5 w-5" />
-                              </span>
-                              <span className="min-w-0 flex-1">
-                                <span className="block truncate text-[13px] text-[var(--color-fg)]">
-                                  {tabLabel(a)}
-                                </span>
-                                {(current || busy) && (
-                                  <span className="block text-[10.5px]">
-                                    {current && <span className="text-[var(--color-accent)]">current</span>}
-                                    {current && busy && <span className="text-[var(--color-fg-faint)]"> · </span>}
-                                    {busy && <span className="text-[var(--color-fg-faint)]">busy</span>}
-                                  </span>
-                                )}
-                              </span>
-                            </button>
-                          );
-                        })}
-                      </div>
-                    )}
-
-                    <div className="flex flex-col gap-0.5">
-                      <div className="mb-0.5 flex items-center gap-1 px-0.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-fg-faint)]">
-                        <Plus className="h-3 w-3" /> Start a new agent
-                      </div>
-                      {newAgentChoices.length === 0 ? (
-                        <div className="px-0.5 py-1 text-[12.5px] text-[var(--color-fg-faint)]">No agents available.</div>
-                      ) : newAgentChoices.map(a => (
-                        <button
-                          key={a.id}
-                          onClick={() => { runPrompt(task.id, { ...firingPrompt, body: firingBody }, { kind: "new", cli: a.id }); setFiringPrompt(null); }}
-                          className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--color-hover)]"
-                        >
-                          <span className={cn("shrink-0 opacity-80", CLI_BRAND_COLOR[a.icon_id])}>
-                            <CliIcon cli={a.icon_id} className="h-4 w-4" />
-                          </span>
-                          <span className="min-w-0 flex-1 truncate text-[12.5px] text-[var(--color-fg-dim)]">{a.display_name}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </AppDialog>
-            )}
             {/* Send-to-main: only shown on actual worktrees, not the
                 repo-root pseudo-task (which IS the main checkout —
                 nothing to send). Hard-blocks on a dirty main checkout

--- a/src/components/dialogs/Dialogs.tsx
+++ b/src/components/dialogs/Dialogs.tsx
@@ -21,11 +21,14 @@ import { FileFinderDialog } from "./FileFinderDialog";
 import { FindInFilesDialog } from "./FindInFilesDialog";
 import { ProjectPickerDialog } from "./ProjectPickerDialog";
 import { CommandPalette } from "./CommandPalette";
+import { PromptDestinationDialog } from "./PromptDestinationDialog";
+import { PromptPalette } from "./PromptPalette";
 import { Loader2 } from "lucide-react";
 
 export function Dialogs() {
   const openWelcome = useUI(s => s.openWelcome);
   const busyMessage = useUI(s => s.busyMessage);
+  const promptLeaderActive = useUI(s => s.promptLeaderActive);
 
   // Fire the welcome wizard on first launch (no settings.welcomed flag yet).
   useEffect(() => {
@@ -51,6 +54,15 @@ export function Dialogs() {
       <FindInFilesDialog />
       <ProjectPickerDialog />
       <CommandPalette />
+      <PromptDestinationDialog />
+      <PromptPalette />
+      {/* ⌘R quick-fire, armed: waiting for the follow-up trigger-key press.
+          See armPromptLeader in useShortcuts.ts. */}
+      {promptLeaderActive && (
+        <div className="fixed bottom-6 left-1/2 z-[55] -translate-x-1/2 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-1)] px-3.5 py-1.5 text-[12.5px] text-[var(--color-fg-dim)] shadow-xl">
+          Prompt: press a key…
+        </div>
+      )}
       {/* Blocking work overlay: shown while a slow IPC call is in flight
           (archive task, etc.). Click-blocks the whole window so users
           don't fire the action twice mid-wait. */}

--- a/src/components/dialogs/PromptDestinationDialog.tsx
+++ b/src/components/dialogs/PromptDestinationDialog.tsx
@@ -1,0 +1,134 @@
+// "Run '<title>'" destination picker — where should this prompt go? A
+// running agent (send / queue), or a new agent with the CLI of your choice.
+// Shared by the Prompts dropdown (UnifiedBar), the ⌘R quick-fire fallback,
+// and the ⇧⌘R search palette fallback (src/lib/promptFire.ts's
+// `fireOrPickDestination`, used when there's no focused live agent to guess
+// at). Self-manages via useUI, same pattern as every other dialog in
+// components/dialogs/ — see Dialogs.tsx.
+
+import { useMemo } from "react";
+import { useApp, useActiveTask } from "@/store/app";
+import { useUI } from "@/store/ui";
+import { AppDialog } from "@/components/ui/Dialog";
+import { CliIcon, CLI_BRAND_COLOR, resolveIconId } from "@/icons/cli";
+import { visibleCliIds, isTerminalEntry, tabLabel } from "@/lib/agents";
+import { findLeaf } from "@/lib/splitTree";
+import { runPrompt } from "@/lib/runPrompt";
+import type { TerminalTab } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Plus } from "lucide-react";
+
+export function PromptDestinationDialog() {
+  const promptFire = useUI(s => s.promptFire);
+  const closePromptFire = useUI(s => s.closePromptFire);
+  const setPromptFireBody = useUI(s => s.setPromptFireBody);
+  const agents = useApp(s => s.agents);
+  const detectedClis = useApp(s => s.detectedClis);
+  const task = useActiveTask();
+  const taskTabs = useApp(s => (task ? s.tabs[task.id] : undefined));
+  const liveAgents = (taskTabs ?? []).filter(
+    (t): t is TerminalTab => t.type === "terminal" && !!t.ptyId && !(t as TerminalTab).runTab,
+  );
+  const focusedAgentId = useApp(s => {
+    if (!task) return undefined;
+    const tree = s.splitTree[task.id];
+    if (tree) {
+      const leaf = findLeaf(tree, s.activePaneId[task.id] ?? "");
+      if (leaf?.activeTabId) return leaf.activeTabId;
+    }
+    return s.activeTab[task.id];
+  });
+  // Spawnable agents for "start a new agent" — same list the new-tab (+) menu offers.
+  const newAgentChoices = useMemo(() => {
+    const vis = visibleCliIds(agents.map(x => x.id), agents, detectedClis);
+    return agents.filter(a => vis.has(a.id) && !isTerminalEntry(a));
+  }, [agents, detectedClis]);
+
+  if (!promptFire || !task) return null;
+  const { prompt, body } = promptFire;
+
+  return (
+    <AppDialog
+      open
+      onOpenChange={(v) => { if (!v) closePromptFire(); }}
+      title={`Run "${prompt.title}"`}
+      description="Tweak the prompt if needed, then pick where it runs."
+      className="max-w-5xl"
+    >
+      <div className="mt-1 flex h-[58vh] gap-4">
+        {/* Left: editable prompt for THIS send (does not change the saved
+            library prompt). */}
+        <textarea
+          value={body}
+          onChange={(e) => setPromptFireBody(e.target.value)}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+          autoComplete="off"
+          className="h-full min-w-0 flex-1 resize-none rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2.5 font-mono text-[12.5px] leading-relaxed text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
+        />
+
+        {/* Right: where to run it. */}
+        <div className="flex w-[260px] shrink-0 flex-col gap-3 overflow-y-auto pr-0.5">
+          {liveAgents.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <div className="px-0.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-fg-faint)]">Send to a running agent</div>
+              {liveAgents.map(a => {
+                const current = a.id === focusedAgentId;
+                const busy = a.workState === "working";
+                return (
+                  <button
+                    key={a.id}
+                    onClick={() => { runPrompt(task.id, { ...prompt, body }, { kind: "agent", tabId: a.id }); closePromptFire(); }}
+                    className={cn(
+                      "flex items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors",
+                      current
+                        ? "border-[var(--color-border)] bg-[var(--color-bg-2)]"
+                        : "border-[var(--color-border)] hover:border-[var(--color-accent-soft)] hover:bg-[var(--color-hover)]",
+                    )}
+                  >
+                    <span className={cn("shrink-0", CLI_BRAND_COLOR[resolveIconId(a.cli, agents)])}>
+                      <CliIcon cli={resolveIconId(a.cli, agents)} className="h-5 w-5" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-[13px] text-[var(--color-fg)]">
+                        {tabLabel(a)}
+                      </span>
+                      {(current || busy) && (
+                        <span className="block text-[10.5px]">
+                          {current && <span className="text-[var(--color-accent)]">current</span>}
+                          {current && busy && <span className="text-[var(--color-fg-faint)]"> · </span>}
+                          {busy && <span className="text-[var(--color-fg-faint)]">busy</span>}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-0.5">
+            <div className="mb-0.5 flex items-center gap-1 px-0.5 text-[11px] font-medium uppercase tracking-wider text-[var(--color-fg-faint)]">
+              <Plus className="h-3 w-3" /> Start a new agent
+            </div>
+            {newAgentChoices.length === 0 ? (
+              <div className="px-0.5 py-1 text-[12.5px] text-[var(--color-fg-faint)]">No agents available.</div>
+            ) : newAgentChoices.map(a => (
+              <button
+                key={a.id}
+                onClick={() => { runPrompt(task.id, { ...prompt, body }, { kind: "new", cli: a.id }); closePromptFire(); }}
+                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--color-hover)]"
+              >
+                <span className={cn("shrink-0 opacity-80", CLI_BRAND_COLOR[a.icon_id])}>
+                  <CliIcon cli={a.icon_id} className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 flex-1 truncate text-[12.5px] text-[var(--color-fg-dim)]">{a.display_name}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </AppDialog>
+  );
+}

--- a/src/components/dialogs/PromptPalette.tsx
+++ b/src/components/dialogs/PromptPalette.tsx
@@ -1,0 +1,156 @@
+// ⇧⌘R prompt search palette — fuzzy-filter the enabled prompt library by
+// TITLE ONLY (not body), Enter runs the highlighted prompt straight at the
+// focused agent (or opens the destination picker when there's none, via
+// `fireOrPickDestination` — same fallback the ⌘R quick-fire leader key
+// uses). Modelled on CommandPalette.tsx: same non-modal Dialog pattern (an
+// action here can open the destination picker, which would get dismissed
+// by a modal palette's closing animation), no solid backdrop.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Search, BookText } from "lucide-react";
+import { useUI } from "@/store/ui";
+import { useApp } from "@/store/app";
+import { usePromptLibrary, effectiveTriggerKeys, type Prompt } from "@/store/prompts";
+import { fireOrPickDestination } from "@/lib/promptFire";
+import { fuzzyMatch, Highlighted } from "@/lib/fuzzy";
+
+export function PromptPalette() {
+  const open = useUI(s => s.promptPaletteOpen);
+  const close = useUI(s => s.closePromptPalette);
+  const taskId = useApp(s => s.activeTaskId);
+  const openSettings = useApp(s => s.openSettings);
+  const allPrompts = usePromptLibrary(s => s.prompts);
+  const enabledPrompts = useMemo(() => allPrompts.filter(p => p.enabled), [allPrompts]);
+  const triggerKeys = useMemo(() => effectiveTriggerKeys(allPrompts), [allPrompts]);
+
+  const [query, setQuery] = useState("");
+  const [activeIdx, setActiveIdx] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (open) { setQuery(""); setActiveIdx(0); }
+  }, [open]);
+  useEffect(() => { setActiveIdx(0); }, [query]);
+
+  const rows = useMemo(() => {
+    type Scored = { prompt: Prompt; matches: number[] };
+    if (!query) return enabledPrompts.map<Scored>(p => ({ prompt: p, matches: [] }));
+    const out: Array<Scored & { score: number }> = [];
+    for (const p of enabledPrompts) {
+      const m = fuzzyMatch(p.title, query);
+      if (!m) continue;
+      out.push({ prompt: p, matches: m.matches, score: m.score });
+    }
+    out.sort((a, b) => b.score - a.score);
+    return out;
+  }, [enabledPrompts, query]);
+
+  useEffect(() => {
+    if (activeIdx > rows.length - 1) setActiveIdx(Math.max(0, rows.length - 1));
+  }, [rows.length, activeIdx]);
+  useEffect(() => {
+    listRef.current?.querySelector<HTMLElement>(`[data-row="${activeIdx}"]`)?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx]);
+
+  function run(prompt: Prompt) {
+    if (!taskId) return;
+    close();
+    fireOrPickDestination(taskId, prompt);
+  }
+
+  function onKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx(i => Math.min(i + 1, rows.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx(i => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const p = rows[activeIdx]?.prompt;
+      if (p) run(p);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(v) => (v ? null : close())} modal={false}>
+      <Dialog.Portal>
+        <div
+          aria-hidden
+          data-state={open ? "open" : "closed"}
+          className="termic-backdrop pointer-events-none fixed inset-0 z-40 bg-black/30"
+        />
+        <Dialog.Content
+          onOpenAutoFocus={() => { returnFocusRef.current = (document.activeElement as HTMLElement) ?? null; }}
+          onCloseAutoFocus={(e) => {
+            e.preventDefault();
+            const el = returnFocusRef.current;
+            requestAnimationFrame(() => {
+              const ae = document.activeElement;
+              if ((!ae || ae === document.body) && el && document.contains(el)) el.focus();
+            });
+          }}
+          style={{ background: "color-mix(in srgb, var(--color-bg-1) 86%, transparent)" }}
+          className="termic-pop fixed left-1/2 top-[14vh] z-50 w-[min(480px,92vw)] -translate-x-1/2 overflow-hidden rounded-xl border border-[var(--color-border)] shadow-2xl outline-none backdrop-blur-lg"
+          onKeyDown={onKeyDown}
+        >
+          <Dialog.Title className="sr-only">Prompt search</Dialog.Title>
+          <Dialog.Description className="sr-only">Search library prompts by title and run one.</Dialog.Description>
+          <div className="flex items-center gap-2 border-b border-[var(--color-border)] px-3 py-2.5">
+            <Search className="h-4 w-4 shrink-0 text-[var(--color-fg-faint)]" />
+            <input
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              spellCheck={false}
+              autoCorrect="off"
+              autoCapitalize="off"
+              autoComplete="off"
+              placeholder="Search prompts by title…"
+              className="w-full bg-transparent pl-1 text-[14px] text-[var(--color-fg)] placeholder:text-[var(--color-fg-faint)] focus:outline-none"
+            />
+          </div>
+          <div ref={listRef} className="no-scrollbar max-h-[min(50vh,360px)] overflow-y-auto py-1">
+            {rows.length === 0 && (
+              <div className="px-3 py-3 text-[13px] text-[var(--color-fg-faint)]">
+                {enabledPrompts.length === 0 ? "No prompts yet." : "No matching prompts"}
+              </div>
+            )}
+            {rows.map(({ prompt, matches }, i) => (
+              <button
+                key={prompt.id}
+                data-row={i}
+                onClick={() => run(prompt)}
+                onMouseMove={() => setActiveIdx(i)}
+                style={i === activeIdx ? { background: "color-mix(in srgb, var(--color-fg) 13%, transparent)" } : undefined}
+                className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left"
+              >
+                <span className="min-w-0 flex-1 truncate text-[13px] text-[var(--color-fg)]">
+                  {query ? <Highlighted text={prompt.title} matches={matches} /> : prompt.title}
+                </span>
+                {triggerKeys.get(prompt.id) && (
+                  <kbd className="shrink-0 rounded border border-[var(--color-border-soft)] px-1 font-mono text-[10.5px] uppercase leading-[16px] text-[var(--color-fg-faint)]">
+                    {triggerKeys.get(prompt.id)}
+                  </kbd>
+                )}
+              </button>
+            ))}
+          </div>
+          <div className="border-t border-[var(--color-border)]">
+            <button
+              onClick={() => { close(); requestAnimationFrame(() => openSettings("prompts")); }}
+              className="flex w-full items-center gap-2.5 px-3 py-2.5 text-left text-[12.5px] text-[var(--color-fg-faint)] hover:text-[var(--color-fg-dim)]"
+            >
+              <BookText className="h-3.5 w-3.5" />
+              Manage prompts…
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/settings/PromptLibrarySection.tsx
+++ b/src/components/settings/PromptLibrarySection.tsx
@@ -6,12 +6,12 @@
 // src/store/prompts.ts.
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { usePromptLibrary } from "@/store/prompts";
+import { usePromptLibrary, effectiveTriggerKeys } from "@/store/prompts";
 import { useUI } from "@/store/ui";
 import { Button } from "@/components/ui/Button";
 import { AppDialog } from "@/components/ui/Dialog";
 import { cn } from "@/lib/utils";
-import { GripVertical, Copy, Trash2, RotateCcw, Eye, EyeOff, Plus, Pencil } from "lucide-react";
+import { GripVertical, Copy, Trash2, RotateCcw, Eye, EyeOff, Plus, Pencil, X } from "lucide-react";
 
 interface DragState {
   id: string;
@@ -38,7 +38,40 @@ export function PromptLibrarySection() {
   const toggleEnabled = usePromptLibrary(s => s.toggleEnabled);
   const reorderPrompts = usePromptLibrary(s => s.reorderPrompts);
   const restoreBuiltins = usePromptLibrary(s => s.restoreBuiltins);
+  const setTriggerKey = usePromptLibrary(s => s.setTriggerKey);
   const deletedCount = usePromptLibrary(s => s.deletedBuiltins.length);
+  const triggerKeys = effectiveTriggerKeys(prompts);
+
+  // ⌘R quick-fire / palette trigger-key recorder — one row at a time, same
+  // capture-phase pattern as the Shortcuts settings recorder so the keystroke
+  // never reaches the app's global shortcut handler.
+  const [recordingKeyId, setRecordingKeyId] = useState<string | null>(null);
+  const [keyRecordError, setKeyRecordError] = useState<string | null>(null);
+  useEffect(() => {
+    if (!recordingKeyId) return;
+    const onKey = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      if (e.key === "Escape") { setRecordingKeyId(null); setKeyRecordError(null); return; }
+      if (["Meta", "Control", "Shift", "Alt", "CapsLock"].includes(e.key)) return;
+      const key = e.key.toLowerCase();
+      if (!/^[a-z0-9]$/.test(key)) {
+        setKeyRecordError("Use a single letter or digit.");
+        return;
+      }
+      const takenBy = prompts.find(p => p.id !== recordingKeyId && triggerKeys.get(p.id) === key);
+      if (takenBy) {
+        setKeyRecordError(`Already used by "${takenBy.title}".`);
+        return;
+      }
+      setTriggerKey(recordingKeyId, key);
+      setRecordingKeyId(null);
+      setKeyRecordError(null);
+    };
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recordingKeyId]);
 
   // Body editor modal — the inline row only shows a preview.
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -186,7 +219,9 @@ export function PromptLibrarySection() {
           <p className="mt-0.5 max-w-xl text-[12.5px] text-[var(--color-fg-dim)]">
             Reusable prompts for the Prompts menu in the top bar. When you fire one, you pick
             where it goes: an existing agent (queued if it is busy) or a new agent. Drag to
-            reorder. Built-ins can be edited and reset.
+            reorder. Built-ins can be edited and reset. Each prompt also gets a quick-fire key
+            (press ⌘R, then that key) for the currently focused agent, auto-assigned 1-9 then
+            a-z, editable per prompt.
           </p>
         </div>
         <Button variant="primary" size="sm" className="shrink-0 gap-1.5" onClick={openNewPrompt}>
@@ -244,6 +279,28 @@ export function PromptLibrarySection() {
                 </span>
               )}
 
+              {/* ⌘R quick-fire / palette trigger key — click to record a new
+                  one, × to clear an override back to auto-assigned. */}
+              <div className="flex shrink-0 items-center gap-0.5">
+                <button
+                  title="Click to set the ⌘R quick-fire key"
+                  onClick={() => { setKeyRecordError(null); setRecordingKeyId(recordingKeyId === p.id ? null : p.id); }}
+                  className={cn(
+                    "flex h-6 min-w-[22px] items-center justify-center rounded border px-1 font-mono text-[11px] uppercase leading-none",
+                    recordingKeyId === p.id
+                      ? "border-[var(--color-accent)] text-[var(--color-accent)]"
+                      : "border-[var(--color-border-soft)] text-[var(--color-fg-faint)] hover:border-[var(--color-border)] hover:text-[var(--color-fg-dim)]",
+                  )}
+                >
+                  {recordingKeyId === p.id ? "…" : (triggerKeys.get(p.id) ?? "-")}
+                </button>
+                {p.triggerKeyOverride && (
+                  <IconBtn title="Clear override (back to auto)" onClick={() => setTriggerKey(p.id, null)}>
+                    <X className="h-3.5 w-3.5" />
+                  </IconBtn>
+                )}
+              </div>
+
               {/* Row actions */}
               <IconBtn title="Edit prompt" onClick={() => setEditingId(p.id)}>
                 <Pencil className="h-4 w-4" />
@@ -263,6 +320,12 @@ export function PromptLibrarySection() {
                 <Trash2 className="h-4 w-4" />
               </IconBtn>
             </div>
+
+            {recordingKeyId === p.id && (
+              <div className={cn("mt-1 pl-8 text-[11.5px]", keyRecordError ? "text-[var(--color-err)]" : "text-[var(--color-fg-faint)]")}>
+                {keyRecordError ?? "Press a letter or digit for the quick-fire key. Esc to cancel."}
+              </div>
+            )}
 
             {/* Body preview — click to edit in the modal. Blank lines stripped. */}
             <button

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -18,11 +18,15 @@
 //   ⌘L       → focus the main agent (its terminal or editor) from any pane
 //   ⌘T       → new tab · ⌘K → clear terminal · ⌘P → file finder
 //   ⇧⌘F      → find in files · ⇧⌘B → broadcast · ⌘, → settings
+//   ⌘R       → prompt quick-fire (press, then a prompt's trigger key)
+//   ⇧⌘R      → prompt search palette
 //   Shortcuts cheat-sheet: icon-only, no keyboard binding
 import { useEffect } from "react";
 import { useApp } from "@/store/app";
 import { useUI } from "@/store/ui";
 import { usePrefs } from "@/store/prefs";
+import { usePromptLibrary, effectiveTriggerKeys } from "@/store/prompts";
+import { fireOrPickDestination } from "@/lib/promptFire";
 import { requestCloseTab, requestClosePaneTab } from "@/lib/closeTab";
 import { focusTerminalTab, focusMainTab, focusPaneTab } from "@/lib/tabFocus";
 import { jumpToNextWaiting } from "@/lib/waitingAgents";
@@ -30,6 +34,50 @@ import { bindingMatches, eventKeyToken, IS_MAC, SHORTCUT_DEFS, type ShortcutId }
 import type { TerminalTab } from "@/lib/types";
 import { findAdjacentPane, findLeaf, computeLeafBounds, getAllLeaves, treeHasDir } from "@/lib/splitTree";
 import type { NavDir } from "@/lib/splitTree";
+
+// ⌘R quick-fire: arms a transient "press a key" mode (module-scope, not
+// component state — useShortcuts' listener is registered once at mount) that
+// captures the FOLLOW-UP keystroke in the capture phase, before it reaches a
+// focused terminal/editor, and matches it against each prompt's effective
+// trigger key (src/store/prompts.ts `effectiveTriggerKeys`). A match fires
+// immediately at the focused agent (or opens the destination picker when
+// there's none, via `fireOrPickDestination`); Escape, an unmapped key, or a
+// ~2s idle timeout disarms with no side effect.
+let promptLeaderTimeout: number | null = null;
+let promptLeaderKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+
+function disarmPromptLeader() {
+  if (promptLeaderTimeout != null) { window.clearTimeout(promptLeaderTimeout); promptLeaderTimeout = null; }
+  if (promptLeaderKeyHandler) {
+    window.removeEventListener("keydown", promptLeaderKeyHandler, { capture: true });
+    promptLeaderKeyHandler = null;
+  }
+  useUI.getState().closePromptLeader();
+}
+
+function armPromptLeader() {
+  disarmPromptLeader(); // re-arming (a second ⌘R while already armed) restarts clean
+  useUI.getState().openPromptLeader();
+  const onKey = (e: KeyboardEvent) => {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    if (e.key === "Escape") { disarmPromptLeader(); return; }
+    // Bare modifier keydown (still settling into the chord) — keep waiting.
+    if (["Meta", "Control", "Shift", "Alt", "CapsLock"].includes(e.key)) return;
+    disarmPromptLeader();
+    const taskId = useApp.getState().activeTaskId;
+    if (!taskId) return;
+    const key = e.key.toLowerCase();
+    if (!/^[a-z0-9]$/.test(key)) return;
+    const prompts = usePromptLibrary.getState().prompts;
+    const keys = effectiveTriggerKeys(prompts);
+    const prompt = prompts.find(p => p.enabled && keys.get(p.id) === key);
+    if (prompt) fireOrPickDestination(taskId, prompt);
+  };
+  promptLeaderKeyHandler = onKey;
+  window.addEventListener("keydown", onKey, { capture: true });
+  promptLeaderTimeout = window.setTimeout(disarmPromptLeader, 2000);
+}
 
 /**
  * Pick the next pane to focus in `dir`, preferring the most recently visited
@@ -461,6 +509,25 @@ export function useShortcuts() {
           useUI.getState().openBroadcast(taskId);
           return;
 
+        // ⌘R → prompt quick-fire. NO `isTyping` guard (must arm from inside
+        // a focused terminal); the follow-up key is what actually needs
+        // capturing before the terminal sees it (armPromptLeader does that).
+        case "prompt-quick-fire":
+          if (!taskId) return;
+          e.preventDefault();
+          armPromptLeader();
+          return;
+
+        // ⇧⌘R → toggle the prompt search palette. Same no-`isTyping`
+        // rationale as ⌘K's command palette.
+        case "prompt-palette": {
+          e.preventDefault();
+          const ui = useUI.getState();
+          if (ui.promptPaletteOpen) ui.closePromptPalette();
+          else ui.openPromptPalette();
+          return;
+        }
+
         // ⌘T → new tab, behaviour depends on which pane has focus. NO
         // `isTyping` guard (xterm's hidden textarea).
         case "new-tab": {
@@ -552,7 +619,7 @@ export function useShortcuts() {
       }
     }
     window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    return () => { window.removeEventListener("keydown", onKey); disarmPromptLeader(); };
   }, []);
 }
 

--- a/src/lib/promptFire.ts
+++ b/src/lib/promptFire.ts
@@ -1,0 +1,49 @@
+// Shared "fire a library prompt" logic for the ⌘R quick-fire leader key and
+// the ⇧⌘R search palette (src/hooks/useShortcuts.ts, PromptPalette.tsx). The
+// Prompts dropdown in UnifiedBar always opens the destination picker instead
+// (its whole point is letting you tweak the body / pick a target every
+// time) — these fast paths skip straight to the focused agent when there is
+// one, and fall back to the same picker otherwise.
+
+import { useApp } from "@/store/app";
+import { useUI } from "@/store/ui";
+import { findLeaf } from "@/lib/splitTree";
+import { runPrompt } from "@/lib/runPrompt";
+import type { TerminalTab } from "@/lib/types";
+import type { Prompt } from "@/store/prompts";
+
+/** The tab id showing in the currently-focused pane (main or split) of a
+ *  workspace. Mirrors the main pane's focus-jump lookup in useShortcuts.ts
+ *  (`focus-terminal` case) / UnifiedBar's `focusedAgentId`. */
+export function getFocusedTabId(wsId: string): string | undefined {
+  const s = useApp.getState();
+  const tree = s.splitTree[wsId];
+  if (tree) {
+    const leaf = findLeaf(tree, s.activePaneId[wsId] ?? "");
+    if (leaf?.activeTabId) return leaf.activeTabId;
+  }
+  return s.activeTab[wsId];
+}
+
+/** Live agent-terminal tabs in a workspace — prompt fire destinations. Run
+ *  tabs are terminals with a live PTY too, but a dev server isn't a prompt
+ *  destination, so they're excluded (matches UnifiedBar's `liveAgents`). */
+export function getLiveAgentTabs(wsId: string): TerminalTab[] {
+  const tabs = useApp.getState().tabs[wsId] ?? [];
+  return tabs.filter(
+    (t): t is TerminalTab => t.type === "terminal" && !!t.ptyId && !(t as TerminalTab).runTab,
+  );
+}
+
+/** Fire `prompt` straight at the focused tab when it's a live agent;
+ *  otherwise open the destination picker so the user chooses (no eligible
+ *  agent to guess at — e.g. focus is on an editor tab, or nothing's running). */
+export function fireOrPickDestination(wsId: string, prompt: Prompt): void {
+  const focusedId = getFocusedTabId(wsId);
+  const liveAgents = getLiveAgentTabs(wsId);
+  if (focusedId && liveAgents.some(a => a.id === focusedId)) {
+    runPrompt(wsId, prompt, { kind: "agent", tabId: focusedId });
+    return;
+  }
+  useUI.getState().openPromptFire(prompt);
+}

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -51,6 +51,8 @@ export type ShortcutId =
   | "toggle-left-sidebar"
   | "toggle-right-sidebar"
   | "broadcast"
+  | "prompt-quick-fire"
+  | "prompt-palette"
   | "stage-file"
   | "discard-file";
 
@@ -157,6 +159,12 @@ export const SHORTCUT_DEFS: ShortcutDef[] = [
     hint: "Show / hide the right panel", defaultBinding: B("b", { cmd: true, alt: true }) },
   { id: "broadcast", group: "General", label: "Broadcast to agents",
     defaultBinding: B("b", { cmd: true, shift: true }) },
+  { id: "prompt-quick-fire", group: "General", label: "Prompt quick-fire",
+    hint: "Press, then a prompt's key (shown in the Prompts menu), to run it on the focused agent",
+    defaultBinding: B("r", { cmd: true }) },
+  { id: "prompt-palette", group: "General", label: "Prompt search palette",
+    hint: "Search prompts by title; Enter runs the highlighted one",
+    defaultBinding: B("r", { cmd: true, shift: true }) },
 
   // Git — contextual: these act on the file selected in the Git panel and
   // are handled there (GitPanel), not the global handler. The discard

--- a/src/store/prompts.ts
+++ b/src/store/prompts.ts
@@ -27,6 +27,39 @@ export interface Prompt {
   enabled: boolean;
   /** Built-in only: true once the user edited it away from the shipped text. */
   modified: boolean;
+  /** Manually assigned trigger-key (single char), or undefined to auto-assign
+   *  from the default 1-9, a-z sequence. See `effectiveTriggerKeys`. */
+  triggerKeyOverride?: string;
+}
+
+// Default trigger-key sequence for ⌘R quick-fire / the palette badges:
+// digits first (they read fastest), then letters.
+const TRIGGER_KEY_SEQUENCE = "123456789abcdefghijklmnopqrstuvwxyz".split("");
+
+/** Resolve each prompt's EFFECTIVE trigger key: its manual override if set
+ *  and not already claimed by an earlier prompt, else the next free slot in
+ *  the default sequence. Walks the full list (not just enabled) so a
+ *  prompt's number doesn't shift when a sibling is toggled on/off - only
+ *  enabled prompts are actually reachable via the key, but everyone still
+ *  holds their place in line. */
+export function effectiveTriggerKeys(prompts: readonly Prompt[]): Map<string, string> {
+  const used = new Set<string>();
+  const result = new Map<string, string>();
+  for (const p of prompts) {
+    const ov = p.triggerKeyOverride;
+    if (ov && !used.has(ov)) { result.set(p.id, ov); used.add(ov); }
+  }
+  let seqIdx = 0;
+  for (const p of prompts) {
+    if (result.has(p.id)) continue;
+    while (seqIdx < TRIGGER_KEY_SEQUENCE.length && used.has(TRIGGER_KEY_SEQUENCE[seqIdx])) seqIdx++;
+    if (seqIdx >= TRIGGER_KEY_SEQUENCE.length) continue;
+    const key = TRIGGER_KEY_SEQUENCE[seqIdx];
+    result.set(p.id, key);
+    used.add(key);
+    seqIdx++;
+  }
+  return result;
 }
 
 interface BuiltinDef { id: string; title: string; body: string }
@@ -51,9 +84,13 @@ interface Persisted {
   deletedBuiltins: string[];
   disabled: string[];
   order: string[];
+  /** Manual trigger-key overrides for ⌘R quick-fire / the palette, id -> single char. */
+  triggerKeys: Record<string, string>;
 }
 
-const EMPTY: Persisted = { customs: [], overrides: {}, deletedBuiltins: [], disabled: [], order: [] };
+const EMPTY: Persisted = {
+  customs: [], overrides: {}, deletedBuiltins: [], disabled: [], order: [], triggerKeys: {},
+};
 
 function isCustom(c: unknown): c is StoredCustom {
   return !!c && typeof c === "object"
@@ -73,6 +110,7 @@ function load(): Persisted {
       deletedBuiltins: Array.isArray(s.deletedBuiltins) ? s.deletedBuiltins : [],
       disabled: Array.isArray(s.disabled) ? s.disabled : [],
       order: Array.isArray(s.order) ? s.order : [],
+      triggerKeys: s.triggerKeys && typeof s.triggerKeys === "object" ? s.triggerKeys : {},
     };
   } catch {
     return { ...EMPTY };
@@ -96,10 +134,15 @@ function computePrompts(p: Persisted): Prompt[] {
       builtin: true,
       enabled: !p.disabled.includes(d.id),
       modified: !!ov,
+      triggerKeyOverride: p.triggerKeys[d.id],
     });
   }
   for (const c of p.customs) {
-    items.push({ id: c.id, title: c.title, body: c.body, builtin: false, enabled: !p.disabled.includes(c.id), modified: false });
+    items.push({
+      id: c.id, title: c.title, body: c.body, builtin: false,
+      enabled: !p.disabled.includes(c.id), modified: false,
+      triggerKeyOverride: p.triggerKeys[c.id],
+    });
   }
   // Apply explicit order; anything not listed (new built-in / freshly added)
   // keeps its natural position at the end.
@@ -126,6 +169,9 @@ interface PromptStore {
   reorderPrompts: (from: number, to: number) => void;
   /** Re-add any built-ins the user deleted. */
   restoreBuiltins: () => void;
+  /** Manually pin a prompt's ⌘R quick-fire / palette trigger key. `key` must
+   *  be a single lowercase alphanumeric char; pass null to clear back to auto. */
+  setTriggerKey: (id: string, key: string | null) => void;
 }
 
 export const usePromptLibrary = create<PromptStore>((set) => {
@@ -199,11 +245,12 @@ export const usePromptLibrary = create<PromptStore>((set) => {
     deletePrompt: (id) => {
       const order = p.order.filter(x => x !== id);
       const disabled = p.disabled.filter(x => x !== id);
+      const triggerKeys = { ...p.triggerKeys }; delete triggerKeys[id];
       if (builtinDef(id)) {
         const overrides = { ...p.overrides }; delete overrides[id];
-        commit({ ...p, deletedBuiltins: Array.from(new Set([...p.deletedBuiltins, id])), overrides, order, disabled });
+        commit({ ...p, deletedBuiltins: Array.from(new Set([...p.deletedBuiltins, id])), overrides, order, disabled, triggerKeys });
       } else {
-        commit({ ...p, customs: p.customs.filter(c => c.id !== id), order, disabled });
+        commit({ ...p, customs: p.customs.filter(c => c.id !== id), order, disabled, triggerKeys });
       }
     },
 
@@ -229,6 +276,12 @@ export const usePromptLibrary = create<PromptStore>((set) => {
 
     restoreBuiltins: () => {
       commit({ ...p, deletedBuiltins: [] });
+    },
+
+    setTriggerKey: (id, key) => {
+      const triggerKeys = { ...p.triggerKeys };
+      if (key) triggerKeys[id] = key; else delete triggerKeys[id];
+      commit({ ...p, triggerKeys });
     },
   };
 });

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -2,6 +2,7 @@
 // triggered by opening a dialog don't churn the task tree).
 
 import { create } from "zustand";
+import type { Prompt } from "@/store/prompts";
 
 export interface ConfirmCheckbox {
   label: string;
@@ -91,6 +92,17 @@ interface UIState {
   projectPickerOpen: boolean;
   /** ⌘K command palette — searchable list of every command / action. */
   commandPaletteOpen: boolean;
+  /** ⇧⌘R prompt palette — searchable list of library prompts (title only). */
+  promptPaletteOpen: boolean;
+  /** ⌘R quick-fire armed: waiting for the follow-up trigger-key press.
+   *  Drives the transient "press a key…" hint pill. See useShortcuts.ts. */
+  promptLeaderActive: boolean;
+  /** The prompt-destination picker: "Run "<title>"" modal shared by the
+   *  Prompts dropdown, ⌘R quick-fire's no-focused-agent fallback, and the
+   *  prompt palette's fallback. `body` is a one-shot editable copy of the
+   *  prompt text for this send only — doesn't touch the saved library entry.
+   *  null = closed. */
+  promptFire: { prompt: Prompt; body: string } | null;
   /** Fire-and-forget "start inline-rename on this task row" signal.
    *  The sidebar's TaskRow watches the nonce and, when the taskId
    *  matches, flips its own local rename state (the same thing the row's
@@ -157,6 +169,14 @@ interface UIState {
   closeProjectPicker: () => void;
   openCommandPalette: () => void;
   closeCommandPalette: () => void;
+  openPromptPalette: () => void;
+  closePromptPalette: () => void;
+  openPromptLeader: () => void;
+  closePromptLeader: () => void;
+  /** Open the destination picker for `prompt`, seeding the editable body. */
+  openPromptFire: (prompt: Prompt) => void;
+  closePromptFire: () => void;
+  setPromptFireBody: (body: string) => void;
   /** Ask the sidebar to start inline-renaming `taskId`. */
   requestTaskRename: (taskId: string) => void;
   openFindInFiles: (taskId: string) => void;
@@ -231,6 +251,9 @@ export const useUI = create<UIState>(set => ({
   findInFilesTaskId: null,
   projectPickerOpen: false,
   commandPaletteOpen: false,
+  promptPaletteOpen: false,
+  promptLeaderActive: false,
+  promptFire: null,
   renameRequest: null,
   busyMessage: null,
   fileTreeNonce: 0,
@@ -270,6 +293,13 @@ export const useUI = create<UIState>(set => ({
   closeProjectPicker:() => set({ projectPickerOpen: false }),
   openCommandPalette: () => set({ commandPaletteOpen: true }),
   closeCommandPalette:() => set({ commandPaletteOpen: false }),
+  openPromptPalette: () => set({ promptPaletteOpen: true }),
+  closePromptPalette:() => set({ promptPaletteOpen: false }),
+  openPromptLeader:  () => set({ promptLeaderActive: true }),
+  closePromptLeader: () => set({ promptLeaderActive: false }),
+  openPromptFire:    (prompt) => set({ promptFire: { prompt, body: prompt.body } }),
+  closePromptFire:   () => set({ promptFire: null }),
+  setPromptFireBody: (body) => set(s => (s.promptFire ? { promptFire: { ...s.promptFire, body } } : s)),
   requestTaskRename: (taskId) => set(s => ({
     renameRequest: { taskId, nonce: (s.renameRequest?.nonce ?? 0) + 1 },
   })),


### PR DESCRIPTION


https://github.com/user-attachments/assets/c40904b2-22e8-4470-a96d-c335139bd6d4



## Summary
- Add per-prompt keyboard shortcuts: a leader-key sequence (R, then a
  letter/number) fires a saved prompt directly into the focused agent,
  or opens a destination picker when it can't auto-resolve one.
- Add a quick-fire command palette (Shift+Cmd+R) for browsing and firing
  prompts without memorizing their assigned key.
- Shortcut keys can be overridden per-prompt in Settings > Prompt Library;
  unassigned prompts auto-fill free 1-9/a-z slots, stable across
  enable/disable toggles.

Fixes #80

## Test plan
- [x] `npm test` (vitest): 145/145 passing
- [x] `npx tsc -b`: clean
- [x] Manual: press leader key + assigned key with an agent focused,
      confirm prompt fires into that agent
- [x] Manual: fire a prompt with no live agent focused, confirm the
      destination dialog appears and picks correctly
- [x] Manual: open the palette (Shift+Cmd+R), fire a prompt by search
- [x] Manual: assign/clear an override key in Settings > Prompt Library,
      confirm it persists across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)