### PR TITLE
feat: per-theme palette shades for group folder colors

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -60,7 +60,7 @@ never shadow the built-in Claude theme.
     "accent": "#c4a7e7", "accent-soft": "rgba(196,167,231,0.22)", "accent-deep": "#6f5b9e",
     "accent-fg": "#232136",
     "ok": "#9ccfd8", "ok-fg": "#232136", "warn": "#f6c177", "err": "#eb6f92",
-    "palette-red": "#eb6f92", "palette-orange": "#ea9a97", "palette-yellow": "#f6c177",
+    "palette-red": "#eb6f92", "palette-orange": "#e89f6f", "palette-yellow": "#f6c177",
     "palette-green": "#97c9a3", "palette-teal": "#9ccfd8", "palette-blue": "#3e8fb0",
     "palette-purple": "#c4a7e7", "palette-pink": "#d8a0c9"
   },

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -59,7 +59,10 @@ never shadow the built-in Claude theme.
     "hover": "rgba(224,222,244,0.05)", "sel": "rgba(196,167,231,0.22)",
     "accent": "#c4a7e7", "accent-soft": "rgba(196,167,231,0.22)", "accent-deep": "#6f5b9e",
     "accent-fg": "#232136",
-    "ok": "#9ccfd8", "ok-fg": "#232136", "warn": "#f6c177", "err": "#eb6f92"
+    "ok": "#9ccfd8", "ok-fg": "#232136", "warn": "#f6c177", "err": "#eb6f92",
+    "palette-red": "#eb6f92", "palette-orange": "#ea9a97", "palette-yellow": "#f6c177",
+    "palette-green": "#97c9a3", "palette-teal": "#9ccfd8", "palette-blue": "#3e8fb0",
+    "palette-purple": "#c4a7e7", "palette-pink": "#d8a0c9"
   },
   "terminal": {
     "background": "#232136", "foreground": "#e0def4",
@@ -112,6 +115,7 @@ just `bg` and `accent` and still look coherent.
 | `ok-fg` | ink on a solid `ok` fill (toggle knobs). Defaults to white |
 | `warn` | warning yellow |
 | `err` | error red |
+| `palette-red` … `palette-pink` | hue-named accent ramp for user-assigned marks (today: project-group folder colors). 8 keys: `palette-red`, `palette-orange`, `palette-yellow`, `palette-green`, `palette-teal`, `palette-blue`, `palette-purple`, `palette-pink`. Tune shades to your theme, but keep each hue recognizable: users pick colors by name and expect "red" to stay red across themes |
 
 The `--color-cli-*` agent tint variables are not themeable in v1; they keep
 their defaults.

--- a/src-tauri/assets/themes/example.json.sample
+++ b/src-tauri/assets/themes/example.json.sample
@@ -22,7 +22,7 @@
     "warn": "#f6c177",
     "err": "#eb6f92",
     "palette-red": "#eb6f92",
-    "palette-orange": "#ea9a97",
+    "palette-orange": "#e89f6f",
     "palette-yellow": "#f6c177",
     "palette-green": "#97c9a3",
     "palette-teal": "#9ccfd8",

--- a/src-tauri/assets/themes/example.json.sample
+++ b/src-tauri/assets/themes/example.json.sample
@@ -20,7 +20,15 @@
     "ok": "#9ccfd8",
     "ok-fg": "#232136",
     "warn": "#f6c177",
-    "err": "#eb6f92"
+    "err": "#eb6f92",
+    "palette-red": "#eb6f92",
+    "palette-orange": "#ea9a97",
+    "palette-yellow": "#f6c177",
+    "palette-green": "#97c9a3",
+    "palette-teal": "#9ccfd8",
+    "palette-blue": "#3e8fb0",
+    "palette-purple": "#c4a7e7",
+    "palette-pink": "#d8a0c9"
   },
   "terminal": {
     "background": "#232136",

--- a/src/index.css
+++ b/src/index.css
@@ -368,9 +368,12 @@
     --color-err:         #eb6f92;       /* love */
     /* Palette ramp from the canon palette: love/rose/gold/foam/pine/iris.
        Rosé Pine has no true green, so green is a muted moss tuned to sit
-       in-family; pink is an iris–love blend to stay distinct from red. */
+       in-family; pink is an iris–love blend to stay distinct from red.
+       Orange is NOT canon rose (#ea9a97): rose sits at hue 2°, i.e. red,
+       so a folder marked "orange" rendered salmon and crowded love. This
+       is rose warmed toward gold, in-family but an actual orange. */
     --color-palette-red:    #eb6f92;    /* love */
-    --color-palette-orange: #ea9a97;    /* rose */
+    --color-palette-orange: #e89f6f;    /* rose, warmed toward gold */
     --color-palette-yellow: #f6c177;    /* gold */
     --color-palette-green:  #97c9a3;
     --color-palette-teal:   #9ccfd8;    /* foam */

--- a/src/index.css
+++ b/src/index.css
@@ -72,10 +72,11 @@
 
   /* Palette ramp: hue-named accents for user-assigned identity marks
      (project-group folders today; the user's pick is stored by hue key,
-     e.g. "red"). One fixed set for every theme in v1 (the light palette
-     re-tunes shades for contrast on cream). If themes ever define their
-     own ramp, the contract is: tune SHADE, keep each hue recognizable,
-     never collapse the ramp — the marks are user data, not decoration. */
+     e.g. "red"). Hue identity is the contract — a theme tunes SHADE to
+     its palette but must keep each hue recognizable, and should never
+     collapse the ramp (the marks are user data, not decoration). Every
+     built-in theme overrides all 8; these defaults serve Dark+ and any
+     custom theme that omits the keys. */
   --color-palette-red:    #e5484d;
   --color-palette-orange: #f76b15;
   --color-palette-yellow: #ffb224;
@@ -206,6 +207,16 @@
     --color-accent:      #d97757;       /* terax `primary` */
     --color-accent-soft: rgba(217, 119, 87, 0.22);
     --color-accent-deep: #b35e3f;
+    /* Palette ramp: warm-shifted + slightly muted to sit with the
+       charcoal/terracotta chrome. */
+    --color-palette-red:    #e0605e;
+    --color-palette-orange: #e08d52;
+    --color-palette-yellow: #dcae4a;
+    --color-palette-green:  #78a865;
+    --color-palette-teal:   #4fae9e;
+    --color-palette-blue:   #6da8e0;
+    --color-palette-purple: #a685d6;
+    --color-palette-pink:   #d179ad;
     color-scheme: dark;
   }
 
