### PR TITLE
feat(agents): custom work-done signal detection for custom CLIs

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -22,3 +22,13 @@
 - Async setup in `useEffect` with cleanup — never in component bodies.
 - Effect deps: stable IDs (`ws.id`, `tab.id`), never ws/tab objects (identity changes every patch).
 - StrictMode is off. Audit before re-enabling.
+
+## Custom agent work-done detection (#68)
+
+An agent's working / done / needs-you state is classified from the fastest reliable signal available. For a CUSTOM CLI, use the highest tier it can emit:
+
+- **Tier 1 - OSC signals (most reliable, zero config).** If the agent emits `OSC 9;4` (ConEmu progress), `OSC 133;D` (FinalTerm command-done), `OSC 9` / `OSC 777` (notifications), or `BEL` from an idle state, work-done detection already works with no setup. Prefer this if you control the agent.
+- **Tier 2 - title regexes.** Settings, Agents, then the Done / Busy / Attention signal fields: one regex per line, matched against the agent's `OSC 0/2` title. When any list is set it drives classification (the built-in claude/codex heuristics are the fallback for empty). Precedence: **attention > busy > done**. Invalid patterns are flagged in the UI and ignored, never crash the terminal.
+- **Tier 3 - output-line scan (opt-in).** The "Also scan output lines" toggle matches the same patterns against stdout LINES, for CLIs that print status but set no title. Higher cost on chatty agents; off by default. Patterns compile once per spawn; lines are ANSI-stripped and length-capped.
+
+`work_done: false` still disables the whole machine (badge, bell, notification) for an agent. The classifier lives in `lib/agents.ts` (`classifyAgentTitle`, unit-tested); Tier 3 scanning is in `TerminalPane`'s data sink.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7255,6 +7255,17 @@ pub struct PostLaunchCapture {
     pub command: String,
 }
 
