### PR TITLE
fix(terminal): gate the WebGL attach on the font instead of clearing the atlas (#70)

### DIFF
--- a/src/lib/terminalFontReady.ts
+++ b/src/lib/terminalFontReady.ts
@@ -1,0 +1,75 @@
+// Owns the terminal's critical JetBrains Mono faces (latin 400 + 700) as
+// explicit FontFace handles so the WebGL glyph-atlas readiness gate can await
+// GENUINE rasterization readiness instead of a document.fonts status query.
+//
+// Why this exists (GH #70): xterm's WebGL atlas keys glyphs per (char,fg,bg,ext)
+// with no font in the key, so any glyph rasterized before the real face is
+// active caches at the fallback height and never corrects until an atlas
+// rebuild. The prior gate used document.fonts.check()/load() on the family
+// string. Both return a truthy "ready" for a family that is not yet REGISTERED
+// in the FontFaceSet (vacuous-true, reproduced on WKWebView: check() and load()
+// against an unregistered family return/resolve truthy with zero faces).
+// fontsource registers "JetBrains Mono" via async CSS @font-face, so that
+// vacuous window is the #70 poison window on a cold spawn.
+//
+// Public surface: `terminalFontReady` (resolves when the owned faces are
+// loaded) and `isTerminalFontReady()` (sync warm-path check).
+// NOT responsible for: cyrillic JB Mono (kept on CSS @font-face; terminals are
+// overwhelmingly latin and a rare cyrillic glyph mid-load is not the #70
+// mixed-height bug), user-selected system fonts (installed, never race).
+//
+// These duplicate the fontsource latin @font-face rules (same family, weight,
+// and woff2 URL, so the byte fetch is shared via HTTP cache). The duplication
+// is intentional and sound: xterm rasterizes glyphs through Canvas 2D, which
+// draws only with FontFaceSet faces that are actually LOADED and ignores
+// unloaded ones, so once these awaited handles are loaded the atlas rasterizes
+// against the real face regardless of the CSS faces' load state. Owning the
+// handles is the whole point: it is the only way to await genuine readiness.
+
+import url400 from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2";
+import url700 from "@fontsource/jetbrains-mono/files/jetbrains-mono-latin-700-normal.woff2";
+
+// FontFaceSet is setlike in the spec, but TS 5.7's lib.dom omits add()/delete().
+declare global {
+  interface FontFaceSet {
+    add(font: FontFace): void;
+  }
+}
+
+const FAMILY = "JetBrains Mono";
+
+const makeFace = (url: string, weight: string): FontFace =>
+  new FontFace(FAMILY, `url(${url}) format("woff2")`, {
+    weight,
+    style: "normal",
+    display: "swap", // mirror the fontsource CSS: fallback text, not invisible, while loading
+  });
+
+let ready = false;
+
+/** Resolves `true` once both owned latin faces (400 + 700) are genuinely
+ *  loaded. Resolves `false` (never rejects, never hangs) if FontFace is
+ *  unavailable or a load fails, so a font that will not load still lets the
+ *  terminal attach its GPU renderer: a consistent fallback height beats the
+ *  #70 mixed-height waves and beats a terminal stuck on the DOM renderer. */
+export const terminalFontReady: Promise<boolean> = (async () => {
+  if (typeof FontFace === "undefined" || !document.fonts) {
+    ready = true;
+    return true;
+  }
+  try {
+    const faces = [makeFace(url400, "400"), makeFace(url700, "700")];
+    faces.forEach(f => document.fonts.add(f));
+    await Promise.all(faces.map(f => f.load()));
+    ready = true;
+    return true;
+  } catch {
+    ready = true;
+    return false;
+  }
+})();
+
+/** Sync warm-path check. Backed by real FontFace handles, so unlike
+ *  document.fonts.check() it is never vacuously true before the faces exist.
+ *  True once `terminalFontReady` has settled. */
+export const isTerminalFontReady = (): boolean => ready;

--- a/src/lib/terminalRenderer.ts
+++ b/src/lib/terminalRenderer.ts
@@ -8,7 +8,8 @@
 
 import { WebglAddon } from "@xterm/addon-webgl";
 import type { Terminal } from "@xterm/xterm";
-import { usePrefs, terminalFontsSettled } from "@/store/prefs";
+import { usePrefs } from "@/store/prefs";
+import { terminalFontReady, isTerminalFontReady } from "@/lib/terminalFontReady";
 import * as ipc from "@/lib/ipc";
 
 function dumpRenderer(addon: WebglAddon | null): void {
@@ -37,24 +38,29 @@ function dumpRenderer(addon: WebglAddon | null): void {
  *  and typing crawls), the load is skipped and xterm's built-in DOM renderer
  *  remains. Read once at mount; toggling the pref takes effect on the next
  *  terminal spawn (relaunch to switch every open terminal). */
-/** GH #70: hold the first fit + PTY spawn until the terminal font's faces
- *  are active. The bundled JetBrains Mono is a lazy @font-face; if output
- *  is rasterized before it activates, xterm's WebGL atlas caches those
- *  glyphs drawn with the fallback monospace — keyed per (char, fg, bg,
- *  style), with the font only in the atlas config — so the same char keeps
- *  its wrong-height glyph until the cell happens to re-rasterize (selection
- *  changes the bg → new key → correct glyph, which is why selecting text
- *  "fixed" it). Gating the spawn means metrics AND glyphs come from the
- *  real font from the start: no post-hoc refit, no atlas churn.
+/** GH #70: the bundled JetBrains Mono is a lazy @font-face; xterm's WebGL atlas
+ *  keys glyphs per (char, fg, bg, ext) with no font in the key, so a glyph
+ *  rasterized against the fallback stays wrong-height until the cell happens to
+ *  re-rasterize (selection changes the bg, new key, correct glyph, which is why
+ *  selecting text "fixed" it).
  *
- *  prefs warms the load at module start, so this normally resolves in a
- *  microtask and adds zero spawn latency. The wait is capped so a hung
- *  load can never stall a spawn; on that (practically unreachable) path a
- *  one-shot repair runs when the face finally lands, guarded against the
- *  two hazards a late fit() has: zero-geometry hosts (collapsed split —
- *  same reason the panes' ResizeObservers bail at 0x0) and the mid-spawn
- *  window where term.onResize isn't registered yet, which would silently
- *  desync PTY cols/rows (hence the explicit ptyResize with retry). */
+ *  The previous gate polled `document.fonts` for the family, but check() and
+ *  load() both report a family READY before it is registered in the FontFaceSet
+ *  (check() returns true and load() resolves with zero faces for an unregistered
+ *  family, reproduced on WKWebView). Since fontsource registers "JetBrains Mono"
+ *  via async CSS @font-face, that vacuous window is the poison window on a cold
+ *  spawn. So correctness now comes from loadTerminalRenderer holding the WebGL
+ *  attach until `terminalFontReady` resolves: real FontFace handles we own and
+ *  await (lib/terminalFontReady). The atlas is then built against the real face
+ *  and never poisoned, so nothing is cleared under a live renderer (the
+ *  disproven #70 path). This fn is the spawn-side gate: it waits the same
+ *  promise, then RE-FITS so the PTY cols/rows match the real metrics.
+ *
+ *  Warm path (faces already loaded, the norm thanks to the boot warm-up in
+ *  main.tsx): return immediately, zero cost. The re-fit is guarded against
+ *  zero-geometry hosts (collapsed split, same reason the panes' ResizeObservers
+ *  bail at 0x0) and the mid-spawn window where term.onResize isn't registered
+ *  yet, which would silently desync PTY cols/rows (hence the ptyResize retry). */
 export async function awaitTerminalFonts(
   term: Terminal,
   fit: { fit(): void },
@@ -62,31 +68,30 @@ export async function awaitTerminalFonts(
   isCancelled: () => boolean,
   ptyId: () => string | null,
 ): Promise<void> {
-  let ready = false;
-  await Promise.race([
-    terminalFontsSettled().then(() => { ready = true; }),
-    new Promise<void>(r => window.setTimeout(r, 800)),
-  ]);
-  if (ready || isCancelled()) return;
-  terminalFontsSettled().then(() => {
-    if (isCancelled()) return;
-    try { term.clearTextureAtlas(); } catch {}
-    if (host.offsetWidth === 0 || host.offsetHeight === 0) return;
-    try { fit.fit(); } catch {}
-    let tries = 20;
-    const push = () => {
-      if (isCancelled() || tries-- <= 0) return;
-      const pid = ptyId();
-      if (pid) ipc.ptyResize(pid, term.rows, term.cols).catch(() => {});
-      else window.setTimeout(push, 250);
-    };
-    push();
-  });
+  if (isTerminalFontReady()) return;
+  await terminalFontReady;
+  if (isCancelled()) return;
+  // Faces are genuinely loaded now, so cols/rows measured against the fallback
+  // are stale: re-fit. No clearTextureAtlas (the WebGL renderer only attached
+  // once the faces were loaded, so the atlas was never poisoned).
+  if (host.offsetWidth === 0 || host.offsetHeight === 0) return;
+  try { fit.fit(); } catch {}
+  let tries = 20;
+  const push = () => {
+    if (isCancelled() || tries-- <= 0) return;
+    const pid = ptyId();
+    if (pid) ipc.ptyResize(pid, term.rows, term.cols).catch(() => {});
+    else window.setTimeout(push, 250);
+  };
+  push();
 }
 
 export function loadTerminalRenderer(term: Terminal): { dispose(): void } {
   let addon: WebglAddon | null = null;
-  if (usePrefs.getState().terminalGpuEnabled) {
+  let disposed = false;
+
+  const attach = () => {
+    if (disposed || addon || !usePrefs.getState().terminalGpuEnabled) return;
     try {
       const a = new WebglAddon();
       a.onContextLoss(() => a.dispose());
@@ -95,6 +100,20 @@ export function loadTerminalRenderer(term: Terminal): { dispose(): void } {
     } catch {
       addon = null;  // WebGL unsupported → xterm's DOM renderer remains
     }
+  };
+
+  // GH #70: hold the FIRST attach until the owned faces are genuinely loaded
+  // (terminalFontReady is real FontFace handles, not document.fonts.check(),
+  // which is vacuously true before the family is registered). The addon then
+  // builds its glyph atlas against the real face instead of caching
+  // fallback-height glyphs that never correct, so nothing is ever cleared under
+  // a live renderer. xterm's DOM renderer covers the gap. GPU-off and warm-face
+  // attach right away; a face that never loads still resolves terminalFontReady
+  // and gets GPU (consistent fallback, not the mixed-height "waves").
+  if (isTerminalFontReady() || !usePrefs.getState().terminalGpuEnabled) {
+    attach();
+  } else {
+    terminalFontReady.then(() => { if (!disposed && !addon) attach(); });
   }
 
   // TEMP diagnostic. Auto-dumps the launch state; the global lets the
@@ -105,6 +124,7 @@ export function loadTerminalRenderer(term: Terminal): { dispose(): void } {
 
   return {
     dispose() {
+      disposed = true;
       dumpTimers.forEach(t => window.clearTimeout(t));
       try { addon?.dispose(); } catch { /* already gone */ }
     },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,10 @@
 import "@/lib/lsMigration";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+// GH #70: register + start loading the terminal's owned JetBrains Mono faces at
+// boot so the WebGL glyph-atlas gate (lib/terminalFontReady) resolves before the
+// first terminal spawns, not on first paint.
+import "@/lib/terminalFontReady";
 import { App } from "./App";
 import { logLine } from "@/lib/ipc";
 import { initTerminalDropHandler } from "@/lib/terminalDrop";


### PR DESCRIPTION
## What

Fixes #70 (character heights render wrong until an atlas rebuild). This supersedes the earlier `document.fonts.check()`-based approach on this branch, which @simion confirmed still poisoned the atlas on a cold non-retina spawn.

## Root cause (reproduced on WKWebView)

xterm's WebGL atlas keys glyphs per `(char, fg, bg, ext)` with no font in the key, so a glyph rasterized before the real face is active caches at the fallback height and never corrects until the cell re-rasterizes (selecting text re-keys it, which is why that "fixed" it).

The gate meant to prevent that used `document.fonts.check()` for "JetBrains Mono". On WKWebView I reproduced that `check()` (and `load()`) report a family READY before it is registered in the FontFaceSet: `check('400 1em "JetBrains Mono"')` returns `true`, and `load()` resolves with zero faces, for an unregistered family (vacuous-true). fontsource registers the family via async CSS `@font-face`, so that pre-registration window is the poison window on a cold spawn: the gate passes, the atlas builds against the fallback, heights stick. `check()` is honest for a registered face mid-load, so it only bites before registration, which is the cold-resume timing.

The "heals on a display move, just like changing the font" report confirms this is transient atlas poisoning, not a DPR rendering bug: a round-trip ending back on the same non-retina DPR would reproduce a DPR-deterministic bug, but it heals, because any atlas rebuild clears it.

## Fix

Stop trusting `document.fonts` status. Own the latin 400/700 faces as explicit `FontFace` handles (`src/lib/terminalFontReady.ts`), registered and `load()`-awaited at boot. Gate the WebGL attach (`loadTerminalRenderer`) and the PTY spawn (`awaitTerminalFonts`) on those real handles instead of `document.fonts.check()`. The atlas can only build once the exact face it rasterizes with is genuinely loaded, so nothing is ever cleared under a live renderer (no scramble). Drops the 800ms race + poller.

The owned faces duplicate the fontsource latin `@font-face` rules (same family/weight/URL, so the byte fetch is shared). That is intentional and sound: xterm rasterizes glyphs through Canvas 2D, which draws only with FontFaceSet faces that are actually loaded and ignores unloaded ones, so once the awaited handles load the atlas rasterizes against the real face regardless of the CSS faces' state. Cyrillic stays on the CSS `@font-face` (terminals are overwhelmingly latin).

## Validation

- WKWebView before/after: the old `check` gate returns `true` in the pre-registration window (would attach early); the owned-handle gate stays `false` until the face genuinely loads, then `true`.
- A real terminal spawns with the WebGL renderer attached, no console errors.
- `tsc -b` + test suite + `vite build` all green.

I couldn't force the exact cold non-retina spawn on a warm dev instance (a warm instance can't be forced cold), so a retest on the affected machine is the real confirmation.