@@ -239,6 +250,17 @@
        a deep azure that still reads cobalt-family. */
     --color-accent-deep: #1f6fa8;
     --color-accent-fg:   #193549;   /* navy ink on the sky accent (white was ~1.9:1) */
+    /* Palette ramp: Cobalt 2's own syntax colors (they're vivid by
+       design and read cleanly on the navy surfaces); teal toned down
+       from the canon cyan #80fcff, which is too hot for a UI mark. */
+    --color-palette-red:    #ff628c;
+    --color-palette-orange: #ff9d00;
+    --color-palette-yellow: #ffc600;
+    --color-palette-green:  #3ad900;
+    --color-palette-teal:   #2ee5d4;
+    --color-palette-blue:   #3c9dff;
+    --color-palette-purple: #b361ff;
+    --color-palette-pink:   #fb94ff;
     color-scheme: dark;
   }
 
@@ -264,6 +286,18 @@
     --color-accent-soft: rgba(63, 185, 80, 0.20);
     --color-accent-deep: #2a7a36;       /* deeper phosphor for button surfaces */
     --color-accent-fg:   #050905;       /* near-black ink on phosphor green (white was ~2.5:1) */
+    /* Palette ramp: desaturated a step so the phosphor green stays the
+       loudest thing on screen — but every hue KEEPS its identity (nine
+       shades of green would be on-brand and would erase the user's
+       marks; see the @theme note). Green maps to the accent itself. */
+    --color-palette-red:    #d9544f;
+    --color-palette-orange: #d9824f;
+    --color-palette-yellow: #cfc04a;
+    --color-palette-green:  #3fb950;
+    --color-palette-teal:   #3fb9a0;
+    --color-palette-blue:   #4f9dd9;
+    --color-palette-purple: #9d7fd9;
+    --color-palette-pink:   #d96fae;
     color-scheme: dark;
   }
 
