### PR TITLE
feat(discovery): dismiss dormant repos from the Add Project picker

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7194,6 +7194,12 @@ pub struct Settings {
     /// non-fatal regardless of this toggle.
     #[serde(default)]
     pub fetch_before_create: Option<bool>,
+    /// Canonical repo paths the user has hidden from the Add Project
+    /// discovery list. Discovery still finds them (they exist on disk),
+    /// but the UI filters them out until restored — lets a dormant local
+    /// clone stop cluttering the picker without deleting it.
+    #[serde(default)]
+    pub discovery_dismissed: Vec<String>,
 }
 
 /// Whether the pre-create base fetch (GH #79) is enabled. Default-on: only an
@@ -7782,6 +7788,29 @@ fn settings_save(s: Settings) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+/// Hide (`dismissed = true`) or restore (`false`) a discovered repo from the
+/// Add Project picker. Persists the CANONICAL path in Settings so the choice
+/// survives restarts; discovery keeps finding the repo but flags it dismissed.
+#[tauri::command]
+fn discovery_dismiss(path: String, dismissed: bool) -> Result<(), String> {
+    // Match discover_repos, which returns canonical paths — canonicalize so a
+    // symlinked or non-normalized input still lands on the same key. A deleted
+    // repo can't canonicalize; fall back to the raw path so a stale entry is
+    // still removable.
+    let canon = fs::canonicalize(&path)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or(path);
+    let mut s = load_settings_inner();
+    if dismissed {
+        if !s.discovery_dismissed.contains(&canon) {
+            s.discovery_dismissed.push(canon);
+        }
+    } else {
+        s.discovery_dismissed.retain(|p| p != &canon);
+    }
+    settings_save(s)
+}
+
 /// Replace just the agents list, preserving the rest of settings (repos_dir,
 /// welcomed, etc.). Used by the Settings → Agents page so the user can edit
 /// CLI commands, args, and YOLO flags without us shipping a new release every
@@ -7925,6 +7954,10 @@ pub struct DiscoveredRepo {
     /// True if this repo is already in projects.json (so the UI can render it
     /// disabled / labeled "added" instead of hiding it — less surprising).
     pub already_added: bool,
+    /// True if the user dismissed this repo from discovery (Settings
+    /// `discovery_dismissed`). Still returned so the UI can offer a restore;
+    /// the picker hides it by default.
+    pub dismissed: bool,
 }
 
 /// Best-effort "last activity" time for a repo, used to sort the discovery
