### PR TITLE
Git tab: show current branch + switch branches (stash and re-apply) (#101)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4905,6 +4905,62 @@ async fn task_git_status(id: String) -> Result<GitStatus, String> {
     .map_err(|e| e.to_string())?
 }
 
+/// Result of a branch switch: which branch we're on, whether local work was
+/// stashed to get there, and whether re-applying that stash hit conflicts
+/// (conflict markers are left in the tree and the stash is retained).
+#[derive(Serialize)]
+struct CheckoutResult {
+    branch: String,
+    stashed: bool,
+    conflicted: bool,
+}
+
+/// Local branch names for a task's repo (host, or a member when `dir_name` is
+/// set). Used by the Git tab's branch switcher.
+#[tauri::command]
+async fn task_git_branches(id: String, dir_name: String) -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || -> Result<Vec<String>, String> {
+        let w = load_tasks().into_iter().find(|w| w.id == id).ok_or("no task")?;
+        let cwd = repo_cwd(&w, &dir_name)?;
+        let out = git(&["branch", "--format=%(refname:short)"], &cwd).map_err(|e| e.to_string())?;
+        Ok(out.lines().map(|l| l.trim().to_string()).filter(|l| !l.is_empty()).collect())
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+/// Fork-style branch switch: stash local work (including untracked files),
+/// check out `branch`, then re-apply the stash. A failed checkout (e.g. the
+/// branch is already checked out in another worktree) restores the stash and
+/// errors. A pop conflict is reported, not swallowed - the caller warns the
+/// user so they resolve it instead of silently losing the changes.
+#[tauri::command]
+async fn task_git_checkout(id: String, dir_name: String, branch: String) -> Result<CheckoutResult, String> {
+    tauri::async_runtime::spawn_blocking(move || -> Result<CheckoutResult, String> {
+        let w = load_tasks().into_iter().find(|w| w.id == id).ok_or("no task")?;
+        let cwd = repo_cwd(&w, &dir_name)?;
+        let dirty = !git(&["status", "--porcelain"], &cwd).map_err(|e| e.to_string())?.trim().is_empty();
+        let mut stashed = false;
+        if dirty {
+            git(&["stash", "push", "-u", "-m", &format!("termic: switch to {branch}")], &cwd)
+                .map_err(|e| e.to_string())?;
+            stashed = true;
+        }
+        if let Err(e) = git(&["checkout", &branch], &cwd) {
+            // Put the user's work back exactly where it was before erroring out.
+            if stashed { let _ = git(&["stash", "pop"], &cwd); }
+            return Err(e.to_string());
+        }
+        let mut conflicted = false;
+        if stashed && git(&["stash", "pop"], &cwd).is_err() {
+            conflicted = true;
+        }
+        Ok(CheckoutResult { branch, stashed, conflicted })
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
 /// Resolve the git cwd for a stage/commit op: the host task path
 /// when `dir_name` is empty, otherwise the matching composition member.
 fn repo_cwd(w: &Task, dir_name: &str) -> Result<PathBuf, String> {
@@ -8482,7 +8538,7 @@ pub fn run() {
             task_grep_start, task_grep_cancel,
             task_spotlight_start, task_spotlight_stop, task_spotlight_resync, task_spotlight_status,
             task_diff, task_files, task_list_files_for_finder, task_send_diff_to_main,
-            task_changes, task_git_status, task_stage, task_unstage, task_commit, task_discard,
+            task_changes, task_git_status, task_git_branches, task_git_checkout, task_stage, task_unstage, task_commit, task_discard,
             task_file_diff, task_file_diff_sides, task_file_read, task_file_read_base64, task_file_write, task_dir_list, task_path_stat,
             task_path_rename, task_path_delete, task_reveal_path,
             task_rename, project_rename,

--- a/src/components/task/GitPanel.tsx
+++ b/src/components/task/GitPanel.tsx
@@ -18,10 +18,10 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  ChevronRight, ChevronDown, ArrowDown, ArrowUp, List, ListTree, Rows3, Check, Eye, Search, Trash2, MessageSquare,
+  ChevronRight, ChevronDown, ArrowDown, ArrowUp, List, ListTree, Rows3, Check, Eye, Search, Trash2, MessageSquare, Loader2, GitBranch,
 } from "lucide-react";
 import type { Task, GitStatus, GitRepo, GitFile } from "@/lib/types";
-import { taskStage, taskUnstage, taskCommit, taskDiscard } from "@/lib/ipc";
+import { taskStage, taskUnstage, taskCommit, taskDiscard, taskGitBranches, taskGitCheckout } from "@/lib/ipc";
 import { useApp } from "@/store/app";
 import { useUI } from "@/store/ui";
 import { usePrefs } from "@/store/prefs";
@@ -346,10 +346,13 @@ export function GitPanel({ task, status, refresh, onOpenDiff, onDoubleClickDiff 
   }
   if (!repo || (status.total_changed === 0 && !pinnedExists)) {
     return (
-      <div className="px-3 py-3 text-[13.5px] text-[var(--color-fg-faint)]">
-        {nonGit
-          ? "Not a git repository. Changes aren't tracked here."
-          : "No changes. Working tree is clean."}
+      <div className="flex h-full flex-col">
+        {!nonGit && <BranchBar task={task} branch={status.repos[0]?.branch ?? task.branch} dir="" refresh={refresh} />}
+        <div className="px-3 py-3 text-[13.5px] text-[var(--color-fg-faint)]">
+          {nonGit
+            ? "Not a git repository. Changes aren't tracked here."
+            : "No changes. Working tree is clean."}
+        </div>
       </div>
     );
   }
@@ -384,6 +387,8 @@ export function GitPanel({ task, status, refresh, onOpenDiff, onDoubleClickDiff 
 
   return (
     <div className="flex h-full flex-col">
+      {/* 0. Current branch + switcher (fork-style: stash, checkout, re-apply) */}
+      {!nonGit && <BranchBar task={task} branch={repo?.branch ?? task.branch} dir={dir} refresh={refresh} />}
       {/* 1. Repo sub-tabs (wrapping pills) */}
       {showSubTabs && (
         <div className="flex shrink-0 flex-wrap gap-1 border-b border-[var(--color-border-soft)] px-2 py-1.5">
@@ -544,6 +549,88 @@ export function GitPanel({ task, status, refresh, onOpenDiff, onDoubleClickDiff 
           </DropdownRoot>
         </div>
       </div>
+    </div>
+  );
+}
+
+// Current-branch chip + switcher (issue #101). The chip shows the live branch
+// (from git status, so it's always the true HEAD even after a switch). Opening
+// the dropdown lazily lists local branches; picking one does a Fork-style
+// switch (stash local work, checkout, re-apply) via task_git_checkout. A pop
+// conflict is surfaced as an error toast, not swallowed.
+function BranchBar({ task, branch, dir, refresh }: {
+  task: Task;
+  branch: string;
+  dir: string;
+  refresh: () => void;
+}) {
+  const pushToast = useUI(s => s.pushToast);
+  const [branches, setBranches] = useState<string[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [switching, setSwitching] = useState(false);
+
+  const loadBranches = () => {
+    if (loading) return;
+    setLoading(true);
+    taskGitBranches(task.id, dir)
+      .then(setBranches)
+      .catch(e => pushToast(String(e), "error"))
+      .finally(() => setLoading(false));
+  };
+
+  const switchTo = (target: string) => {
+    if (switching || target === branch) return;
+    setSwitching(true);
+    taskGitCheckout(task.id, dir, target)
+      .then(r => {
+        setBranches(null);   // stale after a switch - reload on next open
+        refresh();
+        if (r.conflicted) {
+          pushToast(`Switched to ${r.branch}. Your stashed changes conflicted on re-apply; resolve them.`, "error", { ttlMs: 8000 });
+        } else if (r.stashed) {
+          pushToast(`Switched to ${r.branch}. Local changes stashed and re-applied.`);
+        } else {
+          pushToast(`Switched to ${r.branch}.`);
+        }
+      })
+      .catch(e => pushToast(String(e), "error"))
+      .finally(() => setSwitching(false));
+  };
+
+  return (
+    <div className="flex h-8 shrink-0 items-center border-b border-[var(--color-border-soft)] px-2">
+      <DropdownRoot>
+        <DropdownTrigger asChild>
+          <button
+            onClick={loadBranches}
+            disabled={switching}
+            title="Switch branch (stashes and re-applies local changes)"
+            className="flex h-6 min-w-0 max-w-full items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-2 text-[12px] transition-colors hover:border-[var(--color-accent-soft)] disabled:opacity-50"
+          >
+            {switching
+              ? <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-[var(--color-fg-faint)]" />
+              : <GitBranch className="h-3.5 w-3.5 shrink-0 text-[var(--color-fg-faint)]" />}
+            <span className="truncate font-mono text-[var(--color-fg)]">{branch || "detached HEAD"}</span>
+            <ChevronDown className="h-3 w-3 shrink-0 text-[var(--color-fg-faint)]" />
+          </button>
+        </DropdownTrigger>
+        <DropdownMenu align="start">
+          {loading ? (
+            <div className="flex items-center gap-2 px-2 py-1.5 text-[12px] text-[var(--color-fg-faint)]">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading branches…
+            </div>
+          ) : !branches || branches.length === 0 ? (
+            <div className="px-2 py-1.5 text-[12px] text-[var(--color-fg-faint)]">No local branches.</div>
+          ) : (
+            branches.map(b => (
+              <DropdownItem key={b} onSelect={() => switchTo(b)} className="items-center">
+                <Check className={cn("h-3.5 w-3.5", b !== branch && "opacity-0")} />
+                <span className="truncate font-mono text-[12px]">{b}</span>
+              </DropdownItem>
+            ))
+          )}
+        </DropdownMenu>
+      </DropdownRoot>
     </div>
   );
 }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -6,7 +6,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
   Project, ProjectMember, Task, CreateTaskArgs, CreateMultiArgs, Settings, DiscoveredRepo,
-  ImportableWorktree, CliInfo, ChangeFile, Changes, GitStatus, FileEntry, Agent, RepoConfig,
+  ImportableWorktree, CliInfo, ChangeFile, Changes, GitStatus, CheckoutResult, FileEntry, Agent, RepoConfig,
   SandboxMode,
 } from "./types";
 import type { CustomThemeFile } from "./customTheme";
@@ -362,6 +362,12 @@ export const taskRevealPath = (id: string, path: string) =>
 export const taskChanges  = (id: string) => invoke<Changes>("task_changes", { id });
 // Fork-style staging: staged/unstaged split per repo + stage/unstage/commit.
 export const taskGitStatus = (id: string) => invoke<GitStatus>("task_git_status", { id });
+/** Local branch names for a task's repo (host, or a member via dirName). */
+export const taskGitBranches = (id: string, dirName: string) =>
+  invoke<string[]>("task_git_branches", { id, dirName });
+/** Fork-style switch: stash local work, checkout `branch`, re-apply the stash. */
+export const taskGitCheckout = (id: string, dirName: string, branch: string) =>
+  invoke<CheckoutResult>("task_git_checkout", { id, dirName, branch });
 export const taskStage   = (id: string, dirName: string, paths: string[]) =>
   invoke<void>("task_stage", { id, dirName, paths });
 export const taskUnstage = (id: string, dirName: string, paths: string[]) =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -507,6 +507,15 @@ export interface GitStatus {
   repos_changed: number;
 }
 
+/** Result of a Git-tab branch switch. `stashed` = local work was parked and
+ *  re-applied; `conflicted` = the re-apply hit conflicts (markers left in the
+ *  tree, stash retained). */
+export interface CheckoutResult {
+  branch: string;
+  stashed: boolean;
+  conflicted: boolean;
+}
+
 export interface FileEntry {
   name: string;
   is_dir: boolean;


### PR DESCRIPTION
Implements the two items from #101:

- **Show the current branch** - a branch chip at the top of the Git tab, read live from `git status` so it always reflects the true HEAD (even right after a switch).
- **Switch to another local branch, Fork-style** - stash local work (including untracked), `checkout`, then re-apply the stash. Available in both the clean and dirty states.

### Behaviour
- Clean tree: plain checkout, no stash.
- Dirty tree: `git stash push -u` -> `checkout` -> `git stash pop`. A `CheckoutResult { branch, stashed, conflicted }` drives a toast so the user knows their work was parked and restored.
- Checkout fails (e.g. the target branch is checked out in another worktree): the stash is popped back so no work is stranded, and the error surfaces.
- Stash-pop conflict: reported, not swallowed, so the user resolves it rather than silently losing changes.

### Shape
- Backend (`lib.rs`): `task_git_branches` (local branch list) + `task_git_checkout` (the stash/checkout/re-apply).
- Frontend: a `BranchBar` in `GitPanel`, rendered in both the clean and dirty returns.

Scoped to the show-branch + checkout-with-stash items; the update/pull/rebase parts of the title are a natural follow-up.

Verified locally: `tsc` + `cargo` clean, and I drove the flow through the automation bridge against a multi-branch repo - branch listing, a clean switch, and a dirty stash -> switch -> re-apply (tracked change restored on the new branch) all check out.
