### PR TITLE
fix(macOS): declare local network usage

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,5 +4,7 @@
 <dict>
   <key>NSMicrophoneUsageDescription</key>
   <string>Termic uses your microphone for Claude Code voice input.</string>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>Termic uses your local network so terminal processes can connect to development services and devices on your network.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

I use a self-hosted GitLab server and use their `glab` CLI program to have agents make PRs and check GitLab's equivalent of Actions and whatnot. The agents always had to find a workaround because Termic never asks for Local Network Access, so macOS never grants it.

This PR:

- Add NSLocalNetworkUsageDescription to the macOS app bundle.
- Explain that Local Network access is used by terminal processes to reach development services and devices.

## Validation

- plutil -lint src-tauri/Info.plist
- make check-all
- Built Termic Beta.app and verified the generated bundle contains NSLocalNetworkUsageDescription
- Verified a previously failing glab auth status request to a private LAN GitLab instance succeeds from a Termic agent PTY