### PR TITLE
feat(terminal): open file paths on Cmd/Ctrl+click

### DIFF
--- a/src/components/task/AuxTerminal.tsx
+++ b/src/components/task/AuxTerminal.tsx
@@ -112,7 +112,10 @@ export function AuxTerminal({ taskId, taskPath, active, autoFocus, onExited, onT
     // GH #58: mouse-reporting-proof Cmd/Ctrl+click opener — the user can run
     // a TUI in the scratch shell too (htop, an agent CLI by hand). See
     // TerminalPane / lib/termLinkOpener.
-    const disposeLinkOpener = attachCmdClickLinkOpener(term, host, openLink("capture"));
+    const disposeLinkOpener = attachCmdClickLinkOpener(term, host, (target) => {
+      // URLs only; file-path open is a TerminalPane feature.
+      if (target.kind === "url") openLink("capture")(target.uri);
+    });
     // Korean/CJK IME (WKWebView). WebKit composes via textarea `input` events
     // (insertText + insertReplacementText), not compositionstart/end, and
     // xterm drops the replacement events — so input gets mangled (안녕 → ㅇㄴ).

--- a/src/components/task/AuxTerminal.tsx
+++ b/src/components/task/AuxTerminal.tsx
@@ -112,10 +112,12 @@ export function AuxTerminal({ taskId, taskPath, active, autoFocus, onExited, onT
     // GH #58: mouse-reporting-proof Cmd/Ctrl+click opener — the user can run
     // a TUI in the scratch shell too (htop, an agent CLI by hand). See
     // TerminalPane / lib/termLinkOpener.
+    // urlsOnly: file-path open is a TerminalPane feature. Without this the
+    // opener would arm on path tokens here and swallow the click (dead in the
+    // scratch shell, and eaten from under a mouse-reporting TUI).
     const disposeLinkOpener = attachCmdClickLinkOpener(term, host, (target) => {
-      // URLs only; file-path open is a TerminalPane feature.
       if (target.kind === "url") openLink("capture")(target.uri);
-    });
+    }, { urlsOnly: true });
     // Korean/CJK IME (WKWebView). WebKit composes via textarea `input` events
     // (insertText + insertReplacementText), not compositionstart/end, and
     // xterm drops the replacement events — so input gets mangled (안녕 → ㅇㄴ).

--- a/src/components/task/TerminalPane.tsx
+++ b/src/components/task/TerminalPane.tsx
@@ -477,7 +477,7 @@ const captureArmedRef = useRef(false);
             setPathMenu({ x, y, candidates: matches, line: target.line, col: target.col });
           }
         })
-        .catch(() => {});
+        .catch(() => useUI.getState().pushToast("Couldn't list files to open that path", "error"));
     }
     const onActivate = (target: ClickTarget, x: number, y: number) => {
       if (target.kind === "url") openLink("capture")(target.uri);
@@ -2052,6 +2052,13 @@ const captureArmedRef = useRef(false);
           candidates={pathMenu.candidates}
           onPick={(path) => { openPathFile(path, pathMenu.line, pathMenu.col); setPathMenu(null); }}
           onClose={() => setPathMenu(null)}
+          onCloseAutoFocus={(e, picked) => {
+            // The anchor is an invisible, non-focusable div, so never let Radix
+            // return focus to it. On dismiss, hand focus back to the terminal;
+            // on a pick, leave it for the editor that just opened.
+            e.preventDefault();
+            if (!picked) termRef.current?.focus();
+          }}
         />
       )}
       {searchOpen && (

--- a/src/components/task/TerminalPane.tsx
+++ b/src/components/task/TerminalPane.tsx
@@ -11,7 +11,9 @@ import { cn } from "@/lib/utils";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { attachCmdClickLinkOpener } from "@/lib/termLinkOpener";
+import { attachCmdClickLinkOpener, registerPathLinkProvider, type ClickTarget } from "@/lib/termLinkOpener";
+import { resolvePathClick } from "@/lib/pathMatch";
+import { TerminalPathMenu } from "@/components/task/TerminalPathMenu";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ClipboardAddon } from "@xterm/addon-clipboard";
 import { Osc52Base64 } from "@/lib/osc52";
@@ -121,6 +123,15 @@ export function TerminalPane({ task, tab, active }: Props) {
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [pathMenu, setPathMenu] = useState<{ x: number; y: number; candidates: string[]; line?: number; col?: number } | null>(null);
+  const openPathFile = useCallback((path: string, line?: number, col?: number) => {
+    useApp.getState().openPreviewTab(task.id, {
+      type: "edit",
+      path,
+      title: path.split("/").pop() || path,
+      revealAt: line ? { line, col } : undefined,
+    });
+  }, [task.id]);
   const unlistenDataRef = useRef<(() => void) | null>(null);
   const unlistenExitRef = useRef<(() => void) | null>(null);
   const ptyRef = useRef<string | null>(null);
@@ -444,6 +455,10 @@ const captureArmedRef = useRef(false);
     term.loadAddon(new WebLinksAddon((event, uri) => {
       if (event.metaKey || event.ctrlKey) openLink("addon")(uri);
     }));
+    // Hover-underline for file-path references, mirroring the URL addon above.
+    const disposePathLinks = registerPathLinkProvider(term, (path, line, col, event) => {
+      if (event.metaKey || event.ctrlKey) handlePathTarget({ path, line, col }, event.clientX, event.clientY);
+    });
     term.open(host);
     // GH #58: when the agent TUI enables xterm mouse reporting, the modified
     // click is consumed by the mouse pipeline before the addon's activation
@@ -451,7 +466,24 @@ const captureArmedRef = useRef(false);
     // sees the gesture first, resolves the URL from the buffer itself, and
     // swallows the click so nothing double-fires. Must attach AFTER
     // term.open (it reads .xterm-screen geometry).
-    const disposeLinkOpener = attachCmdClickLinkOpener(term, host, openLink("capture"));
+    // GH #117: the same opener also resolves file-path references.
+    function handlePathTarget(target: { path: string; line?: number; col?: number }, x: number, y: number) {
+      ipc.taskListFilesForFinder(task.id)
+        .then(files => {
+          const matches = resolvePathClick(files, target.path);
+          if (matches.length === 1) {
+            openPathFile(matches[0], target.line, target.col);
+          } else {
+            setPathMenu({ x, y, candidates: matches, line: target.line, col: target.col });
+          }
+        })
+        .catch(() => {});
+    }
+    const onActivate = (target: ClickTarget, x: number, y: number) => {
+      if (target.kind === "url") openLink("capture")(target.uri);
+      else handlePathTarget(target, x, y);
+    };
+    const disposeLinkOpener = attachCmdClickLinkOpener(term, host, onActivate);
     termRef.current = term;
     fitRef.current = fit;
 
@@ -1612,6 +1644,7 @@ const captureArmedRef = useRef(false);
       ro.disconnect();
       disposeCopyOnSelect();
       disposeLinkOpener();
+      disposePathLinks.dispose();
       unregisterDrop();
       disposeImeBridge();
       unlistenDataRef.current?.();
@@ -2012,6 +2045,15 @@ const captureArmedRef = useRef(false);
         />
       )}
       <div ref={hostRef} className="min-h-0 flex-1 bg-[var(--color-bg)]" />