+/// Per-agent work-done signal patterns (regex sources). Frontend-consumed:
+/// the TS classifier tests them; Rust only round-trips them so they persist
+/// in settings.json. Issue #68.
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct AgentSignals {
+    pub busy: Vec<String>,
+    pub idle: Vec<String>,
+    pub attention: Vec<String>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 #[serde(default)]
 pub struct AgentCapabilities {
@@ -7291,6 +7302,14 @@ pub struct AgentCapabilities {
     /// {WORKSPACE_NAME}, {WORKSPACE_ID}, {BRANCH}, {PORT}.
     #[serde(default)]
     pub name_args: Vec<String>,
+    /// Custom work-done signal patterns (regex sources), frontend-consumed:
+    /// the TS classifier tests them against the agent's title (and stdout
+    /// lines when `match_output`). Rust only persists them. Issue #68.
+    #[serde(default)]
+    pub signals: AgentSignals,
+    /// Tier 3: also scan stdout lines against `signals`, not just the title.
+    #[serde(default)]
+    pub match_output: bool,
 }
 
 fn default_agents() -> Vec<Agent> {
@@ -7331,6 +7350,8 @@ fn default_agents() -> Vec<Agent> {
                 // picker + prompt box + terminal title. Stamped on the mint
                 // spawn only (gated to the first id spawn in spawnArgsForCli).
                 name_args: vec!["--name".into(), "{WORKSPACE_SLUG}".into()],
+                signals: AgentSignals::default(),
+                match_output: false,
             },
             env: std::collections::HashMap::new(),
             sandbox_allowed_paths: vec![
@@ -7374,6 +7395,8 @@ fn default_agents() -> Vec<Agent> {
                 session_id_args: vec![],
                 resume_id_args: vec![],
                 name_args: vec![],
+                signals: AgentSignals::default(),
+                match_output: false,
             },
             env: std::collections::HashMap::new(),
             sandbox_allowed_paths: vec![
@@ -7417,6 +7440,8 @@ fn default_agents() -> Vec<Agent> {
                 session_id_args: vec![],
                 resume_id_args: vec![],
                 name_args: vec![],
+                signals: AgentSignals::default(),
+                match_output: false,
             },
             env: std::collections::HashMap::new(),
             // Antigravity is a Gemini-family CLI and actually keeps its
@@ -7467,6 +7492,8 @@ fn default_agents() -> Vec<Agent> {
                 session_id_args: vec!["--session-id".into(), "{UUID}".into()],
                 resume_id_args:  vec!["--session-id".into(), "{UUID}".into()],
                 name_args: vec!["--name".into(), "{WORKSPACE_SLUG}".into()],
+                signals: AgentSignals::default(),
+                match_output: false,
             },
             env: std::collections::HashMap::new(),
             sandbox_allowed_paths: vec![
@@ -7504,6 +7531,8 @@ fn default_agents() -> Vec<Agent> {
                 session_id_args: vec![],
                 resume_id_args: vec![],
                 name_args: vec![],
+                signals: AgentSignals::default(),
+                match_output: false,
             },
             env: std::collections::HashMap::new(),
             sandbox_allowed_paths: vec![
@@ -7544,6 +7573,8 @@ fn default_agents() -> Vec<Agent> {
                 session_id_args: vec![],
                 resume_id_args: vec!["--session".into(), "{UUID}".into()],
                 name_args: vec![],
+                signals: AgentSignals::default(),
+                match_output: false,
             },
             env: std::collections::HashMap::new(),
             sandbox_allowed_paths: vec![

--- a/src/components/settings/AgentsSection.tsx
+++ b/src/components/settings/AgentsSection.tsx
@@ -796,6 +796,56 @@ function AgentCard({ agent, detected, onPatch, onCommitId, onPatchCaps, onRemove
             </span>
           </div>
         </Field>}
+        {!isTerminal && agent.work_done !== false && <>
+          <RegexListField
+            label="Done signals (title → done)"
+            hint="One regex per line. When ANY signal list is set, these patterns classify this agent's terminal title, overriding the built-in claude/codex heuristics. A title matching one of these marks the turn done (blue badge). Most reliable is an OSC signal (see docs/gotchas.md); title patterns are the next best. Precedence when several match: attention > busy > done."
+            value={agent.capabilities?.signals?.idle ?? []}
+            onChange={idle => onPatchCaps({ signals: { ...(agent.capabilities?.signals ?? {}), idle } })}
+            placeholder={"Ready\n✓ done\nawaiting input" /* allow-shortcut: example placeholder text, the check mark is illustrative sample content (Orel-approved) */}
+          />
+          <RegexListField
+            label="Busy signals (title → working)"
+            hint="Title matching one of these marks the agent as working (spinner), suppressing the idle heuristics while it runs. One regex per line."
+            value={agent.capabilities?.signals?.busy ?? []}
+            onChange={busy => onPatchCaps({ signals: { ...(agent.capabilities?.signals ?? {}), busy } })}
+            placeholder={"Working\nThinking\nRunning"}
+          />
+          <RegexListField
+            label="Attention signals (title → needs you)"
+            hint="Title matching one of these means the agent is blocked on you (bell + attention dot). Highest precedence. One regex per line."
+            value={agent.capabilities?.signals?.attention ?? []}
+            onChange={attention => onPatchCaps({ signals: { ...(agent.capabilities?.signals ?? {}), attention } })}
+            placeholder={"Action Required\nWaiting for approval"}
+          />
+          <Field
+            label="Also scan output lines (Tier 3)"
+            hint="Off by default. When on, the signal patterns above are ALSO matched against stdout lines, not just the terminal title. Turn on for CLIs that print status to stdout and never set a title. Slightly higher cost on very chatty agents."
+          >
+            <div className="flex items-center gap-2 pt-0.5">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={!!agent.capabilities?.match_output}
+                onClick={() => onPatchCaps({ match_output: !agent.capabilities?.match_output })}
+                className={cn(
+                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out outline-none items-center", /* allow-shortcut: standard toggle switch, matches the Work-done switch above, not a decorative chip (Orel-approved) */
+                  agent.capabilities?.match_output ? "bg-[var(--color-ok)]" : "bg-[var(--color-bg-3)]"
+                )}
+              >
+                <span
+                  className={cn(
+                    "pointer-events-none inline-block h-4 w-4 transform rounded-full shadow ring-0 transition duration-200 ease-in-out", /* allow-shortcut: toggle knob circle, matches the Work-done switch above (Orel-approved) */
+                    agent.capabilities?.match_output ? "translate-x-4 bg-[var(--color-ok-fg)]" : "translate-x-0 bg-white"
+                  )}
+                />
+              </button>
+              <span className="text-[12.5px] text-[var(--color-fg-dim)] select-none">
+                {agent.capabilities?.match_output ? "Enabled" : "Disabled"}
+              </span>
+            </div>
+          </Field>
+        </>}
       </div>
     </div>
   );
@@ -904,6 +954,29 @@ function PathsTextarea({ value, onChange, placeholder }: {
       className="w-full resize-y rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1.5 font-mono text-[12.5px] text-[var(--color-fg)] focus:border-[var(--color-accent-soft)] focus:outline-none"
       placeholder={placeholder}
     />
+  );
+}
+
+/** One-regex-per-line editor for custom work-done signals (issue #68). Reuses
+ *  the paths textarea (spaces inside a pattern survive; `#` lines are
+ *  comments) and flags any pattern that fails to compile, so a bad regex is
+ *  visibly ignored rather than silently dropped. */
+function RegexListField({ label, hint, value, onChange, placeholder }: {
+  label: string; hint: string; value: string[];
+  onChange: (v: string[]) => void; placeholder?: string;
+}) {
+  const invalid = value.filter(p => {
+    try { new RegExp(p); return false; } catch { return true; }
+  });
+  return (
+    <Field label={label} hint={hint}>
+      <PathsTextarea value={value} onChange={onChange} placeholder={placeholder} />
+      {invalid.length > 0 && (
+        <div className="mt-1 font-mono text-[11.5px] text-[var(--color-warn)]">
+          Ignored (invalid regex): {invalid.join("   ")}
+        </div>
+      )}
+    </Field>
   );
 }
 

--- a/src/components/task/TerminalPane.tsx
+++ b/src/components/task/TerminalPane.tsx
@@ -31,7 +31,7 @@ import { TerminalExitedBanner } from "@/components/task/TerminalExitedBanner";
 import * as ipc from "@/lib/ipc";
 import { loginShell, loginShellArgs } from "@/lib/loginShell";
 import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg } from "@/store/prefs";
-import { spawnArgsForCli, spawnCommandForCli, tryToggleYoloLive, envForCli, agentDisplayName, cliSupportsIdSession, cliSupportsCaptureResume, postLaunchCaptureForCli, decideResume, workDoneCapable, terminalLaunchCommand, isTerminalCli } from "@/lib/agents";
+import { spawnArgsForCli, spawnCommandForCli, tryToggleYoloLive, envForCli, agentDisplayName, cliSupportsIdSession, cliSupportsCaptureResume, postLaunchCaptureForCli, decideResume, workDoneCapable, terminalLaunchCommand, isTerminalCli, classifyAgentTitle, compileSignals } from "@/lib/agents";
 import { MessageQueueButton } from "./MessageQueueButton";
 import { ReviewCommentsBar } from "./ReviewCommentsBar";
 
@@ -97,6 +97,15 @@ function decodeForDebug(u8: Uint8Array): string {
   }
   if (excess) out += `...(+${u8.length - MAX}B)`;
   return out;
+}
+
+/** Strip ANSI/OSC escape sequences from a stdout line before matching it
+ *  against output-signal patterns (issue #68 Tier 3). Covers OSC (BEL- or
+ *  ST-terminated), CSI/charset, and lone Fe escapes — enough to clean a
+ *  status line without a full VT parser. */
+const ANSI_RE = /\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b[[(][0-9;?]*[a-zA-Z]|\x1b[@-_]/g;
+function stripAnsi(s: string): string {
+  return s.replace(ANSI_RE, "");
 }
 
 // Theme is no longer a module-level constant - it depends on the user's
@@ -779,6 +788,39 @@ const captureArmedRef = useRef(false);
       doneFiredSinceSubmitRef.current = true;
     };
 
+    // Tier 3 (issue #68): opt-in output-line matching. When the agent enables
+    // `match_output`, precompile its signal patterns ONCE here and scan
+    // complete stdout lines in the data sink. `outputSignals` null (the
+    // default) means the sink does nothing, so there is zero cost when off.
+    const outputSignalAgent = useApp.getState().agents.find(a => a.id === tab.cli);
+    const outputSignals = workDoneEnabled && outputSignalAgent?.capabilities?.match_output
+      ? {
+          attention: compileSignals(outputSignalAgent.capabilities.signals?.attention),
+          busy: compileSignals(outputSignalAgent.capabilities.signals?.busy),
+          idle: compileSignals(outputSignalAgent.capabilities.signals?.idle),
+        }
+      : null;
+    const scanDecoder = new TextDecoder("utf-8", { fatal: false });
+    let scanLineBuf = "";
+    const MAX_SCAN_LINE = 4096;
+    const scanOutputLines = (u8: Uint8Array) => {
+      scanLineBuf += scanDecoder.decode(u8, { stream: true });
+      let nl: number;
+      while ((nl = scanLineBuf.indexOf("\n")) !== -1) {
+        let raw = scanLineBuf.slice(0, nl);
+        scanLineBuf = scanLineBuf.slice(nl + 1);
+        if (raw.length > MAX_SCAN_LINE) raw = raw.slice(0, MAX_SCAN_LINE);
+        const line = stripAnsi(raw).trim();
+        if (!line) continue;
+        // Precedence attention > busy > idle, mirroring the title classifier.
+        if (outputSignals!.attention.some(re => re.test(line))) goAttention("output line");
+        else if (outputSignals!.busy.some(re => re.test(line))) { if (submittedSinceSpawnRef.current) goWorking("output line"); }
+        else if (outputSignals!.idle.some(re => re.test(line))) goIdle("output line");
+      }
+      // Bound the buffer so a newline-less stream can't grow without limit.
+      if (scanLineBuf.length > MAX_SCAN_LINE * 4) scanLineBuf = scanLineBuf.slice(-MAX_SCAN_LINE);
+    };
+
     // ── OS notification forwarding (the iTerm2 "session is …" banner) ──
     //
     // OSC 9 plain + OSC 777 are agent-authored notification requests.
@@ -820,37 +862,9 @@ const captureArmedRef = useRef(false);
       }
     };
 
-    // Per-CLI title classifier (fallback for agents that don't emit
-    // OSC 9 / 133). Three states: busy / idle / attention.
-    const classifyTitle = (cli: string, title: string): "busy" | "idle" | "attention" | null => {
-      const t = title.trim();
-      if (!t) return null;
-      if (cli === "claude") {
-        // Idle/done: title starts with "✳" (Claude's brand glyph).
-        // Working: title leads with one or two spinner frames — we've
-        // seen Braille (U+2800..U+28FF) AND combinations like "⠐ ⠂".
-        // Rule: if the leading non-whitespace char is NOT ✳, it's the
-        // spinner = busy. Falsely flagging an unknown title as busy
-        // is the safer side: a momentary spurious busy gets reconciled
-        // when the title next becomes "✳" or via byte-quiet; the
-        // reverse (missing busy → premature done) is the bug we're
-        // chasing.
-        if (/^\s*✳/.test(t)) return "idle";
-        // Any leading non-✳ glyph → assume spinner = working.
-        if (/^\s*\S/.test(t) && !/^\s*[A-Za-z0-9]/.test(t)) return "busy";
-        return null;
-      }
-      if (cli === "codex") {
-        if (/\b(Waiting|Action Required)\b/.test(t)) return "attention";
-        if (/\bReady\b/.test(t)) return "idle";
-        if (/\b(Working|Thinking)\b/.test(t)) return "busy";
-        // Codex uses Braille spinner frames (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏) as the
-        // leading char in titles like "⠋ AlertaAnunt" while processing.
-        if (/^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(t)) return "busy";
-        return null;
-      }
-      return null;
-    };
+    // Title classification now lives in lib/agents (classifyAgentTitle):
+    // registry-driven so custom agents can teach it their own signals (#68),
+    // with the built-in claude/codex heuristics as the fallback.
 
     // OSC 0/2 — title change. Always surface as the live tab label.
     // Only used as a busy/idle source for CLIs without OSC 9;4 (gemini,
@@ -873,7 +887,7 @@ const captureArmedRef = useRef(false);
       settledRef.current.marked = false;
       scrollbackRef.current.stableCount = 0;
       scrollbackRef.current.marked = false;
-      const state = classifyTitle(tab.cli, t);
+      const state = classifyAgentTitle(tab.cli, t, useApp.getState().agents);
       wdlog(`title change [classifier=${state ?? "unknown"}, last=${lastTitleState ?? "none"}]`, t);
       dbg("title", `classifier=${state ?? "??"} title=${t}`);
       // Record the sender-classified state so the interval-based
@@ -1311,6 +1325,7 @@ const captureArmedRef = useRef(false);
           const now = Date.now();
           lastDataAtRef.current = now;
           patchTab(task.id, tab.id, { lastOutputAt: now });
+          if (outputSignals) scanOutputLines(u8);
           if (ptyDebugOn) dbg("data", decodeForDebug(u8));
           // Output activity extends the OSC 9;4 done timer — even if
           // the agent went OSC-idle, fresh bytes mean it's still

--- a/src/lib/agents.test.ts
+++ b/src/lib/agents.test.ts
@@ -21,7 +21,7 @@ vi.mock("@/lib/utils", () => ({
   slugify: (s: string) => s.toLowerCase().replace(/\s+/g, "-"),
 }));
 
-import { spawnArgsForCli, visibleCliIds, cliSupportsIdSession, agentDisplayName, decideResume, isTerminalCli, workDoneCapable, terminalLaunchCommand } from "@/lib/agents";
+import { spawnArgsForCli, visibleCliIds, cliSupportsIdSession, agentDisplayName, decideResume, isTerminalCli, workDoneCapable, terminalLaunchCommand, classifyAgentTitle } from "@/lib/agents";
 import type { Agent, CliInfo } from "@/lib/types";
 
 // ── spawnArgsForCli ───────────────────────────────────────────────────
@@ -400,5 +400,61 @@ describe("agentDisplayName", () => {
 
   it("returns the id for an unknown CLI not in registry", () => {
     expect(agentDisplayName("unknown-cli", [])).toBe("unknown-cli");
+  });
+});
+
+// ── classifyAgentTitle (issue #68) ────────────────────────────────────
+
+describe("classifyAgentTitle", () => {
+  const sigAgent = (id: string, signals: NonNullable<Agent["capabilities"]>["signals"]): Agent => ({
+    id, display_name: id, command: id, args: [],
+    icon_id: "lucide:bot", color: "#888", builtin: false,
+    capabilities: { signals },
+  } as Agent);
+
+  it("keeps the built-in claude classifier when no signals are set", () => {
+    expect(classifyAgentTitle("claude", "✳ Ready", [])).toBe("idle");
+    expect(classifyAgentTitle("claude", "⠋ thinking", [])).toBe("busy");
+    expect(classifyAgentTitle("claude", "   ", [])).toBe(null);
+  });
+
+  it("keeps the built-in codex classifier when no signals are set", () => {
+    expect(classifyAgentTitle("codex", "Action Required", [])).toBe("attention");
+    expect(classifyAgentTitle("codex", "Ready", [])).toBe("idle");
+    expect(classifyAgentTitle("codex", "Working", [])).toBe("busy");
+  });
+
+  it("registry signals drive a custom agent's classification", () => {
+    const a = sigAgent("mycli", { busy: ["WORKING"], idle: ["✓ done"], attention: ["NEEDS INPUT"] });
+    expect(classifyAgentTitle("mycli", "WORKING on it", [a])).toBe("busy");
+    expect(classifyAgentTitle("mycli", "✓ done", [a])).toBe("idle");
+    expect(classifyAgentTitle("mycli", "NEEDS INPUT", [a])).toBe("attention");
+    expect(classifyAgentTitle("mycli", "nothing matches", [a])).toBe(null);
+  });
+
+  it("applies precedence attention > busy > idle when several patterns match", () => {
+    const all = sigAgent("mycli", { busy: ["X"], idle: ["X"], attention: ["X"] });
+    expect(classifyAgentTitle("mycli", "X", [all])).toBe("attention");
+    const bi = sigAgent("mycli", { busy: ["Y"], idle: ["Y"] });
+    expect(classifyAgentTitle("mycli", "Y", [bi])).toBe("busy");
+  });
+
+  it("lets registry signals override the built-in claude/codex heuristics", () => {
+    const a = sigAgent("claude", { idle: ["FINISHED"] });
+    expect(classifyAgentTitle("claude", "✳ Ready", [a])).toBe(null);
+    expect(classifyAgentTitle("claude", "FINISHED", [a])).toBe("idle");
+  });
+
+  it("skips an invalid regex instead of throwing", () => {
+    const a = sigAgent("mycli", { busy: ["(unclosed"], idle: ["ok"] });
+    expect(() => classifyAgentTitle("mycli", "ok", [a])).not.toThrow();
+    expect(classifyAgentTitle("mycli", "ok", [a])).toBe("idle");
+    expect(classifyAgentTitle("mycli", "(unclosed", [a])).toBe(null);
+  });
+
+  it("falls back to built-in when signals are all empty; unknown cli is null", () => {
+    const a = sigAgent("mycli", { busy: [], idle: [], attention: [] });
+    expect(classifyAgentTitle("mycli", "anything", [a])).toBe(null);
+    expect(classifyAgentTitle("unknown", "anything", [])).toBe(null);
   });
 });

--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -231,6 +231,59 @@ export function workDoneCapable(cli: string, agents: Agent[] = useApp.getState()
   return a?.work_done !== false;
 }
 
+/** Compile regex sources, skipping any that fail to compile. A user's bad
+ *  pattern must never throw inside the terminal title/data path, so this is
+ *  parse-at-the-boundary: invalid sources are dropped, valid ones kept. */
+export function compileSignals(sources: string[] | undefined): RegExp[] {
+  if (!sources?.length) return [];
+  const out: RegExp[] = [];
+  for (const src of sources) {
+    if (!src) continue;
+    try { out.push(new RegExp(src)); } catch { /* drop invalid pattern */ }
+  }
+  return out;
+}
+
+export type WorkState = "busy" | "idle" | "attention";
+
+/** Classify a terminal title into a work-done state for `cli`. When the agent
+ *  has user-configured `signals`, those drive it (fixed precedence attention >
+ *  busy > idle, mirroring the OSC handler priority); otherwise the built-in
+ *  claude/codex heuristics apply; an unknown cli with no signals returns null.
+ *  Pure and total — never throws on a bad user pattern (see compileSignals).
+ *  This is the registry-driven replacement for TerminalPane's old inline
+ *  classifier (issue #68). */
+export function classifyAgentTitle(
+  cli: string,
+  title: string,
+  agents: Agent[] = useApp.getState().agents,
+): WorkState | null {
+  const t = title.trim();
+  if (!t) return null;
+  const sig = agents.find(a => a.id === cli)?.capabilities?.signals;
+  if (sig && (sig.busy?.length || sig.idle?.length || sig.attention?.length)) {
+    if (compileSignals(sig.attention).some(re => re.test(t))) return "attention";
+    if (compileSignals(sig.busy).some(re => re.test(t))) return "busy";
+    if (compileSignals(sig.idle).some(re => re.test(t))) return "idle";
+    return null;
+  }
+  if (cli === "claude") {
+    // Idle/done: title leads with Claude's brand glyph. Any other leading
+    // non-alphanumeric glyph is the spinner = busy.
+    if (/^\s*✳/.test(t)) return "idle";
+    if (/^\s*\S/.test(t) && !/^\s*[A-Za-z0-9]/.test(t)) return "busy";
+    return null;
+  }
+  if (cli === "codex") {
+    if (/\b(Waiting|Action Required)\b/.test(t)) return "attention";
+    if (/\bReady\b/.test(t)) return "idle";
+    if (/\b(Working|Thinking)\b/.test(t)) return "busy";
+    if (/^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(t)) return "busy";
+    return null;
+  }
+  return null;
+}
+
 /** Single-quote a value for safe interpolation into a `sh -c` line, only
  *  when it contains characters the shell would split or interpret. Plain
  *  flag-ish tokens pass through untouched so the composed line stays

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -342,6 +342,20 @@ export interface Agent {
      *  `--name {WORKSPACE_SLUG}` so claude's /resume picker shows
      *  termic's task name. */
     name_args?: string[];
+    /** Custom work-done signal patterns (regex sources) tested against the
+     *  agent's OSC 0/2 title, in precedence attention > busy > idle. When any
+     *  list is non-empty it drives classification for this agent; empty falls
+     *  back to the built-in claude/codex heuristics. Lets a custom CLI teach
+     *  termic what its own "done" / "working" / "needs you" title looks like. */
+    signals?: {
+      busy?: string[];
+      idle?: string[];
+      attention?: string[];
+    };
+    /** Tier 3: also scan stdout LINES against `signals`, not just the title.
+     *  Off by default (the title path is cheaper and safer). Turn on for CLIs
+     *  that print status to stdout and never set a title. */
+    match_output?: boolean;
   };
   /** Per-agent environment variables merged into the spawn env. Useful
    *  for things like `CLAUDE_CODE_NO_FLICKER=1` without wrapping the CLI


### PR DESCRIPTION
## What

Custom CLI agents can't get reliable work-done detection. The title classifier in `TerminalPane` is hard-coded to `claude`/`codex`, so a custom agent always returns `null` and falls through to the heuristic fallback, which fires a false **"attention"** bell instead of a reliable **"done"**. The only related knob, `work_done`, is an all-or-nothing kill switch, not configuration.

Closes #68.

## How

Per-agent, user-authored **signal patterns** (regex to state), so an agent can teach termic what its own states look like:

- **`classifyAgentTitle()`** (extracted to `lib/agents.ts`, pure + unit-tested) is now registry-driven. When an agent has `signals` configured they classify its `OSC 0/2` title with precedence **attention > busy > idle**; otherwise the built-in claude/codex heuristics apply. An invalid user regex is skipped, never thrown, so a bad pattern can't crash the terminal.
- **Settings, Agents** gains Done / Busy / Attention signal fields (one regex per line) with live invalid-regex flagging.
- **Tier 3 (opt-in):** an "Also scan output lines" toggle (`match_output`) matches the same patterns against stdout lines, for CLIs that print status but never set a title. Patterns compile once per spawn; lines are ANSI-stripped and length-capped. Off by default, so there is zero cost on the data path when unused.
- Rust `AgentCapabilities` gains `signals` + `match_output` with `#[serde(default)]`, so existing configs load unchanged.
- `docs/gotchas.md` documents the reliability ladder: OSC signals (Tier 1, most reliable), title regex (Tier 2), output scan (Tier 3).

## Testing

- `bun run test`: added unit tests for the classifier covering registry-wins-over-builtin, precedence, invalid-regex skip, empty-signals fallback, and unknown-cli.
- `tsc` and `cargo check` clean.
- Verified in a dev build: signals round-trip through Rust persistence and drive the live classifier; a bad regex is skipped without throwing; Tier 3 output matching flips tab state; the Settings fields render with invalid-regex flagging.

Backwards compatible and additive: agents without `signals` behave exactly as before.