@@ -7952,13 +7985,25 @@ fn repo_activity_time(repo: &Path) -> std::time::SystemTime {
 #[tauri::command]
 fn discover_repos(dir: String) -> Result<Vec<DiscoveredRepo>, String> {
     let root = PathBuf::from(shellexpand(&dir));
-    if !root.is_dir() {
-        return Err(format!("not a directory: {}", root.display()));
-    }
     let added: std::collections::HashSet<String> = load_projects()
         .into_iter()
         .map(|p| p.root_path)
         .collect();
+    let dismissed: std::collections::HashSet<String> =
+        load_settings_inner().discovery_dismissed.into_iter().collect();
+    discover_repos_inner(&root, &added, &dismissed)
+}
+
+/// Pure scan, split from the command so the `added` / `dismissed` sets can be
+/// injected in tests without touching settings.json / projects.json.
+fn discover_repos_inner(
+    root: &Path,
+    added: &std::collections::HashSet<String>,
+    dismissed: &std::collections::HashSet<String>,
+) -> Result<Vec<DiscoveredRepo>, String> {
+    if !root.is_dir() {
+        return Err(format!("not a directory: {}", root.display()));
+    }
     let mut out: Vec<(DiscoveredRepo, std::time::SystemTime)> = Vec::new();
     // Dedup by CANONICAL path: a repo can be reachable both directly and via a
     // grouping folder (e.g. a `code/all -> code` symlink, or the two-level
@@ -7973,8 +8018,9 @@ fn discover_repos(dir: String) -> Result<Vec<DiscoveredRepo>, String> {
         if !seen.insert(path_str.clone()) { return; } // already discovered
         let name = canon.file_name().and_then(|s| s.to_str()).unwrap_or("repo").to_string();
         let already_added = added.contains(&path_str);
+        let dismissed_flag = dismissed.contains(&path_str);
         let activity = repo_activity_time(&canon);
-        out.push((DiscoveredRepo { path: path_str, name, already_added }, activity));
+        out.push((DiscoveredRepo { path: path_str, name, already_added, dismissed: dismissed_flag }, activity));
     };
     let skip = |p: &PathBuf| -> bool {
         match p.file_name().and_then(|s| s.to_str()) {
@@ -7982,7 +8028,7 @@ fn discover_repos(dir: String) -> Result<Vec<DiscoveredRepo>, String> {
             None => true,
         }
     };
-    let rd = fs::read_dir(&root).map_err(|e| e.to_string())?;
+    let rd = fs::read_dir(root).map_err(|e| e.to_string())?;
     for entry in rd.flatten() {
         let path = entry.path();
         if !path.is_dir() || skip(&path) { continue; }
@@ -8442,7 +8488,7 @@ pub fn run() {
             task_rename, project_rename,
             pty_spawn, pty_write, pty_resize, pty_kill,
             notify, open_path, reveal_path, home_dir, default_shell, path_exists, path_is_git_repo, log_line, pty_debug_append, terminal_stage_file, install_notification_sound, play_completion_sound,
-            settings_load, settings_save, agents_save, agents_defaults, run_capture_command, discover_repos, detect_clis,
+            settings_load, settings_save, discovery_dismiss, agents_save, agents_defaults, run_capture_command, discover_repos, detect_clis,
             automation::automation_result,
             automation::automation_armed,
             list_monospace_fonts,
@@ -8762,6 +8808,19 @@ mod tests {
         mkrepo(root.path(), "repo-a");
         mkrepo(root.path(), "repo-b");
         assert_eq!(discovered_names(root.path()), ["repo-a", "repo-b"].map(String::from).into());
+    }
+
+    #[test]
+    fn discover_repos_flags_dismissed() {
+        let root = tempdir().unwrap();
+        mkrepo(root.path(), "keep");
+        mkrepo(root.path(), "hide");
+        let hide_canon = fs::canonicalize(root.path().join("hide"))
+            .unwrap().to_string_lossy().into_owned();
+        let dismissed: std::collections::HashSet<String> = [hide_canon].into();
+        let repos = discover_repos_inner(root.path(), &Default::default(), &dismissed).unwrap();
+        assert!(repos.iter().find(|r| r.name == "hide").unwrap().dismissed);
+        assert!(!repos.iter().find(|r| r.name == "keep").unwrap().dismissed);
     }
 
     #[test]

--- a/src/components/dialogs/NewProjectDialog.tsx
+++ b/src/components/dialogs/NewProjectDialog.tsx
@@ -7,9 +7,9 @@ import { useApp } from "@/store/app";
 import { AppDialog } from "@/components/ui/Dialog";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
-import { projectAdd, projectAddMulti, discoverRepos, settingsLoad, pathIsGitRepo } from "@/lib/ipc";
+import { projectAdd, projectAddMulti, discoverRepos, discoveryDismiss, settingsLoad, pathIsGitRepo } from "@/lib/ipc";
 import type { DiscoveredRepo, Project, ProjectMember } from "@/lib/types";
-import { Folder, FolderPlus, Layers, X } from "lucide-react";
+import { Folder, FolderPlus, Layers, RotateCcw, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // Where a non-git folder is being added — drives the confirm copy. We no
@@ -60,6 +60,8 @@ export function NewProjectDialog() {
   // dialog stays uncluttered for small repos folders. Case-insensitive
   // substring match against name + path.
   const [filter, setFilter] = useState("");
+  // Reveal the dismissed-repos section (repos the user hid from discovery).
+  const [showHidden, setShowHidden] = useState(false);
   // Multi-repo: self-contained inline member rows (order = display order),
   // keyed by root_path. No project registration — a member is just a path
   // plus its per-project scripts.
@@ -72,7 +74,7 @@ export function NewProjectDialog() {
   useEffect(() => {
     if (!open) return;
     setMode("repo");
-    setPath(""); setErr(null); setFilter("");
+    setPath(""); setErr(null); setFilter(""); setShowHidden(false);
     setNonGit(false);
     setConfirm(null);
     setMemberRows([]);
@@ -137,6 +139,20 @@ export function NewProjectDialog() {
       }
       if (p === path) close();
     } catch (e) { setErr(String(e)); } finally { setBusy(false); }
+  }
+
+  // Hide a discovered repo from the picker (or restore it). Optimistic:
+  // flip the local flag now, revert if the IPC fails. Clear the selection
+  // if the repo being hidden was the picked one.
+  async function dismissRepo(p: string, dismissed: boolean) {
+    setDiscovered(prev => prev.map(r => (r.path === p ? { ...r, dismissed } : r)));
+    if (dismissed && path === p) setPath("");
+    try {
+      await discoveryDismiss(p, dismissed);
+    } catch (e) {
+      setDiscovered(prev => prev.map(r => (r.path === p ? { ...r, dismissed: !dismissed } : r)));
+      setErr(String(e));
+    }
   }
 
   // Single-repo Add: detect git, confirm if it's a plain folder, then add.
@@ -408,22 +424,28 @@ export function NewProjectDialog() {
         </>
       ) : (
       <>
-      {discovered.length > 0 && (() => {
+      {(() => {
+        // Dismissed repos (Rust flags them via settings.discovery_dismissed)
+        // are still discovered but hidden from the main list — a dormant local
+        // clone can stop cluttering the picker without being deleted.
+        const visible = discovered.filter(r => !r.dismissed);
+        const hidden = discovered.filter(r => r.dismissed);
+        if (visible.length === 0 && hidden.length === 0) return null;
         const q = filter.trim().toLowerCase();
         const filtered = q
-          ? discovered.filter(r =>
+          ? visible.filter(r =>
               r.name.toLowerCase().includes(q) || r.path.toLowerCase().includes(q),
             )
-          : discovered;
+          : visible;
         return (
         <div className="mb-3">
           <div className="mb-1.5 flex items-baseline justify-between text-[11.5px] uppercase tracking-wider text-[var(--color-fg-dim)]">
             <span>Discovered repos</span>
             <span className="font-mono normal-case text-[11.5px] text-[var(--color-fg-faint)]">
-              {q ? `${filtered.length} of ${discovered.length}` : discovered.length} in {reposDir}
+              {q ? `${filtered.length} of ${visible.length}` : visible.length} in {reposDir}
             </span>
           </div>
-          {discovered.length > 5 && (
+          {visible.length > 5 && (
             <Input
               value={filter}
               onChange={e => setFilter(e.target.value)}
@@ -436,35 +458,76 @@ export function NewProjectDialog() {
               spellCheck={false}
             />
           )}
+          {visible.length > 0 && (
           <div className="max-h-[220px] overflow-auto rounded-md border border-[var(--color-border-soft)]">
             {filtered.length === 0 ? (
               <div className="px-3 py-3 text-[12.5px] text-[var(--color-fg-faint)]">
                 No repos match "{filter}".
               </div>
             ) : filtered.map(r => (
-              <button key={r.path} onClick={() => { setPath(r.path); setNonGit(false); }} disabled={busy}
-                className={cn(
-                  "flex w-full items-center gap-2 px-3 py-2 text-left text-[14px] hover:bg-[var(--color-hover)] disabled:opacity-50",
-                  path === r.path && "bg-[var(--color-accent-deep)]/10",
-                )}
-                title={r.path}
-              >
-                <Folder className={cn("h-4 w-4 shrink-0", path === r.path ? "text-[var(--color-accent)]" : "text-[var(--color-fg-faint)]")} />
-                <span className="shrink-0 truncate">{r.name}</span>
-                {/* Full path, faded, right-aligned. dir=rtl truncates from the
-                    LEFT so the meaningful tail (…/repo) stays readable. */}
-                <span
-                  dir="rtl"
-                  className="min-w-0 flex-1 truncate text-right text-[11px] text-[var(--color-fg-faint)] opacity-50"
+              <div key={r.path} className="group flex w-full items-center">
+                <button onClick={() => { setPath(r.path); setNonGit(false); }} disabled={busy}
+                  className={cn(
+                    "flex min-w-0 flex-1 items-center gap-2 px-3 py-2 text-left text-[14px] hover:bg-[var(--color-hover)] disabled:opacity-50",
+                    path === r.path && "bg-[var(--color-accent-deep)]/10",
+                  )}
+                  title={r.path}
                 >
-                  {r.path}
-                </span>
-                {path === r.path && (
-                  <span className="shrink-0 text-[11.5px] uppercase tracking-wider text-[var(--color-accent)] opacity-70">Selected</span>
-                )}
-              </button>
+                  <Folder className={cn("h-4 w-4 shrink-0", path === r.path ? "text-[var(--color-accent)]" : "text-[var(--color-fg-faint)]")} />
+                  <span className="shrink-0 truncate">{r.name}</span>
+                  {/* Full path, faded, right-aligned. dir=rtl truncates from the
+                      LEFT so the meaningful tail (…/repo) stays readable. */}
+                  <span
+                    dir="rtl"
+                    className="min-w-0 flex-1 truncate text-right text-[11px] text-[var(--color-fg-faint)] opacity-50"
+                  >
+                    {r.path}
+                  </span>
+                  {path === r.path && (
+                    <span className="shrink-0 text-[11.5px] uppercase tracking-wider text-[var(--color-accent)] opacity-70">Selected</span>
+                  )}
+                </button>
+                <button
+                  onClick={() => dismissRepo(r.path, true)}
+                  title="Hide from discovery"
+                  aria-label={`Hide ${r.name} from discovery`}
+                  className="mr-1 shrink-0 rounded p-1 text-[var(--color-fg-faint)] opacity-0 hover:bg-[var(--color-hover)] hover:text-[var(--color-fg)] focus-visible:opacity-100 group-hover:opacity-100"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
             ))}
           </div>
+          )}
+          {hidden.length > 0 && (
+            <div className="mt-1.5">
+              <button
+                onClick={() => setShowHidden(v => !v)}
+                className="text-[11.5px] text-[var(--color-fg-faint)] hover:text-[var(--color-fg-dim)]"
+              >
+                {showHidden ? "Hide" : "Show"} {hidden.length} hidden
+              </button>
+              {showHidden && (
+                <div className="mt-1 max-h-[140px] overflow-auto rounded-md border border-[var(--color-border-soft)]">
+                  {hidden.map(r => (
+                    <div key={r.path} className="flex w-full items-center gap-2 px-3 py-1.5 text-[13px]">
+                      <Folder className="h-4 w-4 shrink-0 text-[var(--color-fg-faint)] opacity-50" />
+                      <span className="shrink-0 truncate text-[var(--color-fg-dim)]">{r.name}</span>
+                      <span dir="rtl" className="min-w-0 flex-1 truncate text-right text-[11px] text-[var(--color-fg-faint)] opacity-50">{r.path}</span>
+                      <button
+                        onClick={() => dismissRepo(r.path, false)}
+                        title="Restore to discovery"
+                        aria-label={`Restore ${r.name} to discovery`}
+                        className="shrink-0 rounded p-1 text-[var(--color-fg-faint)] hover:bg-[var(--color-hover)] hover:text-[var(--color-fg)]"
+                      >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
           <div className="relative my-3 text-center">
             <div className="absolute inset-x-0 top-1/2 h-px bg-[var(--color-border-soft)]" />
             <span className="relative bg-[var(--color-bg-1)] px-2 text-[11.5px] uppercase tracking-wider text-[var(--color-fg-faint)]">or add manually</span>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -452,6 +452,10 @@ export const themesDir  = () => invoke<string>("themes_dir");
 export const settingsSave  = (s: Settings) => invoke<void>("settings_save", { s });
 export const agentsSave    = (agents: Agent[]) => invoke<void>("agents_save", { agents });
 export const discoverRepos = (dir: string) => invoke<DiscoveredRepo[]>("discover_repos", { dir });
+/** Hide (`dismissed=true`) or restore (`false`) a discovered repo from the
+ *  Add Project picker. Persists to settings; discovery keeps finding it. */
+export const discoveryDismiss = (path: string, dismissed: boolean) =>
+  invoke<void>("discovery_dismiss", { path, dismissed });
 export const detectClis    = () => invoke<CliInfo[]>("detect_clis");
 export const listMonospaceFonts = () => invoke<string[]>("list_monospace_fonts");
 /** True when this debug instance is driven by the e2e automation bridge

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -416,12 +416,18 @@ export interface Settings {
    *  commit instead of a stale local `origin/*` (GH #79). Absent = on; set
    *  false to opt out. The fetch is always time-bounded and non-fatal. */
   fetch_before_create?: boolean;
+  /** Canonical repo paths hidden from the Add Project discovery list.
+   *  Discovery still finds them; the picker filters them out until restored. */
+  discovery_dismissed?: string[];
 }
 
 export interface DiscoveredRepo {
   path: string;
   name: string;
   already_added: boolean;
+  /** User hid this repo from discovery. Still returned so the picker can
+   *  offer a restore; hidden from the main list by default. */
+  dismissed: boolean;
 }
 
 /** A git worktree of a project's repo that isn't yet tracked as a


### PR DESCRIPTION
Fixes #108.

## Problem
`discover_repos` re-scans `repos_dir` on every open, so a dormant local clone that was archived remotely but never deleted keeps cluttering the picker, with no way to hide it short of deleting the clone.

## Change
- `Settings.discovery_dismissed: Vec<String>` (serde default) stores canonical repo paths the user hid.
- `DiscoveredRepo.dismissed` flag: `discover_repos` still finds dismissed repos and marks them, so the choice survives restarts.
- New `discovery_dismiss(path, dismissed)` command toggles an entry, canonicalizing the path to match `discover_repos` output.
- Dialog: an X hides a discovered repo; a "Show N hidden" section restores it.
- Split `discover_repos` into a pure `discover_repos_inner(root, added, dismissed)` so the flag is unit-tested without touching settings/projects on disk.

## Verification
- `cargo test` green, including a new `discover_repos_flags_dismissed`; the existing 6 discovery tests are unchanged.
- `tsc -b` clean.
- Driven live: dismiss removes a repo from the visible list and surfaces "Show 1 hidden"; restore brings it back; state persists to `settings.discovery_dismissed`.