@@ -286,6 +320,16 @@
     --color-accent:      #cb4b16;       /* solarized orange */
     --color-accent-soft: rgba(203, 75, 22, 0.22);
     --color-accent-deep: #9d3a11;       /* deeper solarized orange for buttons */
+    /* Palette ramp: Solarized's canon accent set, mapped by hue
+       (teal ← cyan, purple ← violet, pink ← magenta). */
+    --color-palette-red:    #dc322f;
+    --color-palette-orange: #cb4b16;
+    --color-palette-yellow: #b58900;
+    --color-palette-green:  #859900;
+    --color-palette-teal:   #2aa198;
+    --color-palette-blue:   #268bd2;
+    --color-palette-purple: #6c71c4;
+    --color-palette-pink:   #d33682;
     color-scheme: dark;
   }
 
@@ -322,6 +366,17 @@
                                            light --color-ok in the app */
     --color-warn:        #f6c177;       /* gold */
     --color-err:         #eb6f92;       /* love */
+    /* Palette ramp from the canon palette: love/rose/gold/foam/pine/iris.
+       Rosé Pine has no true green, so green is a muted moss tuned to sit
+       in-family; pink is an iris–love blend to stay distinct from red. */
+    --color-palette-red:    #eb6f92;    /* love */
+    --color-palette-orange: #ea9a97;    /* rose */
+    --color-palette-yellow: #f6c177;    /* gold */
+    --color-palette-green:  #97c9a3;
+    --color-palette-teal:   #9ccfd8;    /* foam */
+    --color-palette-blue:   #5896b4;    /* pine, lifted a step for the dark base */
+    --color-palette-purple: #c4a7e7;    /* iris */
+    --color-palette-pink:   #d8a0c9;
     color-scheme: dark;
   }
   ::-webkit-scrollbar { width: 10px; height: 10px; }

--- a/src/lib/customTheme.ts
+++ b/src/lib/customTheme.ts
@@ -47,6 +47,11 @@ export const UI_KEYS = [
   "hover", "sel",
   "accent", "accent-soft", "accent-deep", "accent-fg",
   "ok", "ok-fg", "warn", "err",
+  // Palette ramp: hue-named accents for user-assigned marks (project-group
+  // folders consume it). Optional like everything else — omitted keys keep
+  // the built-in hues. Tune shades to your theme but keep hues recognizable.
+  "palette-red", "palette-orange", "palette-yellow", "palette-green",
+  "palette-teal", "palette-blue", "palette-purple", "palette-pink",
 ] as const;
 
 /** xterm ITheme color keys (see TERMINAL_THEMES in store/prefs.ts). */


### PR DESCRIPTION
Follow-up to #84 (project groups). Split out deliberately so the folder feature and the theme-system change could be reviewed separately.

## What

The group folder colors introduced in #84 use one fixed set of 8 hues for every theme. This PR makes the ramp theme-tunable:

- Every built-in theme now defines the 8 `--color-palette-*` tokens in its own visual language:
  - **Claude/Dark**: warm-shifted, slightly muted set that sits with the charcoal + terracotta chrome
  - **Cobalt**: Cobalt 2's own syntax colors (`#ffc600` yellow, `#3ad900` green, ...), with teal toned down from the canon cyan which is too hot for a UI mark
  - **Matrix**: desaturated one step so the phosphor green stays the loudest thing on screen; green maps to the accent itself
  - **Solarized**: the canon accent set mapped by hue (teal from cyan, purple from violet, pink from magenta)
  - **Rose Pine**: love/rose/gold/foam/pine/iris; green is a muted moss (the palette has no true green), pine lifted a step so blue reads on the dark base
  - Dark+ keeps the `@theme` defaults; Light keeps the darker high-contrast set from #84
- Custom theme files can override the same 8 keys (`palette-red` ... `palette-pink`) via the existing `ui` allowlist, falling back per-key to the built-in hues like every other key. Documented in `docs/themes.md` and exercised by the seeded `example.json.sample`.

