### PR TITLE
fix: allow native text selection in altscreen mode using Option key

### DIFF
--- a/src/components/task/AuxTerminal.tsx
+++ b/src/components/task/AuxTerminal.tsx
@@ -88,6 +88,8 @@ export function AuxTerminal({ taskId, taskPath, active, autoFocus, onExited, onT
       scrollback: Math.round(usePrefs.getState().terminalScrollback / 2),
       // Option-as-Meta for terminal editors. See TerminalPane. (issue #11)
       macOptionIsMeta: usePrefs.getState().terminalOptionAsMeta,
+      // Allow bypassing mouse reporting for text selection by holding Option.
+      macOptionClickForcesSelection: true,
       // OSC 8 hyperlinks (anchor text like "Learn more"). Same Cmd/Ctrl gate;
       // without a linkHandler xterm parses them but activates nothing.
       linkHandler: {

--- a/src/components/task/TerminalPane.tsx
+++ b/src/components/task/TerminalPane.tsx
@@ -409,6 +409,9 @@ const captureArmedRef = useRef(false);
       // Option-as-Meta for terminal editors (vim/emacs/nano). Off by default;
       // pref lives in Appearance. (issue #11)
       macOptionIsMeta: usePrefs.getState().terminalOptionAsMeta,
+      // Allow bypassing mouse reporting (e.g. in vim/tmux) for text selection
+      // by holding the Option key, matching iTerm2/xterm.js convention.
+      macOptionClickForcesSelection: true,
       // OSC 8 hyperlinks (anchor text like "Learn more" with the URL only in
       // the escape sequence). Same Cmd/Ctrl gate as visible URLs; without a
       // linkHandler xterm parses these links but activates nothing.


### PR DESCRIPTION
This PR fixes the issue where text cannot be selected in altscreen mode when mouse reporting is enabled. It sets `macOptionClickForcesSelection` in xterm.js so holding the Option key correctly forces native text selection, matching the standard behavior in other web-based terminals like VS Code and native terminals like iTerm2.

Fixes #104