### PR TITLE
fix: light-theme minimumContrastRatio so CLI truecolor text stays readable (#83)

### DIFF
--- a/src/components/task/AuxTerminal.tsx
+++ b/src/components/task/AuxTerminal.tsx
@@ -25,7 +25,7 @@ import { setupImeReplacementBridge } from "@/lib/ime";
 import * as ipc from "@/lib/ipc";
 import { loginShell } from "@/lib/loginShell";
 import { TerminalExitedBanner } from "@/components/task/TerminalExitedBanner";
-import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg } from "@/store/prefs";
+import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg, currentMinimumContrastRatio } from "@/store/prefs";
 import { useApp } from "@/store/app";
 import { IS_MAC, bindingMatches } from "@/lib/shortcuts";
 
@@ -82,6 +82,8 @@ export function AuxTerminal({ taskId, taskPath, active, autoFocus, onExited, onT
       letterSpacing: usePrefs.getState().terminalLetterSpacing,
       lineHeight: 1.0,
       theme: currentTerminalTheme() as any,
+      // Light-theme truecolor readability. See TerminalPane / #83.
+      minimumContrastRatio: currentMinimumContrastRatio(),
       allowProposedApi: true,
       scrollback: Math.round(usePrefs.getState().terminalScrollback / 2),
       // Option-as-Meta for terminal editors. See TerminalPane. (issue #11)
@@ -311,6 +313,7 @@ export function AuxTerminal({ taskId, taskPath, active, autoFocus, onExited, onT
     const t = termRef.current;
     if (!t) return;
     t.options.theme = currentTerminalTheme() as any;
+    t.options.minimumContrastRatio = currentMinimumContrastRatio();
   }, [themeMode, customThemeRev]);
 
   return (

--- a/src/components/task/TerminalPane.tsx
+++ b/src/components/task/TerminalPane.tsx
@@ -30,7 +30,7 @@ import { SandboxIcon, SANDBOX_VISUALS } from "@/components/SandboxIcon";
 import { TerminalExitedBanner } from "@/components/task/TerminalExitedBanner";
 import * as ipc from "@/lib/ipc";
 import { loginShell, loginShellArgs } from "@/lib/loginShell";
-import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg } from "@/store/prefs";
+import { usePrefs, currentTerminalStack, currentTerminalTheme, currentColorFgBg, currentMinimumContrastRatio } from "@/store/prefs";
 import { spawnArgsForCli, spawnCommandForCli, tryToggleYoloLive, envForCli, agentDisplayName, cliSupportsIdSession, cliSupportsCaptureResume, postLaunchCaptureForCli, decideResume, workDoneCapable, terminalLaunchCommand, isTerminalCli } from "@/lib/agents";
 import { MessageQueueButton } from "./MessageQueueButton";
 import { ReviewCommentsBar } from "./ReviewCommentsBar";
@@ -386,6 +386,9 @@ const captureArmedRef = useRef(false);
       // band against neighbouring rows.
       lineHeight: 1.0,
       theme: currentTerminalTheme() as any,
+      // Keeps CLI truecolor text readable on a light bg — see
+      // currentMinimumContrastRatio (#83).
+      minimumContrastRatio: currentMinimumContrastRatio(),
       allowProposedApi: true,
       scrollback: usePrefs.getState().terminalScrollback,
       // Option-as-Meta for terminal editors (vim/emacs/nano). Off by default;
@@ -1662,6 +1665,7 @@ const captureArmedRef = useRef(false);
     const t = termRef.current;
     if (!t) return;
     t.options.theme = currentTerminalTheme() as any;
+    t.options.minimumContrastRatio = currentMinimumContrastRatio();
   }, [themeMode, customThemeRev]);
 
   // YOLO live toggle — for agents that support runtime mode switching (only

--- a/src/store/prefs.test.ts
+++ b/src/store/prefs.test.ts
@@ -62,3 +62,40 @@ describe("prefs: loadRemoteImages", () => {
     expect(localStorage.getItem(LS_KEY)).toBe("0");
   });
 });