+      {pathMenu && (
+        <TerminalPathMenu
+          x={pathMenu.x}
+          y={pathMenu.y}
+          candidates={pathMenu.candidates}
+          onPick={(path) => { openPathFile(path, pathMenu.line, pathMenu.col); setPathMenu(null); }}
+          onClose={() => setPathMenu(null)}
+        />
+      )}
       {searchOpen && (
         <div className="absolute right-2 top-2 z-20 flex items-center gap-0.5 rounded border border-[var(--color-border)] bg-[var(--color-bg-2)] px-2 py-1 shadow-lg">
           <input

--- a/src/components/task/TerminalPathMenu.tsx
+++ b/src/components/task/TerminalPathMenu.tsx
@@ -1,0 +1,40 @@
+import { DropdownRoot, DropdownTrigger, DropdownMenu, DropdownItem } from "@/components/ui/Dropdown";
+import { fileIconUrl } from "@/lib/explorer/iconResolver";
+
+export function TerminalPathMenu({ x, y, candidates, onPick, onClose }: {
+  x: number;
+  y: number;
+  candidates: string[];
+  onPick: (path: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <DropdownRoot open onOpenChange={(v) => { if (!v) onClose(); }}>
+      <DropdownTrigger asChild>
+        {/* invisible anchor at the click point; Radix positions the menu off it */}
+        <div style={{ position: "fixed", left: x, top: y, width: 1, height: 1, pointerEvents: "none" }} />
+      </DropdownTrigger>
+      <DropdownMenu align="start" side="bottom" sideOffset={4}>
+        {candidates.length === 0 ? (
+          <div className="px-3 py-3 text-[13px] text-[var(--color-fg-faint)]">
+            No matches
+          </div>
+        ) : candidates.map(path => {
+          const name = path.split("/").pop() || path;
+          const dir = path.slice(0, path.length - name.length);
+          return (
+            <DropdownItem key={path} onSelect={() => onPick(path)}>
+              <img src={fileIconUrl(name)} alt="" className="h-4 w-4 shrink-0 file-icon" />
+              <span className="truncate">{name}</span>
+              {dir && (
+                <span className="ml-2 min-w-0 flex-1 truncate text-[12px] text-[var(--color-fg-faint)]">
+                  {dir.replace(/\/$/, "")}
+                </span>
+              )}
+            </DropdownItem>
+          );
+        })}
+      </DropdownMenu>
+    </DropdownRoot>
+  );
+}

--- a/src/components/task/TerminalPathMenu.tsx
+++ b/src/components/task/TerminalPathMenu.tsx
@@ -1,20 +1,26 @@
+import { useRef } from "react";
 import { DropdownRoot, DropdownTrigger, DropdownMenu, DropdownItem } from "@/components/ui/Dropdown";
 import { fileIconUrl } from "@/lib/explorer/iconResolver";
 
-export function TerminalPathMenu({ x, y, candidates, onPick, onClose }: {
+export function TerminalPathMenu({ x, y, candidates, onPick, onClose, onCloseAutoFocus }: {
   x: number;
   y: number;
   candidates: string[];
   onPick: (path: string) => void;
   onClose: () => void;
+  // `picked` distinguishes a candidate selection from a dismiss (Escape /
+  // click-away), so the caller can route focus accordingly.
+  onCloseAutoFocus?: (e: Event, picked: boolean) => void;
 }) {
+  const picked = useRef(false);
   return (
     <DropdownRoot open onOpenChange={(v) => { if (!v) onClose(); }}>
       <DropdownTrigger asChild>
         {/* invisible anchor at the click point; Radix positions the menu off it */}
         <div style={{ position: "fixed", left: x, top: y, width: 1, height: 1, pointerEvents: "none" }} />
       </DropdownTrigger>
-      <DropdownMenu align="start" side="bottom" sideOffset={4}>
+      <DropdownMenu align="start" side="bottom" sideOffset={4}
+        onCloseAutoFocus={onCloseAutoFocus && ((e) => onCloseAutoFocus(e, picked.current))}>
         {candidates.length === 0 ? (
           <div className="px-3 py-3 text-[13px] text-[var(--color-fg-faint)]">
             No matches
@@ -23,7 +29,7 @@ export function TerminalPathMenu({ x, y, candidates, onPick, onClose }: {
           const name = path.split("/").pop() || path;
           const dir = path.slice(0, path.length - name.length);
           return (
-            <DropdownItem key={path} onSelect={() => onPick(path)}>
+            <DropdownItem key={path} onSelect={() => { picked.current = true; onPick(path); }}>
               <img src={fileIconUrl(name)} alt="" className="h-4 w-4 shrink-0 file-icon" />
               <span className="truncate">{name}</span>
               {dir && (

--- a/src/lib/pathMatch.test.ts
+++ b/src/lib/pathMatch.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { normalizePath, matchesSuffix, resolvePathClick } from "./pathMatch";
+
+describe("normalizePath", () => {
+  it("strips a leading ./", () => {
+    expect(normalizePath("./src/a.ts")).toBe("src/a.ts");
+  });
+  it("strips all leading ./ and / segments", () => {
+    expect(normalizePath(".//src/a.ts")).toBe("src/a.ts");
+    expect(normalizePath("././src/a.ts")).toBe("src/a.ts");
+    expect(normalizePath("/./src/a.ts")).toBe("src/a.ts");
+  });
+  it("strips a leading absolute slash", () => {
+    expect(normalizePath("/src/a.ts")).toBe("src/a.ts");
+  });
+  it("leaves ../ alone (parent traversal is meaningful)", () => {
+    expect(normalizePath("../src/a.ts")).toBe("../src/a.ts");
+  });
+  it("leaves an already-bare path untouched", () => {
+    expect(normalizePath("src/a.ts")).toBe("src/a.ts");
+  });
+});
+
+describe("matchesSuffix", () => {
+  it("matches an identical path", () => {
+    expect(matchesSuffix("src/file.ts", "src/file.ts")).toBe(true);
+  });
+  it("matches a segment-boundary suffix", () => {
+    expect(matchesSuffix("foo/src/file.ts", "src/file.ts")).toBe(true);
+  });
+  it("matches a bare filename against a deeper path", () => {
+    expect(matchesSuffix("foo/src/file.ts", "file.ts")).toBe(true);
+  });
+  it("rejects a different leading segment", () => {
+    expect(matchesSuffix("abc/file.ts", "src/file.ts")).toBe(false);
+  });
+  it("rejects a raw (non-segment-boundary) suffix", () => {
+    expect(matchesSuffix("foo/barfile.ts", "file.ts")).toBe(false);
+  });
+  it("normalizes both sides before comparing", () => {
+    expect(matchesSuffix("/foo/src/file.ts", "./src/file.ts")).toBe(true);
+  });
+  it("does not match when the candidate is shorter than the query", () => {
+    expect(matchesSuffix("file.ts", "src/file.ts")).toBe(false);
+  });
+});
+
+describe("resolvePathClick", () => {
+  const files = ["src/app/dup.ts", "src/lib/dup.ts", "src/main.ts", "README.md"];
+
+  it("returns a single match (handler opens it directly)", () => {
+    expect(resolvePathClick(files, "main.ts")).toEqual(["src/main.ts"]);
+  });
+  it("returns every duplicate-basename match (handler shows the picker)", () => {
+    expect(resolvePathClick(files, "dup.ts")).toEqual(["src/app/dup.ts", "src/lib/dup.ts"]);
+  });
+  it("disambiguates a duplicate down to one when the click is dir-qualified", () => {
+    expect(resolvePathClick(files, "app/dup.ts")).toEqual(["src/app/dup.ts"]);
+  });
+  it("returns nothing for an unknown path (handler shows the no-matches row)", () => {
+    expect(resolvePathClick(files, "nope.ts")).toEqual([]);
+  });
+});

--- a/src/lib/pathMatch.ts
+++ b/src/lib/pathMatch.ts
@@ -1,0 +1,17 @@
+// Matching a file-path fragment from terminal output against the workspace
+// file list, on segment boundaries (not raw string suffix).
+
+export function normalizePath(p: string): string {
+  // Strip every leading "./" and "/" (but not "../", which is meaningful).
+  return p.replace(/^(?:\.?\/)+/, "");
+}
+
+export function matchesSuffix(candidate: string, clicked: string): boolean {
+  const c = normalizePath(candidate);
+  const q = normalizePath(clicked);
+  return c === q || c.endsWith("/" + q);
+}
+
+export function resolvePathClick(files: string[], clicked: string): string[] {
+  return files.filter(f => matchesSuffix(f, clicked));
+}

--- a/src/lib/termLinkOpener.test.ts
+++ b/src/lib/termLinkOpener.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { PATH_TOKEN_RE, parsePathToken } from "./termLinkOpener";
+import { PATH_TOKEN_RE, parsePathToken, scanPathTokens } from "./termLinkOpener";
 
 const firstMatch = (s: string): string | null => PATH_TOKEN_RE.exec(s)?.[0] ?? null;
+const scan = (s: string): string[] => scanPathTokens(s).map(t => t.raw);
 
 describe("PATH_TOKEN_RE", () => {
   it("matches a dir-qualified path", () => {
@@ -26,6 +27,47 @@ describe("PATH_TOKEN_RE", () => {
   it("does not match an extension-less, slash-less word", () => {
     expect(firstMatch("README")).toBeNull();
     expect(firstMatch("just words here")).toBeNull();
+  });
+  it("matches an @ filename (retina asset)", () => {
+    expect(firstMatch("logo@2x.png")).toBe("logo@2x.png");
+  });
+  it("stays fast on a long slash-less/dot-less blob (no O(n^2) backtracking)", () => {
+    // A wrapped base64/hash line can reach tens of thousands of chars; the
+    // hover-underline pass runs this regex on every row, so a quadratic blowup
+    // would stall the main thread. Bounded segment runs keep it linear.
+    const blob = "a".repeat(40000);
+    const start = performance.now();
+    expect(firstMatch(blob)).toBeNull();
+    expect(performance.now() - start).toBeLessThan(100);
+  });
+});
+
+describe("scanPathTokens", () => {
+  it("skips a schemed URL (WebLinksAddon owns it) but keeps a nearby path", () => {
+    expect(scan("https://example.com/a/b.ts and src/file.ts:10")).toEqual(["src/file.ts:10"]);
+  });
+  it("skips an scp-style host:path git remote entirely", () => {
+    expect(scan("git@github.com:dancras/termic.git clone")).toEqual([]);
+  });
+  it("keeps a :line:col position ref (colon before a digit is not a connector)", () => {
+    expect(scan("error at src/app.ts:45:2 today")).toEqual(["src/app.ts:45:2"]);
+  });
+  it("keeps a path before a prose colon ((path): description)", () => {
+    expect(scan("see (my/path.ts): description here")).toEqual(["my/path.ts"]);
+    expect(scan("file.ts: some description")).toEqual(["file.ts"]);
+  });
+  it("keeps @ filenames and scoped-package paths", () => {
+    expect(scan("retina logo@2x.png and node_modules/@types/node/index.d.ts"))
+      .toEqual(["logo@2x.png", "node_modules/@types/node/index.d.ts"]);
+  });
+  it("still underlines bare domains (addon does not; they are path-shaped)", () => {
+    expect(scan("bare example.com/page utils.ts")).toEqual(["example.com/page", "utils.ts"]);
+  });
+  it("stays fast on a long connector-heavy blob (bounded first run)", () => {
+    const blob = ("x".repeat(300) + ":").repeat(200) + "@".repeat(40000);
+    const start = performance.now();
+    scan(blob);
+    expect(performance.now() - start).toBeLessThan(150);
   });
 });
 

--- a/src/lib/termLinkOpener.test.ts
+++ b/src/lib/termLinkOpener.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { PATH_TOKEN_RE, parsePathToken } from "./termLinkOpener";
+
+const firstMatch = (s: string): string | null => PATH_TOKEN_RE.exec(s)?.[0] ?? null;
+
+describe("PATH_TOKEN_RE", () => {
+  it("matches a dir-qualified path", () => {
+    expect(firstMatch("src/index.ts")).toBe("src/index.ts");
+  });
+  it("matches a bare filename with a letter-led extension", () => {
+    expect(firstMatch("file.ts")).toBe("file.ts");
+  });
+  it("matches a multi-dotted filename", () => {
+    expect(firstMatch("file.min.js")).toBe("file.min.js");
+  });
+  it("captures a trailing :line:col", () => {
+    expect(firstMatch("app.tsx:45:2")).toBe("app.tsx:45:2");
+  });
+  it("captures a trailing :line", () => {
+    expect(firstMatch("src/a.ts:12")).toBe("src/a.ts:12");
+  });
+  it("does not match a bare version string", () => {
+    expect(firstMatch("1.2.3")).toBeNull();
+    expect(firstMatch("v1.2.3")).toBeNull();
+  });
+  it("does not match an extension-less, slash-less word", () => {
+    expect(firstMatch("README")).toBeNull();
+    expect(firstMatch("just words here")).toBeNull();
+  });
+});
+
+describe("parsePathToken", () => {
+  it("splits path, line, and col", () => {
+    expect(parsePathToken("src/file.ts:123:5")).toEqual({ path: "src/file.ts", line: 123, col: 5 });
+  });
+  it("splits path and line with no col", () => {
+    expect(parsePathToken("src/file.ts:123")).toEqual({ path: "src/file.ts", line: 123, col: undefined });
+  });
+  it("returns just the path when there is no trailing line", () => {
+    expect(parsePathToken("src/file.ts")).toEqual({ path: "src/file.ts" });
+  });
+  it("handles a bare filename", () => {
+    expect(parsePathToken("file.ts")).toEqual({ path: "file.ts" });
+  });
+});

--- a/src/lib/termLinkOpener.ts
+++ b/src/lib/termLinkOpener.ts
@@ -64,9 +64,14 @@ function osc8LinkAt(term: Terminal, absRow: number, col: number): string | null 
   }
 }
 
-/** URL or file-path reference at the mouse position, or null. URLs win: the
- *  URL scan runs before the path scan over the same click index. */
-function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): ClickTarget | null {
+interface ClickContext { absRow: number; col: number; text: string; clickIdx: number; }
+
+/** The clicked cell plus the LOGICAL line under it (soft-wrapped rows joined),
+ *  with the clicked cell's index into that line. translateToString(false)
+ *  keeps trailing spaces so column math stays aligned across rows. (Wide CJK
+ *  glyphs before the token can shift the index; accepted.) Null if the click
+ *  isn't over a cell. Shared by urlAt/pathAt so the join runs once. */
+function clickContext(term: Terminal, host: HTMLElement, ev: MouseEvent): ClickContext | null {
   const screen = host.querySelector(".xterm-screen") as HTMLElement | null;
   if (!screen) return null;
   const rect = screen.getBoundingClientRect();
@@ -75,16 +80,6 @@ function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): ClickTarget 
   const row = Math.floor((ev.clientY - rect.top) / (rect.height / term.rows));
   if (col < 0 || col >= term.cols || row < 0 || row >= term.rows) return null;
 
-  // OSC 8 first: if the clicked cell carries an explicit hyperlink, that
-  // beats any text-scrape guess.
-  const osc8 = osc8LinkAt(term, term.buffer.active.viewportY + row, col);
-  if (osc8) return { kind: "url", uri: osc8 };
-
-  // Reconstruct the LOGICAL line under the click (soft-wrapped rows joined),
-  // tracking the clicked cell's character index. translateToString(false)
-  // keeps trailing spaces so column math stays aligned across rows. (Wide
-  // CJK glyphs before the URL can shift the index; accepted — URLs and the
-  // text around them are overwhelmingly single-width.)
   const buf = term.buffer.active;
   const clickedLine = buf.viewportY + row;
   let start = clickedLine;
@@ -98,18 +93,30 @@ function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): ClickTarget 
     text += line.translateToString(false);
   }
   if (clickIdx < 0) return null;
+  return { absRow: clickedLine, col, text, clickIdx };
+}
 
+/** URL at the click: an OSC 8 hyperlink on the cell (explicit, so it beats any
+ *  text scrape), else a scraped http(s) URL. Null if neither. */
+function urlAt(term: Terminal, ctx: ClickContext): ClickTarget | null {
+  const osc8 = osc8LinkAt(term, ctx.absRow, ctx.col);
+  if (osc8) return { kind: "url", uri: osc8 };
   URL_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
-  while ((m = URL_RE.exec(text))) {
-    if (clickIdx >= m.index && clickIdx < m.index + m[0].length) {
+  while ((m = URL_RE.exec(ctx.text))) {
+    if (ctx.clickIdx >= m.index && ctx.clickIdx < m.index + m[0].length) {
       return { kind: "url", uri: m[0].replace(TRAILING_PUNCT_RE, "") };
     }
   }
+  return null;
+}
 
+/** File-path reference at the click, or null. */
+function pathAt(ctx: ClickContext): ClickTarget | null {
   PATH_TOKEN_RE_G.lastIndex = 0;
-  while ((m = PATH_TOKEN_RE_G.exec(text))) {
-    if (clickIdx >= m.index && clickIdx < m.index + m[0].length) {
+  let m: RegExpExecArray | null;
+  while ((m = PATH_TOKEN_RE_G.exec(ctx.text))) {
+    if (ctx.clickIdx >= m.index && ctx.clickIdx < m.index + m[0].length) {
       const { path, line, col } = parsePathToken(m[0].replace(TRAILING_PUNCT_RE, ""));
       return { kind: "path", path, line, col };
     }
@@ -122,6 +129,7 @@ export function attachCmdClickLinkOpener(
   term: Terminal,
   host: HTMLElement,
   onActivate: (target: ClickTarget, clientX: number, clientY: number) => void,
+  opts?: { urlsOnly?: boolean },
 ): () => void {
   // Armed between mousedown and the trailing click event so the whole
   // gesture is swallowed as one unit (mouse reporting never sees any of it,
@@ -131,7 +139,10 @@ export function attachCmdClickLinkOpener(
   function onDown(ev: MouseEvent) {
     armed = null;
     if (ev.button !== 0 || !(ev.metaKey || ev.ctrlKey)) return;
-    const target = linkAt(term, host, ev);
+    const ctx = clickContext(term, host, ev);
+    if (!ctx) return;
+    // URLs win over paths; the scratch shell (urlsOnly) never resolves paths.
+    const target = urlAt(term, ctx) ?? (opts?.urlsOnly ? null : pathAt(ctx));
     if (!target) return;
     armed = { target, x: ev.clientX, y: ev.clientY };
     ev.preventDefault();
@@ -174,8 +185,8 @@ export function registerPathLinkProvider(
       const y0 = bufferLineNumber - 1;
       let start = y0;
       while (start > 0 && buf.getLine(start)?.isWrapped) start--;
-      // Reconstruct the wrapped logical line (as in linkAt), tracking each
-      // row's start offset. Single-width assumption: wide CJK can shift it.
+      // Reconstruct the wrapped logical line (as in clickContext), tracking
+      // each row's start offset. Single-width assumption: wide CJK can shift it.
       let text = "";
       const rowStart: number[] = [];
       for (let ln = start; ln - start < 100; ln++) {
@@ -199,11 +210,12 @@ export function registerPathLinkProvider(
         const raw = m[0].replace(TRAILING_PUNCT_RE, "");
         if (!raw) continue;
         const s = toPos(m.index);
-        const e = toPos(m.index + raw.length);
+        // End on the last char (+1 -> 1-based inclusive), not one-past: a token
+        // ending on a soft wrap would otherwise land at col 0 of the next row.
+        const e = toPos(m.index + raw.length - 1);
         const { path, line, col } = parsePathToken(raw);
         links.push({
-          // end.x has no +1: xterm's 1-based end == the 0-based "one past last" column.
-          range: { start: { x: s.col + 1, y: s.row + 1 }, end: { x: e.col, y: e.row + 1 } },
+          range: { start: { x: s.col + 1, y: s.row + 1 }, end: { x: e.col + 1, y: e.row + 1 } },
           text: raw,
           activate: (event) => onActivate(path, line, col, event),
         });

--- a/src/lib/termLinkOpener.ts
+++ b/src/lib/termLinkOpener.ts
@@ -24,9 +24,45 @@ import type { Terminal, ILink, IDisposable } from "@xterm/xterm";
 const URL_RE = /https?:\/\/[^\s"'`<>{}|\\^\[\]]+/g;
 // File-path-like token: dir-qualified, or a bare filename with a letter-led
 // extension (so version strings like "1.2.3" don't match), plus optional
-// trailing :line[:col].
-export const PATH_TOKEN_RE = /(?:(?:[\w.-]+\/)+[\w.-]+|[\w.-]+\.[A-Za-z]\w{0,9})(?::\d+(?::\d+)?)?/;
-const PATH_TOKEN_RE_G = new RegExp(PATH_TOKEN_RE.source, "g");
+// trailing :line[:col]. `@` is a valid path char so retina assets
+// (`logo@2x.png`) and scoped packages (`@types/node`) resolve; the cost is a
+// bare `user@host` email underlining and resolving to nothing (harmless).
+// Each segment run is bounded ({1,255}, the max filename length) so a long
+// slash-less/dot-less blob (base64, a hash) can't drive the regex into O(n^2)
+// backtracking and stall the hover-underline pass.
+export const PATH_TOKEN_RE = /(?:(?:[\w.@-]{1,255}\/)+[\w.@-]{1,255}|[\w.@-]{1,255}\.[A-Za-z]\w{0,9})(?::\d+(?::\d+)?)?/;
+
+// Single scan that recognises three things so a fragment of one can't leak as
+// another (e.g. the `host/path.ts` inside a URL, or the two halves of an scp
+// remote, being mistaken for paths). Only the `path` group is ours:
+//   url  - a schemed URL. WebLinksAddon draws its own hover-underline, so we
+//          consume-and-skip it here to avoid a double underline. Scheme bounded
+//          ({0,15}) so it can't backtrack on a long slash-less run.
+//   junk - an scp-style `host:path` git remote: a colon glued straight onto a
+//          path char (not `:line:col`, not a `(path): prose` colon). Consumed
+//          so neither the host nor the path half underlines.
+//   path - PATH_TOKEN_RE.
+const PATH_SCAN_RE_G = new RegExp(
+  "(?<url>[a-zA-Z][\\w+.-]{0,15}:\\/\\/\\S+)" +
+  "|(?<junk>[\\w.@-]{1,255}:(?=[A-Za-z_~./])[\\w.@:/-]*)" +
+  "|(?<path>" + PATH_TOKEN_RE.source + ")",
+  "g",
+);
+
+/** File-path tokens in `text`, skipping URLs and scp `host:path` compounds.
+ *  Each result carries the token's start index so callers can hit-test a click
+ *  or build a hover range; `raw` has trailing prose punctuation trimmed. */
+export function scanPathTokens(text: string): { raw: string; index: number }[] {
+  PATH_SCAN_RE_G.lastIndex = 0;
+  const out: { raw: string; index: number }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = PATH_SCAN_RE_G.exec(text))) {
+    if (m.groups?.path === undefined) continue; // url / junk: not ours
+    const raw = m[0].replace(TRAILING_PUNCT_RE, "");
+    if (raw) out.push({ raw, index: m.index });
+  }
+  return out;
+}
 const TRAILING_LINE_COL_RE = /:(\d+)(?::(\d+))?$/;
 const TRAILING_PUNCT_RE = /[.,;:!?)\]}>'"]+$/;
 
@@ -113,11 +149,9 @@ function urlAt(term: Terminal, ctx: ClickContext): ClickTarget | null {
 
 /** File-path reference at the click, or null. */
 function pathAt(ctx: ClickContext): ClickTarget | null {
-  PATH_TOKEN_RE_G.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = PATH_TOKEN_RE_G.exec(ctx.text))) {
-    if (ctx.clickIdx >= m.index && ctx.clickIdx < m.index + m[0].length) {
-      const { path, line, col } = parsePathToken(m[0].replace(TRAILING_PUNCT_RE, ""));
+  for (const { raw, index } of scanPathTokens(ctx.text)) {
+    if (ctx.clickIdx >= index && ctx.clickIdx < index + raw.length) {
+      const { path, line, col } = parsePathToken(raw);
       return { kind: "path", path, line, col };
     }
   }
@@ -203,16 +237,12 @@ export function registerPathLinkProvider(
         return { row: start + i, col: offset - rowStart[i] };
       };
 
-      PATH_TOKEN_RE_G.lastIndex = 0;
       const links: ILink[] = [];
-      let m: RegExpExecArray | null;
-      while ((m = PATH_TOKEN_RE_G.exec(text))) {
-        const raw = m[0].replace(TRAILING_PUNCT_RE, "");
-        if (!raw) continue;
-        const s = toPos(m.index);
+      for (const { raw, index } of scanPathTokens(text)) {
+        const s = toPos(index);
         // End on the last char (+1 -> 1-based inclusive), not one-past: a token
         // ending on a soft wrap would otherwise land at col 0 of the next row.
-        const e = toPos(m.index + raw.length - 1);
+        const e = toPos(index + raw.length - 1);
         const { path, line, col } = parsePathToken(raw);
         links.push({
           range: { start: { x: s.col + 1, y: s.row + 1 }, end: { x: e.col + 1, y: e.row + 1 } },

--- a/src/lib/termLinkOpener.ts
+++ b/src/lib/termLinkOpener.ts
@@ -11,13 +11,39 @@
 // from the buffer, open it, and swallow the gesture so neither xterm's mouse
 // reporting nor the addon double-handles it. The addon stays loaded for
 // hover-underline and as the opener when no TUI is intercepting.
+//
+// GH #117: the opener also resolves file-path references. Their hover-underline
+// can't reuse WebLinksAddon: its link computer runs every match through
+// `new URL()`, which throws for scheme-less paths and drops them.
+// registerPathLinkProvider below uses xterm's link API directly.
 
-import type { Terminal } from "@xterm/xterm";
+import type { Terminal, ILink, IDisposable } from "@xterm/xterm";
 
 // Slightly looser than the WebLinksAddon regex; trailing punctuation that
 // prose tends to glue onto a URL is trimmed after matching.
 const URL_RE = /https?:\/\/[^\s"'`<>{}|\\^\[\]]+/g;
+// File-path-like token: dir-qualified, or a bare filename with a letter-led
+// extension (so version strings like "1.2.3" don't match), plus optional
+// trailing :line[:col].
+export const PATH_TOKEN_RE = /(?:(?:[\w.-]+\/)+[\w.-]+|[\w.-]+\.[A-Za-z]\w{0,9})(?::\d+(?::\d+)?)?/;
+const PATH_TOKEN_RE_G = new RegExp(PATH_TOKEN_RE.source, "g");
+const TRAILING_LINE_COL_RE = /:(\d+)(?::(\d+))?$/;
 const TRAILING_PUNCT_RE = /[.,;:!?)\]}>'"]+$/;
+
+export type ClickTarget =
+  | { kind: "url"; uri: string }
+  | { kind: "path"; path: string; line?: number; col?: number };
+
+/** Split "src/file.ts:123:5" into { path, line, col }. */
+export function parsePathToken(full: string): { path: string; line?: number; col?: number } {
+  const lc = TRAILING_LINE_COL_RE.exec(full);
+  if (!lc) return { path: full };
+  return {
+    path: full.slice(0, lc.index),
+    line: parseInt(lc[1], 10),
+    col: lc[2] !== undefined ? parseInt(lc[2], 10) : undefined,
+  };
+}
 
 /** OSC 8 hyperlink at a buffer cell, or null. Anchor-text links ("Learn
  *  more") carry their URL only in the escape sequence, never in the visible
@@ -38,8 +64,9 @@ function osc8LinkAt(term: Terminal, absRow: number, col: number): string | null 
   }
 }
 
-/** URL in the terminal buffer at the mouse position, or null. */
-function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): string | null {
+/** URL or file-path reference at the mouse position, or null. URLs win: the
+ *  URL scan runs before the path scan over the same click index. */
+function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): ClickTarget | null {
   const screen = host.querySelector(".xterm-screen") as HTMLElement | null;
   if (!screen) return null;
   const rect = screen.getBoundingClientRect();
@@ -51,7 +78,7 @@ function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): string | nul
   // OSC 8 first: if the clicked cell carries an explicit hyperlink, that
   // beats any text-scrape guess.
   const osc8 = osc8LinkAt(term, term.buffer.active.viewportY + row, col);
-  if (osc8) return osc8;
+  if (osc8) return { kind: "url", uri: osc8 };
 
   // Reconstruct the LOGICAL line under the click (soft-wrapped rows joined),
   // tracking the clicked cell's character index. translateToString(false)
@@ -76,7 +103,15 @@ function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): string | nul
   let m: RegExpExecArray | null;
   while ((m = URL_RE.exec(text))) {
     if (clickIdx >= m.index && clickIdx < m.index + m[0].length) {
-      return m[0].replace(TRAILING_PUNCT_RE, "");
+      return { kind: "url", uri: m[0].replace(TRAILING_PUNCT_RE, "") };
+    }
+  }
+
+  PATH_TOKEN_RE_G.lastIndex = 0;
+  while ((m = PATH_TOKEN_RE_G.exec(text))) {
+    if (clickIdx >= m.index && clickIdx < m.index + m[0].length) {
+      const { path, line, col } = parsePathToken(m[0].replace(TRAILING_PUNCT_RE, ""));
+      return { kind: "path", path, line, col };
     }
   }
   return null;
@@ -86,33 +121,33 @@ function linkAt(term: Terminal, host: HTMLElement, ev: MouseEvent): string | nul
 export function attachCmdClickLinkOpener(
   term: Terminal,
   host: HTMLElement,
-  open: (uri: string) => void,
+  onActivate: (target: ClickTarget, clientX: number, clientY: number) => void,
 ): () => void {
   // Armed between mousedown and the trailing click event so the whole
   // gesture is swallowed as one unit (mouse reporting never sees any of it,
   // and the WebLinksAddon can't double-open).
-  let armedUri: string | null = null;
+  let armed: { target: ClickTarget; x: number; y: number } | null = null;
 
   function onDown(ev: MouseEvent) {
-    armedUri = null;
+    armed = null;
     if (ev.button !== 0 || !(ev.metaKey || ev.ctrlKey)) return;
-    const uri = linkAt(term, host, ev);
-    if (!uri) return;
-    armedUri = uri;
+    const target = linkAt(term, host, ev);
+    if (!target) return;
+    armed = { target, x: ev.clientX, y: ev.clientY };
     ev.preventDefault();
     ev.stopPropagation();
   }
   function onUp(ev: MouseEvent) {
-    if (!armedUri) return;
+    if (!armed) return;
     ev.preventDefault();
     ev.stopPropagation();
-    open(armedUri);
+    onActivate(armed.target, armed.x, armed.y);
     // Clear AFTER the browser dispatches the trailing click (same turn),
     // so onClick below still sees the armed state and swallows it.
-    setTimeout(() => { armedUri = null; }, 0);
+    setTimeout(() => { armed = null; }, 0);
   }
   function onClick(ev: MouseEvent) {
-    if (!armedUri) return;
+    if (!armed) return;
     ev.preventDefault();
     ev.stopPropagation();
   }
@@ -125,4 +160,55 @@ export function attachCmdClickLinkOpener(
     host.removeEventListener("mouseup", onUp, true);
     host.removeEventListener("click", onClick, true);
   };
+}
+
+/** Hover-underline for file-path references. Activation is a fallback; real
+ *  clicks go through the capture-phase opener above. */
+export function registerPathLinkProvider(
+  term: Terminal,
+  onActivate: (path: string, line: number | undefined, col: number | undefined, event: MouseEvent) => void,
+): IDisposable {
+  return term.registerLinkProvider({
+    provideLinks(bufferLineNumber, callback) {
+      const buf = term.buffer.active;
+      const y0 = bufferLineNumber - 1;
+      let start = y0;
+      while (start > 0 && buf.getLine(start)?.isWrapped) start--;
+      // Reconstruct the wrapped logical line (as in linkAt), tracking each
+      // row's start offset. Single-width assumption: wide CJK can shift it.
+      let text = "";
+      const rowStart: number[] = [];
+      for (let ln = start; ln - start < 100; ln++) {
+        const line = buf.getLine(ln);
+        if (!line || (ln !== start && !line.isWrapped)) break;
+        rowStart.push(text.length);
+        text += line.translateToString(false);
+      }
+      if (rowStart.length === 0) { callback(undefined); return; }
+
+      const toPos = (offset: number) => {
+        let i = 0;
+        while (i + 1 < rowStart.length && rowStart[i + 1] <= offset) i++;
+        return { row: start + i, col: offset - rowStart[i] };
+      };
+
+      PATH_TOKEN_RE_G.lastIndex = 0;
+      const links: ILink[] = [];
+      let m: RegExpExecArray | null;
+      while ((m = PATH_TOKEN_RE_G.exec(text))) {
+        const raw = m[0].replace(TRAILING_PUNCT_RE, "");
+        if (!raw) continue;
+        const s = toPos(m.index);
+        const e = toPos(m.index + raw.length);
+        const { path, line, col } = parsePathToken(raw);
+        links.push({
+          // end.x has no +1: xterm's 1-based end == the 0-based "one past last" column.
+          range: { start: { x: s.col + 1, y: s.row + 1 }, end: { x: e.col, y: e.row + 1 } },
+          text: raw,
+          activate: (event) => onActivate(path, line, col, event),
+        });
+      }
+      callback(links.length ? links : undefined);
+    },
+  });
 }


### PR DESCRIPTION
Cmd/Ctrl+click a file path printed in a terminal to open it in the editor. Agents reference files (src/foo.ts:42); this makes those references jump straight to the file instead of requiring a manual search.

### The flow

1. An agent (or any TUI) prints a file path in a terminal pane.
2. Hold Cmd/Ctrl: file paths underline like URLs.
3. Click: the file opens in the editor preview, jumping to :line:col when present.
4. If the path matches more than one file in the project, a small picker lists the candidates.

https://github.com/user-attachments/assets/c062a057-6dfb-4f6f-89b7-45c7c4897115

### Design notes

- Capture-phase opener. Reuses the existing GH #58 gesture handling, so it works even when an agent TUI has xterm mouse reporting on.
- Segment-boundary suffix match against the project's file list: one match opens directly, zero or many show the picker.
- Custom link provider for the hover underline. WebLinksAddon can't be reused, its new URL() gate silently drops scheme-less paths. Third party option `xterm-link-provider` rejected to avoid unjustified dependency.
- Scoped to agent panes; the scratch shell keeps plain URL behavior.

### Testing

Unit tests for path parsing and suffix matching. make check-all clean.

Also have an uncommitted e2e test script and demo recording script.