## The contract

Hue identity is fixed; themes tune shade. A user who marks a folder "red" expects red-ish in every theme (the stored value is the hue key, and the marks are user data, not decoration), so a theme should never remap or collapse hues. This is stated in the `@theme` comment, the `UI_KEYS` comment, and the theme-author docs. The tempting matrix move (nine shades of phosphor green) is called out explicitly as the thing not to do.

## Why this shape

This is also groundwork for spaces accent colors discussed in #76: the ramp is a theme-level primitive any future user-assigned mark (space accents, labels) can consume, not a folder-specific table.

## Security notes

New keys ride the existing hardened pipeline unchanged: key names come from the fixed allowlist (never from the file), values pass the `isValidColor` regex (hex / rgb / hsl shapes only, no `url()` / `var()` / breakout chars) and land in `style.setProperty`, and apply/clear iterate the full allowlist so switching themes cannot leave a stale var.

## Notes

These shades are judgment calls and easy to revisit. Not every theme has a true match for every hue, so some are in-family approximations, e.g. Rosé Pine's "orange" is the canon rose, which leans pink but fits the theme and stays distinct from red and pink. The bar I held: recognizable by name, all 8 mutually distinct.

## Testing

- `make check-all` clean, vitest 258/258 (the sample/allowlist parity tests cover the new keys), production build passes

## Screenshots:
<img width="398" height="70" alt="Screenshot 2026-07-13 at 9 16 41 AM" src="https://github.com/user-attachments/assets/a9ad3210-e551-474d-84d0-aa46f8b463e2" />
<img width="325" height="68" alt="Screenshot 2026-07-13 at 9 16 33 AM" src="https://github.com/user-attachments/assets/0b8fbe60-3a7d-43e5-8d19-b5c1dfdddad7" />
<img width="353" height="80" alt="Screenshot 2026-07-13 at 9 16 23 AM" src="https://github.com/user-attachments/assets/342c4b87-a265-4167-8a9b-6870991ac3c8" />
<img width="371" height="78" alt="Screenshot 2026-07-13 at 9 16 10 AM" src="https://github.com/user-attachments/assets/db2a205d-27c5-4c16-a298-f46df1e41580" />

## Sample Custom Theme:

``` JSON
{
  "name": "Rosé Pine Moon",
  "colorScheme": "dark",
  "ui": {
    "bg": "#232136", "bg-1": "#2a273f", "bg-2": "#393552", "bg-3": "#44415a",
    "fg": "#e0def4", "fg-dim": "#908caa", "fg-faint": "#6e6a86",
    "border": "#56526e", "border-soft": "#393552",
    "hover": "rgba(224,222,244,0.05)", "sel": "rgba(196,167,231,0.22)",
    "accent": "#c4a7e7", "accent-soft": "rgba(196,167,231,0.22)", "accent-deep": "#6f5b9e",
    "accent-fg": "#232136",
    "ok": "#9ccfd8", "warn": "#f6c177", "err": "#eb6f92",
    "palette-red": "#eb6f92", "palette-orange": "#ea9a97", "palette-yellow": "#f6c177",
    "palette-green": "#97c9a3", "palette-teal": "#9ccfd8", "palette-blue": "#3e8fb0",
    "palette-purple": "#c4a7e7", "palette-pink": "#d8a0c9"
  },
  "terminal": {
    "background": "#232136", "foreground": "#e0def4",
    "cursor": "#c4a7e7", "cursorAccent": "#232136", "selectionBackground": "#44415a",
    "black": "#393552", "red": "#eb6f92", "green": "#3e8fb0", "yellow": "#f6c177",
    "blue": "#9ccfd8", "magenta": "#c4a7e7", "cyan": "#ea9a97", "white": "#e0def4",
    "brightBlack": "#6e6a86", "brightRed": "#eb6f92", "brightGreen": "#3e8fb0",
    "brightYellow": "#f6c177", "brightBlue": "#9ccfd8", "brightMagenta": "#c4a7e7",
    "brightCyan": "#ea9a97", "brightWhite": "#e0def4"
  }
}
```

