### PR TITLE
fix(sidebar): copy contact email as a fallback for a hijacked mailto: handler

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { formatTerminalTitle } from "@/lib/terminalTitle";
 import { requestCloseTab } from "@/lib/closeTab";
 import { taskRename, projectRename, openPath, projectReorder, taskSetYolo, projectRemove, projectUpdate, projectSetGroup } from "@/lib/ipc";
+import { copyToClipboard } from "@/lib/clipboard";
 import { groupOf, projectSections } from "@/lib/projectGroups";
 import { createQuickTask, derivedBranch, type NewTaskMode } from "@/lib/quickTask";
 import { confirmAndArchive } from "@/lib/archiveTask";
@@ -121,10 +122,20 @@ export function Sidebar({ compact: compactProp }: { compact?: boolean } = {}) {
   /** Build a mailto: URL with prefilled subject + body and hand it to
    *  the OS's default mail handler via `open_path` (the same Rust
    *  command the Open button uses for preview URLs — it shells out to
-   *  macOS `open`, which DTRT for mailto: too). */
+   *  macOS `open`, which DTRT for mailto: too).
+   *
+   *  `open` always exits 0 once it hands the URL to *some* app, even
+   *  when that app can't do anything useful with a mailto: link — on
+   *  macOS the mailto: scheme handler in LaunchServices isn't tied to
+   *  the "default email reader" setting, and can end up pointing at a
+   *  browser (e.g. Chrome) instead of Mail/Outlook, which just opens a
+   *  blank tab (#103). There's no reliable way to detect that failure
+   *  from here, so always copy the address too: whatever mailto: does,
+   *  the user still walks away with contact@termic.dev in hand. */
   const openMailto = (to: string, subject: string, body: string) => {
     const url = `mailto:${to}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
     openPath(url).catch(() => {});
+    copyToClipboard(to, to);
   };
   /** Open a prefilled "New issue" on the public GitHub tracker. Same
    *  query-string shape as openMailto so both support buttons route through


### PR DESCRIPTION
## Summary
- Clicking Contact shells out to `open mailto:...`, but on macOS the mailto: scheme handler in LaunchServices isn't tied to the "default email reader" setting and can end up pointing at a browser (e.g. Chrome) instead of a mail client. The browser can't do anything useful with a mailto: link, so it just opens a blank tab.
- Verified locally: `defaults read com.apple.LaunchServices/...` shows `mailto` mapped to `com.google.chrome` on this machine, confirming the mechanism.
- `open` exits 0 once it hands the URL to *some* app, so there's no reliable signal from the Rust side to detect that the handoff didn't land on a mail client.
- Fix: keep the mailto: attempt (still works correctly on systems where the handler is a real mail client), but also copy `contact@termic.dev` to the clipboard via the existing `copyToClipboard` helper, which surfaces a toast. Whatever the OS does with the mailto: link, the user walks away with the address in hand.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npx vitest run` 275/275 passing
- [x] `cd src-tauri && GIT_CONFIG_GLOBAL=/dev/null cargo test` 144/144 passing
- [ ] Manual: click Contact in the sidebar footer, confirm a toast reads "Copied contact@termic.dev" and the address is on the clipboard

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)