### PR TITLE
fix: reveal markdown directory links in the file tree, not Finder (#72)

### DIFF
--- a/src/components/task/MarkdownPreview.tsx
+++ b/src/components/task/MarkdownPreview.tsx
@@ -774,13 +774,13 @@ export function MarkdownPreview(
   // (and blow away the app), so preventDefault runs before any early return.
   // External links go to the OS opener, #fragments scroll the preview, and
   // task-relative links are stat'd first — a missing target shows a
-  // toast instead of opening a dead tab, a directory reveals in the file
-  // manager instead of trying to open as text — before opening the target
-  // file in a tab (markdown targets land in MarkdownPane via TaskView
-  // routing); a `file.md#heading` fragment rides along as the new tab's
-  // revealHeading, but only for a markdown target — a non-markdown tab has
-  // no MarkdownPane to ever consume it. Targets an editor can't render
-  // (images, archives) reveal in the OS file manager instead.
+  // toast instead of opening a dead tab, a directory focuses/expands in the
+  // sidebar file tree (GitHub-style folder view, not a jump to Finder) —
+  // before opening the target file in a tab (markdown targets land in
+  // MarkdownPane via TaskView routing); a `file.md#heading` fragment rides
+  // along as the new tab's revealHeading, but only for a markdown target — a
+  // non-markdown tab has no MarkdownPane to ever consume it. Targets an editor
+  // can't render (images, archives) reveal in the OS file manager instead.
   async function onClick(e: React.MouseEvent) {
     const a = (e.target as HTMLElement).closest("a");
     if (!a) return;
@@ -811,7 +811,17 @@ export function MarkdownPreview(
       useUI.getState().pushToast(`File not found: ${resolved}`, "error");
       return;
     }
-    if (stat.is_dir || BINARY_LINK_RE.test(resolved)) {
+    if (stat.is_dir) {
+      // GitHub renders a folder listing for a directory link; mirror that by
+      // focusing/expanding the target in the sidebar file tree instead of
+      // punting out to Finder. `resolved` is already task-root-relative (and
+      // resolveTaskHref guarantees it's contained), so it's exactly the path
+      // space the tree keys on — the same one the breadcrumb reveal uses.
+      useApp.getState().revealInTree(ctx.taskId, resolved, true);
+      return;
+    }
+    if (BINARY_LINK_RE.test(resolved)) {
+      // Editor can't render images/archives — reveal in the OS file manager.
       taskRevealPath(ctx.taskId, resolved)
         .catch(err => useUI.getState().pushToast(`Couldn't reveal ${resolved}: ${err}`, "error"));
       return;


### PR DESCRIPTION
Closes #72.

## Problem

A link in the markdown preview that resolves to a **directory** (e.g. `[some-project](some-project/)`) revealed the folder in Finder, jumping the reader out of the app mid-README, while sibling links to actual files open in a tab right there. GitHub instead renders a folder-listing page for the same link.

## Fix

Redirect the `is_dir` branch in `MarkdownPreview.onClick` to `revealInTree(taskId, resolved, true)` instead of `taskRevealPath`. That store action already:

- un-hides the right panel and switches it to the **All files** view,
- expands the target directory's ancestors (and the dir itself, since `isDir` is supported),
- scrolls to and briefly highlights it.

It's the same reveal the editor breadcrumb's folder segments use (`TaskView.tsx`), so behavior is consistent app-wide.

`resolved` from `resolveTaskHref` is already **task-root-relative** and containment-checked (root-escaping paths return `null`), so it's exactly the path space the tree keys on. Member files resolve to `<member_dir>/rest`, which is just a subfolder in the wrapper tree, so multi-repo works with no special casing.

Binary files (images, archives) that the editor can't render **still** reveal in the OS file manager, unchanged.

## Test plan

- Open a README whose links point to a subfolder (trailing slash) in the markdown preview.
- Click a directory link, confirm the sidebar file tree focuses/expands the folder in-app instead of opening Finder.
- Click a file link, confirm it still opens in an editor tab.
- Click an image/archive link, confirm it still reveals in Finder.

`tsc -b` clean. No CHANGELOG entry (maintainer-authored at release time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x3kbDKdUAfbCKeWhBnmJw