### PR TITLE
Preserve the session on a failed resume instead of discarding it

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -379,6 +379,12 @@ pub struct PersistedTab {
     /// clobbers a freshly minted session.
     #[serde(default)]
     pub session_id: Option<String>,
+    /// The uuid a resume attempt just failed on, stashed here instead of
+    /// discarded so the user can one-click recover it. A transient
+    /// `--resume` fast-exit would otherwise lose the conversation for good
+    /// even though its transcript still exists on disk.
+    #[serde(default)]
+    pub previous_session_id: Option<String>,
     /// Leaf ID of the split pane this tab belongs to (None for main panel tabs).
     #[serde(default)]
     pub pane_leaf_id: Option<String>,
@@ -407,6 +413,8 @@ pub struct PersistedTabInput {
     pub command: Option<String>,
     #[serde(default)]
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub previous_session_id: Option<String>,
     #[serde(default)]
     pub pane_leaf_id: Option<String>,
     #[serde(default)]
@@ -3232,27 +3240,32 @@ fn task_set_resume_override(id: String, command: String) -> Result<Task, String>
 fn task_set_tabs(id: String, tabs: Vec<PersistedTabInput>) -> Result<(), String> {
     let mut list = load_tasks();
     let w = list.iter_mut().find(|w| w.id == id).ok_or("no such task")?;
-    // Carry forward each surviving tab's session uuid by id.
-    let prior: std::collections::HashMap<String, Option<String>> = w
+    // Carry forward each surviving tab's session uuids by id (both the live
+    // uuid and the stashed previous one, owned by the dedicated commands).
+    let prior: std::collections::HashMap<String, (Option<String>, Option<String>)> = w
         .persisted_tabs
         .iter()
-        .map(|t| (t.id.clone(), t.session_id.clone()))
+        .map(|t| (t.id.clone(), (t.session_id.clone(), t.previous_session_id.clone())))
         .collect();
     let next: Vec<PersistedTab> = tabs
         .into_iter()
-        .map(|t| PersistedTab {
-            // Stored uuid wins; only fall back to the payload's session_id
-            // for a tab we've never seen (migrating a legacy per-cli uuid
-            // onto the default tab on its first persist).
-            session_id: prior.get(&t.id).cloned().flatten().or(t.session_id),
-            id: t.id,
-            cli: t.cli,
-            title: t.title,
-            custom_title: t.custom_title,
-            is_default: t.is_default,
-            command: t.command,
-            pane_leaf_id: t.pane_leaf_id,
-            run_member: t.run_member,
+        .map(|t| {
+            let p = prior.get(&t.id).cloned().unwrap_or((None, None));
+            PersistedTab {
+                // Stored uuid wins; only fall back to the payload's session_id
+                // for a tab we've never seen (migrating a legacy per-cli uuid
+                // onto the default tab on its first persist).
+                session_id: p.0.or(t.session_id),
+                previous_session_id: p.1.or(t.previous_session_id),
+                id: t.id,
+                cli: t.cli,
+                title: t.title,
+                custom_title: t.custom_title,
+                is_default: t.is_default,
+                command: t.command,
+                pane_leaf_id: t.pane_leaf_id,
+                run_member: t.run_member,
+            }
         })
         .collect();
     // No-op when nothing actually changed (compare the serialized shape;
@@ -3267,6 +3280,7 @@ fn task_set_tabs(id: String, tabs: Vec<PersistedTabInput>) -> Result<(), String>
                 && a.is_default == b.is_default
                 && a.command == b.command
                 && a.session_id == b.session_id
+                && a.previous_session_id == b.previous_session_id
                 && a.pane_leaf_id == b.pane_leaf_id
                 && a.run_member == b.run_member
         });
@@ -3304,6 +3318,27 @@ fn task_set_tab_session_id(id: String, tab_id: String, uuid: String) -> Result<(
     Ok(())
 }
 
+/// Stash (or clear) the session uuid a resume attempt just failed on, so a
+/// transient `--resume` fast-exit is recoverable instead of permanently
+/// lost. Mirrors `task_set_tab_session_id`; an empty uuid clears the slot
+/// (the user dismissed the offer, or the recover succeeded).
+#[tauri::command]
+fn task_set_tab_previous_session_id(id: String, tab_id: String, uuid: String) -> Result<(), String> {
+    let mut list = load_tasks();
+    let w = list.iter_mut().find(|w| w.id == id).ok_or("no such task")?;
+    let tab = match w.persisted_tabs.iter_mut().find(|t| t.id == tab_id) {
+        Some(t) => t,
+        None => return Ok(()),
+    };
+    let next = if uuid.is_empty() { None } else { Some(uuid) };
+    if tab.previous_session_id == next {
+        return Ok(());
+    }
+    tab.previous_session_id = next;
+    save_task(w).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 /// Persist the JSON-encoded SplitTree for a task so the split layout
 /// can be restored on the next relaunch. Pass `None` to clear (no splits).
 #[tauri::command]
@@ -3325,23 +3360,27 @@ fn task_set_split_layout(id: String, layout: Option<String>) -> Result<(), Strin
 fn task_set_right_tabs(id: String, tabs: Vec<PersistedTabInput>) -> Result<(), String> {
     let mut list = load_tasks();
     let w = list.iter_mut().find(|w| w.id == id).ok_or("no such task")?;
-    let prior: std::collections::HashMap<String, Option<String>> = w
+    let prior: std::collections::HashMap<String, (Option<String>, Option<String>)> = w
         .right_split_tabs
         .iter()
-        .map(|t| (t.id.clone(), t.session_id.clone()))
+        .map(|t| (t.id.clone(), (t.session_id.clone(), t.previous_session_id.clone())))
         .collect();
     let next: Vec<PersistedTab> = tabs
         .into_iter()
-        .map(|t| PersistedTab {
-            session_id: prior.get(&t.id).cloned().flatten().or(t.session_id),
-            id: t.id,
-            cli: t.cli,
-            title: t.title,
-            custom_title: t.custom_title,
-            is_default: t.is_default,
-            command: t.command,
-            pane_leaf_id: None,
-            run_member: None,
+        .map(|t| {
+            let p = prior.get(&t.id).cloned().unwrap_or((None, None));
+            PersistedTab {
+                session_id: p.0.or(t.session_id),
+                previous_session_id: p.1.or(t.previous_session_id),
+                id: t.id,
+                cli: t.cli,
+                title: t.title,
+                custom_title: t.custom_title,
+                is_default: t.is_default,
+                command: t.command,
+                pane_leaf_id: None,
+                run_member: None,
+            }
         })
         .collect();
     let same = next.len() == w.right_split_tabs.len()
@@ -3353,6 +3392,7 @@ fn task_set_right_tabs(id: String, tabs: Vec<PersistedTabInput>) -> Result<(), S
                 && a.is_default == b.is_default
                 && a.command == b.command
                 && a.session_id == b.session_id
+                && a.previous_session_id == b.previous_session_id
         });
     if same {
         return Ok(());
@@ -8305,7 +8345,7 @@ pub fn run() {
             repo_config_load, repo_config_load_at, repo_config_save, repo_config_scaffold, repo_config_add_allowed_host, repo_config_add_allowed_path,
 
             task_restore, task_delete, task_run_script, task_run_script_stream, task_stop_script, task_record_spawn, task_set_has_history, task_set_agent_session_id,
-            task_set_tabs, task_set_tab_session_id,
+            task_set_tabs, task_set_tab_session_id, task_set_tab_previous_session_id,
             task_set_split_layout,
             task_set_right_tabs, task_set_right_tab_session_id,
             task_grep_start, task_grep_cancel,

--- a/src/components/task/TerminalPane.tsx
+++ b/src/components/task/TerminalPane.tsx
@@ -1379,10 +1379,13 @@ const captureArmedRef = useRef(false);
             // task prop refreshes.
             failedResumeRef.current = true;
             if (decision.kind === "resume-id") {
-              // This tab's stored uuid no longer resolves to a live session
-              // (deleted, rotated, …). Drop it (per-tab); the immediate
-              // retry mints a fresh one. setTabSessionId clears both the
-              // in-memory tab and disk.
+              // This tab's stored uuid didn't resolve on this spawn. Don't
+              // discard it — the failure may be transient (the session's
+              // transcript still exists on disk), and nuking the pointer
+              // turns that into permanent conversation loss. Stash it as the
+              // tab's previous session so the recover banner can offer it,
+              // then clear the live slot so the immediate retry mints fresh.
+              if (storedUuid) useApp.getState().setTabPreviousSessionId(task.id, tab.id, storedUuid);
               useApp.getState().setTabSessionId(task.id, tab.id, "");
             } else if (!useIdResume) {
               // Worktree rapid-exit on `--continue` = "no conversation"
@@ -1897,6 +1900,37 @@ const captureArmedRef = useRef(false);
             icon: X,
             onAction: () => useApp.getState().closeTab(task.id, tab.id),
           } : undefined}
+        />
+      )}
+      {!exited && tab.previousSessionId && (
+        // A --resume attempt fast-exited and we fell back to a fresh session;
+        // the old session id was stashed, not discarded, so offer to recover
+        // it. In-flow (like the exited banner) so it pushes the live terminal
+        // down instead of covering it.
+        <TerminalExitedBanner
+          label="Couldn't resume your previous session."
+          actionLabel="Resume it"
+          tone="warning"
+          onAction={() => {
+            const live = useApp.getState().tabs[task.id]?.find(t => t.id === tab.id) as
+              import("@/lib/types").TerminalTab | undefined;
+            const prev = live?.previousSessionId;
+            if (!prev) return;
+            // Promote the stashed uuid back to the live slot and clear the
+            // offer, then respawn: reset the fail flag + bump gen so the spawn
+            // effect re-reads the uuid live and resumes it via --resume.
+            useApp.getState().setTabSessionId(task.id, tab.id, prev);
+            useApp.getState().setTabPreviousSessionId(task.id, tab.id, "");
+            failedResumeRef.current = false;
+            setExited(false);
+            setGen(g => g + 1);
+          }}
+          secondary={{
+            label: "Dismiss",
+            title: "Keep the new session and forget the previous one",
+            icon: X,
+            onAction: () => useApp.getState().setTabPreviousSessionId(task.id, tab.id, ""),
+          }}
         />
       )}
       <div ref={hostRef} className="min-h-0 flex-1 bg-[var(--color-bg)]" />

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -277,6 +277,9 @@ export const taskSetTabs = (id: string, tabs: import("@/lib/types").PersistedTab
  *  Keyed by tab id so several agents in a task resume independently. */
 export const taskSetTabSessionId = (id: string, tabId: string, uuid: string) =>
   invoke<void>("task_set_tab_session_id", { id, tabId, uuid });
+
+export const taskSetTabPreviousSessionId = (id: string, tabId: string, uuid: string) =>
+  invoke<void>("task_set_tab_previous_session_id", { id, tabId, uuid });
 /** Persist the JSON-encoded SplitTree for a task. Pass null to clear. */
 export const taskSetSplitLayout = (id: string, layout: string | null) =>
   invoke<void>("task_set_split_layout", { id, layout });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -233,6 +233,10 @@ export interface PersistedTab {
    *  (claude / gemini). Null for cwd-resume agents (codex) and tabs that
    *  have not minted a session yet. Owned by `taskSetTabSessionId`. */
   session_id?: string | null;
+  /** The uuid a `--resume` attempt just fast-exited on, stashed here
+   *  (instead of discarded) so it can be one-click recovered. Owned by
+   *  `taskSetTabPreviousSessionId`. */
+  previous_session_id?: string | null;
   /** Leaf ID of the split pane this tab belongs to (absent for main panel tabs). */
   pane_leaf_id?: string | null;
   /** Run pop-out tab marker (GH #54): the member dir ("" = host project)
@@ -576,8 +580,14 @@ export interface TerminalTab extends BaseTab {
    *  launch and minted on first spawn otherwise. Distinct per tab so two
    *  agents in one task resume independently — the primary tab is no
    *  longer the only resumable one. Cleared (undefined) when a resume
-   *  attempt rapid-exits (the stored session no longer resolves). */
+   *  attempt rapid-exits (the stored session no longer resolves — the old
+   *  uuid moves to `previousSessionId` for recovery). */
   sessionId?: string;
+  /** The uuid a `--resume` just fast-exited on, stashed instead of thrown
+   *  away so the user can one-click recover it (a transient failure would
+   *  otherwise lose the conversation permanently). Drives the recover
+   *  banner in TerminalPane. Restored from `persisted_tabs` on launch. */
+  previousSessionId?: string;
   /** iTerm2-style work-progress state. Authoritative signals: OSC 9;4
    *  (Claude progress), OSC 133;C/D (FinalTerm semantic prompts), OSC 0
    *  title classifier (gemini/codex). `working` → spinner; `done` →

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -246,6 +246,9 @@ export interface AppState {
    *  to disk. Keyed by tab id so agents in one task resume
    *  independently. */
   setTabSessionId: (taskId: string, tabId: string, uuid: string) => void;
+  /** Stash (or clear, with "") the uuid a `--resume` just fast-exited on, so
+   *  a transient failure is one-click recoverable instead of lost. */
+  setTabPreviousSessionId: (taskId: string, tabId: string, uuid: string) => void;
   /** Mirror a just-persisted custom launch command into the in-memory
    *  task AND any open custom-command tabs so the next PTY respawn
    *  runs the new script (the disk write alone doesn't refresh either). */
@@ -388,6 +391,7 @@ function durablePersistedTabs(tabs: Tab[] | undefined): PersistedTab[] {
       is_default: !!t.is_default,
       command: t.command ?? null,
       session_id: t.sessionId ?? null,
+      previous_session_id: t.previousSessionId ?? null,
       pane_leaf_id: t.paneId ?? null,
       // Run pop-out tabs persist WITH their marker so the RunPane comes back
       // in its pane on relaunch (the run script re-fires, like custom tabs).
@@ -1331,6 +1335,7 @@ export const useApp = create<AppState>((set, get) => ({
         is_default: !!pt.is_default,
         ...(pt.command ? { command: pt.command } : {}),
         ...(pt.session_id ? { sessionId: pt.session_id } : {}),
+        ...(pt.previous_session_id ? { previousSessionId: pt.previous_session_id } : {}),
         // idle: restored run tabs keep their spot but never auto-fire the
         // script — the user presses play (RunPane placeholder / pill).
         ...(pt.run_member != null ? { runTab: { member: pt.run_member, previewUrl: null, idle: true } } : {}),
@@ -1357,6 +1362,7 @@ export const useApp = create<AppState>((set, get) => ({
               paneId: pt.pane_leaf_id!,
               ...(pt.command ? { command: pt.command } : {}),
               ...(pt.session_id ? { sessionId: pt.session_id } : {}),
+        ...(pt.previous_session_id ? { previousSessionId: pt.previous_session_id } : {}),
               ...(pt.run_member != null ? { runTab: { member: pt.run_member, previewUrl: null, idle: true } } : {}),
             });
           }
@@ -1496,6 +1502,29 @@ export const useApp = create<AppState>((set, get) => ({
       };
     });
     ipc.taskSetTabSessionId(taskId, tabId, uuid).catch(() => {});
+  },
+
+  setTabPreviousSessionId: (taskId, tabId, uuid) => {
+    const val = uuid || undefined;
+    set(s => {
+      const list = s.tabs[taskId];
+      const nextTabs = list
+        ? list.map(t => (t.id === tabId && t.type === "terminal" ? { ...t, previousSessionId: val } as Tab : t))
+        : list;
+      const taskUpdate = {
+        tasks: s.tasks.map(w => w.id !== taskId ? w : {
+          ...w,
+          persisted_tabs: (w.persisted_tabs ?? []).map(pt =>
+            pt.id === tabId ? { ...pt, previous_session_id: uuid || null } : pt,
+          ),
+        }),
+      };
+      return {
+        ...(nextTabs ? { tabs: { ...s.tabs, [taskId]: nextTabs } } : {}),
+        ...taskUpdate,
+      };
+    });
+    ipc.taskSetTabPreviousSessionId(taskId, tabId, uuid).catch(() => {});
   },
 
   setTaskYolo: (taskId, yolo) => set(s => ({

--- a/src/store/resume.integration.test.ts
+++ b/src/store/resume.integration.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/ipc", () => ({
   ptyKill: vi.fn().mockResolvedValue(undefined),
   taskSetTabs: vi.fn().mockResolvedValue(undefined),
   taskSetTabSessionId: vi.fn().mockResolvedValue(undefined),
+  taskSetTabPreviousSessionId: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("@/lib/tabFocus", () => ({ focusTerminalTab: vi.fn() }));
 
@@ -173,5 +174,66 @@ describe("worktree main agent resumes across a restart", () => {
 
     useApp.getState().ensureDefaultTab("ws1", "claude");
     expect(argvFor(firstTab(), useApp.getState().tasks[0])).toEqual(["--resume", U, "--name", "seo-improvements"]);
+  });
+});
+
+describe("a fast-exit resume preserves the session and can recover it", () => {
+  it("stashes the uuid to previous, survives a restart, and recover resumes it", () => {
+    const U = "1b02e805-5b4d-482c-927b-b62b9b1c68d8";
+    useApp.setState({ tasks: [makeTask({ is_main_checkout: true })] });
+    useApp.getState().ensureDefaultTab("ws1", "claude");
+    const tab = firstTab();
+
+    // First spawn mints a session that survives.
+    useApp.getState().setTabSessionId("ws1", tab.id, U);
+    expect(firstTab().sessionId).toBe(U);
+
+    // A later --resume fast-exits → TerminalPane stashes then clears (the fix).
+    useApp.getState().setTabPreviousSessionId("ws1", tab.id, U);
+    useApp.getState().setTabSessionId("ws1", tab.id, "");
+    expect(firstTab().sessionId).toBeUndefined();
+    expect(firstTab().previousSessionId).toBe(U);
+
+    // The fallback fresh mint replaces the live slot; previous stays.
+    const NEW = "9f9f9f9f-0000-4000-8000-000000000000";
+    useApp.getState().setTabSessionId("ws1", tab.id, NEW);
+    expect(firstTab().sessionId).toBe(NEW);
+    expect(firstTab().previousSessionId).toBe(U);
+
+    // Both ids round-trip into persisted_tabs.
+    const persisted = useApp.getState().tasks[0].persisted_tabs!;
+    expect(persisted[0].session_id).toBe(NEW);
+    expect(persisted[0].previous_session_id).toBe(U);
+
+    // Simulate a restart: reload from disk, tabs empty again.
+    const reloaded = makeTask({ is_main_checkout: true, persisted_tabs: persisted });
+    useApp.setState({ tasks: [reloaded], tabs: {}, activeTab: {} });
+    useApp.getState().ensureDefaultTab("ws1", "claude");
+    const restored = firstTab();
+    expect(restored.sessionId).toBe(NEW);
+    // The recovery pointer survived the restart — this is the whole point.
+    expect(restored.previousSessionId).toBe(U);
+
+    // Recover: promote previous back to live, clear the offer.
+    useApp.getState().setTabSessionId("ws1", restored.id, U);
+    useApp.getState().setTabPreviousSessionId("ws1", restored.id, "");
+    expect(firstTab().sessionId).toBe(U);
+    expect(firstTab().previousSessionId).toBeUndefined();
+    // decideResume now resumes the recovered session by id.
+    expect(argvFor(firstTab(), useApp.getState().tasks[0])).toEqual(["--resume", U, "--name", "seo-improvements"]);
+  });
+
+  it("dismiss clears the previous pointer and leaves the live session alone", () => {
+    const U = "old-uuid", NEW = "new-uuid";
+    useApp.setState({ tasks: [makeTask({ is_main_checkout: true })] });
+    useApp.getState().ensureDefaultTab("ws1", "claude");
+    const tab = firstTab();
+    useApp.getState().setTabSessionId("ws1", tab.id, NEW);
+    useApp.getState().setTabPreviousSessionId("ws1", tab.id, U);
+    expect(firstTab().previousSessionId).toBe(U);
+
+    useApp.getState().setTabPreviousSessionId("ws1", tab.id, "");
+    expect(firstTab().previousSessionId).toBeUndefined();
+    expect(firstTab().sessionId).toBe(NEW);
   });
 });


### PR DESCRIPTION
### Problem

When a tab's `--resume {uuid}` spawn fast-exits (under `RESUME_FAILURE_MS`), `TerminalPane` treats the stored session as gone: it clears the tab's `session_id` and respawns fresh. But a fast-exit is not always "the session is gone" - a transient failure (a momentary CLI hiccup, a briefly-locked session, a cold-start error) fast-exits the same way. When that happens the stored uuid is discarded permanently, so the conversation can never be resumed again even though its transcript still exists on disk. The user silently lands on a brand-new session with no way back.

### Fix

On a fast-exit `resume-id` failure, stash the uuid into a new per-tab `previous_session_id` instead of discarding it, then respawn fresh exactly as before (the happy path is unchanged). A non-blocking banner - "Couldn't resume your previous session · Resume it · Dismiss" - offers one-click recovery: it promotes the stashed uuid back to the live slot and respawns via `--resume`. `previous_session_id` is persisted (carried through `task_set_tabs` / `task_set_right_tabs` by tab id, like `session_id`) so it survives an app restart, and is cleared on dismiss or a successful recovery.

### Changes
- `PersistedTab` / `TerminalTab`: new `previous_session_id` / `previousSessionId`.
- New `task_set_tab_previous_session_id` command; the field is preserved across layout rewrites in both tab writers.
- Store: `setTabPreviousSessionId`, hydration, and the stash/promote wiring.
- `TerminalPane`: stash-instead-of-discard at the fast-exit branch, plus the recover banner (reusing `TerminalExitedBanner`).

### Tests
Extends `resume.integration.test.ts` with the stash -> persist -> restart -> recover round-trip (resumes by `--resume {uuid}` after a simulated restart) and the dismiss path. Full suite green; `tsc -b` and `cargo check` clean on this branch.
