### PR TITLE
fix(sidebar): pre-select the suggested name when creating a group

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -185,8 +185,13 @@ export function Sidebar({ compact: compactProp }: { compact?: boolean } = {}) {
     const r1 = requestAnimationFrame(() => {
       const r2 = requestAnimationFrame(() => {
         if (cancelled) return;
+        // Focus + select unconditionally (same as PendingRepoRootRow's
+        // name prompt): when the rename starts AFTER the menu's
+        // focus-restore already settled (e.g. new-group, where async IPC
+        // delays setRenaming), autoFocus wins — but the suggested name
+        // must still be selected so typing replaces it.
         const el = renameInputRef.current;
-        if (el && document.activeElement !== el) { el.focus(); el.select(); }
+        if (el) { el.focus(); el.select(); }
       });
       if (cancelled) cancelAnimationFrame(r2);
     });


### PR DESCRIPTION
## Problem

Creating a group via the project context menu ("New group") drops you into the inline rename input with the suggested name ("NEW GROUP"), but the text is not selected, so typing appends to the suggestion instead of replacing it.

## Cause

The rename input's focus effect only ran `focus()` + `select()` when the input was not already focused (the workaround for Radix menus asynchronously restoring focus after `onSelect`). In the new-group flow, `setRenaming` fires after async IPC (`moveToGroup`), long after the menu's focus restore settled, so the input's `autoFocus` won cleanly, the guard saw it already focused, and `select()` was skipped, leaving the caret at the end.

## Fix

Focus + select unconditionally in the effect, matching how `PendingRepoRootRow` (the new-task name prompt) already does it: "pre-selected so the user can hit Enter to accept the default or just start typing to replace". The effect stays keyed on which rename (kind/id), not the value, so typing does not re-select.

One-line behavior change in `src/components/sidebar/Sidebar.tsx`; `make check-all` passes.