+
+// #83: light themes must raise the terminal's minimumContrastRatio so CLI
+// truecolor fg (which bypasses the ANSI-16 remap) stays readable on a light
+// bg; dark themes leave it at 1 (off) so their tuned palettes are untouched.
+describe("prefs: currentMinimumContrastRatio", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", fakeLocalStorage());
+    (document as any).fonts = { load: () => Promise.resolve(), ready: Promise.resolve() };
+    vi.resetModules();
+  });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it("returns 4.5 (WCAG AA) for the light theme", async () => {
+    const { usePrefs, currentMinimumContrastRatio } = await import("./prefs");
+    usePrefs.getState().setThemeMode("light");
+    expect(currentMinimumContrastRatio()).toBe(4.5);
+  });
+
+  it("returns 1 (off) for dark-family themes", async () => {
+    const { usePrefs, currentMinimumContrastRatio } = await import("./prefs");
+    for (const mode of ["dark", "claude", "solarized", "cobalt", "matrix", "rosepine"] as const) {
+      usePrefs.getState().setThemeMode(mode);
+      expect(currentMinimumContrastRatio()).toBe(1);
+    }
+  });
+
+  it("follows a custom theme's colorScheme (light custom -> 4.5)", async () => {
+    const { usePrefs, currentMinimumContrastRatio } = await import("./prefs");
+    const custom = {
+      id: "custom:paper", name: "Paper", colorScheme: "light" as const,
+      ui: {}, terminal: {},
+    };
+    usePrefs.setState({ customThemes: [custom as any] });
+    usePrefs.getState().setThemeMode(custom.id);
+    expect(currentMinimumContrastRatio()).toBe(4.5);
+  });
+});

--- a/src/store/prefs.ts
+++ b/src/store/prefs.ts
@@ -226,6 +226,19 @@ export function currentColorFgBg(): string {
   return resolveTheme(usePrefs.getState().themeMode) === "light" ? "0;15" : "15;0";
 }
 
+/** Minimum foreground/background contrast for the terminal (xterm's
+ *  `minimumContrastRatio`). TERMINAL_THEMES only remaps the 16 indexed ANSI
+ *  colors, so a CLI TUI themed for a dark background (Claude Code, gemini,
+ *  codex) paints near-white *truecolor* fg that COLORFGBG can't redirect —
+ *  invisible on a light terminal bg (#83). xterm darkens any fg below the
+ *  ratio against its actual cell bg at paint time, which catches truecolor
+ *  too. Only light-family palettes need it (dark themes already sit on a
+ *  dark bg); 1 = off, a no-op with zero render cost. 4.5 = WCAG AA, the same
+ *  default VS Code's integrated terminal ships. */
+export function currentMinimumContrastRatio(): number {
+  return resolveTheme(usePrefs.getState().themeMode) === "light" ? 4.5 : 1;
+}
+
 // Curated list of monospace fonts we probe for. JetBrains Mono ships
 // locally via @fontsource so it's always present; the rest are detected at
 // runtime via document.fonts.check(). We don't enumerate the system font


### PR DESCRIPTION
## What

Fixes #83 — in the light theme, body text from a CLI's own truecolor UI (Claude Code's plan/question panels, gemini, codex) renders near-white and is unreadable on the light terminal background.

## Root cause

These CLIs style some text with 24-bit truecolor ANSI (`\x1b[38;2;r;g;bm`), which xterm paints as literal RGB. `TERMINAL_THEMES` only remaps the 16 indexed ANSI colors, and the `COLORFGBG` hint set on spawn can't redirect truecolor — so a tool themed for a dark background paints near-white fg that sits at ~1.05:1 contrast on the light bg (`#faf9f6`). Effectively invisible.

## Fix

Set xterm's `minimumContrastRatio` to **4.5** (WCAG AA — the same default VS Code's integrated terminal ships) for light-family themes only. xterm darkens any fg below the ratio against its *actual cell background* at paint time, so it catches truecolor too, not just the indexed palette. Dark themes stay at `1` (off), which short-circuits to a no-op with zero render cost — the tuned dark palettes are untouched.

`currentMinimumContrastRatio()` mirrors the existing `currentColorFgBg()` light/dark resolution (so custom themes follow their `colorScheme`), and is wired into both terminal constructors and both live theme-swap effects.

## Verification

- Numeric: near-white `#f5f4ee` on `#faf9f6` = 1.05:1 (invisible) → with ratio 4.5, xterm darkens it to ~`#74736d` = 4.52:1 (readable).
- Confirmed against the installed xterm 5.5 source that the WebGL renderer's shared `TextureAtlas` applies `ensureContrastRatio(bg, fg, ratio)` to the cell's resolved truecolor RGBA.
- Drove the live app: on the real xterm instance, `options.minimumContrastRatio` reads 4.5 in the light theme and 1 in dark, flipping correctly on a live theme switch.
- `tsc` clean; added a `prefs` unit test (light → 4.5, dark-family → 1, custom light theme → 4.5).
