### PR TITLE
feat(cli): Phase 0 control plane, list/status/open, bundling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,7 @@ jobs:
           workspaces: src-tauri
       - name: Run unit tests
         working-directory: src-tauri
-        run: cargo test --lib
+        # --workspace so the CLI crates (termic-proto wire round-trips,
+        # termic-cli exit-code + output goldens) run alongside the app's
+        # lib tests. The behavioral sandbox tests self-skip off macOS.
+        run: cargo test --workspace --lib

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,15 @@ run_no_pill: ## Run dev with the DEV pill hidden (VITE_HIDE_DEV_PILL=1). For cle
 	@VITE_HIDE_DEV_PILL=1 node scripts/dev.mjs
 .PHONY: run_no_pill
 
+cli-dev: ## Build the debug termic-cli and symlink it as `termic-dev` in ~/.local/bin (talks to the dev app; coexists with a prod `termic`).
+	@cd src-tauri && TERMIC_APP_VERSION="$$(node -p "require('$(CURDIR)/package.json').version")" cargo build -p termic-cli
+	@mkdir -p "$$HOME/.local/bin"
+	@ln -sf "$(CURDIR)/src-tauri/target/debug/termic-cli" "$$HOME/.local/bin/termic-dev"
+	@echo "✓ termic-dev -> src-tauri/target/debug/termic-cli"
+	@case ":$$PATH:" in *":$$HOME/.local/bin:"*) echo "  ~/.local/bin is on your PATH; run: termic-dev list";; \
+	  *) echo "  note: add ~/.local/bin to your PATH, then run: termic-dev list";; esac
+.PHONY: cli-dev
+
 check: ## Type-check the Rust backend (fast — no codegen, no link).
 	@if command -v cargo >/dev/null 2>&1; then \
 	    cd src-tauri && cargo check; \

--- a/docs/plans/cli.md
+++ b/docs/plans/cli.md
@@ -1,6 +1,9 @@
 # termic CLI (design)
 
-Status: proposed, not started.
+Status: Phase 0 implemented (PR #132) - `termic-proto` + `termic-cli`,
+the socket server, `open`/`list`/`status`, sidecar bundling, PATH install,
+and single-instance-per-data-dir. Phase 1+ pending. Sections below note
+where the implementation refined the original design.
 
 A `termic` command that creates tasks, lists them with live agent state, focuses
 the GUI, injects prompts, and attaches a real TTY to an agent's PTY, from any
@@ -127,8 +130,11 @@ termic (CLI, thin)  ──unix socket──  Termic.app
   auto-updates under a shell that resolved `termic` at login. Bind-time
   check against sun_path's 104-byte Darwin limit with a clear error. Debug
   builds already use a separate data dir (`termic_dev` via `APP_DIR`,
-  lib.rs:545), so dev and release sockets never collide; a hypothetical Beta
-  RELEASE build would share the release socket - accepted for v1, noted.
+  lib.rs:545), so dev and release sockets never collide. Beta shares the
+  release data dir + socket by design (it is long-term prod testing);
+  Phase 0 enforces one instance per data dir (see the launch bullet), so
+  beta and prod are mutually exclusive rather than colliding - launching
+  one while the other runs raises the running one and exits.
   `TERMIC_SOCKET` overrides for cross-targeting. Requests carry a per-boot token (below). Responses
   are either one object or a `stream: true` sequence (setup output, attach)
   ending in a final `done` object.
@@ -145,10 +151,19 @@ termic (CLI, thin)  ──unix socket──  Termic.app
 - **App discovery/launch**: every command requires the running app; there is
   no offline mode and no disk-fallback read path. No socket -> `open -ga
   Termic` (background, no focus steal), poll the socket with a deadline, then
-  fail with "Termic did not start" rather than hanging. `--no-launch` swaps
-  auto-launch for an immediate "Termic must be open" error, for scripts.
-  Concurrent invocations racing `open -ga` are deduped by LaunchServices; if
-  doubles ever show up anyway, tmux's flock'd spawn lock is the known fix.
+  fail with "Termic did not start" rather than hanging. Auto-launch is
+  RELEASE-only: a debug CLI targets the `termic_dev` socket, so it never
+  launches the release app (it fail-fasts with a pointer at `TERMIC_SOCKET`
+  instead). `--no-launch` swaps auto-launch for an immediate "Termic must be
+  open" error, for scripts. Concurrent invocations racing `open -ga` are
+  deduped by LaunchServices. Phase 0 additionally enforces ONE INSTANCE PER
+  DATA DIR: on startup a release build connects to its data dir's socket and,
+  if a live termic answers, asks it to raise its window (a new unauthenticated
+  `raise` verb) and exits, so a second launch (prod vs beta, or a direct
+  binary run) never opens a duplicate racing the shared projects.json/tasks/.
+  Debug is newest-wins (relaunching `make dev` steals the socket). The
+  tmux-style flock'd spawn lock remains the known fix for the residual
+  simultaneous-launch race (two launches within the pre-bind window).
 - **Remote is out of scope.** The auth model is deliberately local-only
   primitives (unix socket, `getpeereid`, 0600 token file) and remote would
   break all three; nothing in this plan designs for it. Worth recording why
@@ -493,11 +508,21 @@ this design; the socket server adds no new webview egress.
 
 Bundled in `Termic.app` via Tauri's `externalBin` (sidecar) mechanism, so the
 CLI updates in lockstep with the app updater and there is never a version-skew
-matrix in v1. PATH install like VS Code: a Settings action (plus a first-run
-hint) symlinks the bundled binary into `/usr/local/bin` (admin prompt) or
-`~/.local/bin` (fallback, no prompt). The hello handshake carries a protocol
-version anyway, so a later Homebrew formula (CLI-only installs, version skew
-becomes real) needs no protocol change.
+matrix in v1. PATH install like VS Code, refined in Phase 0: enabling the CLI
+auto-installs it with no prompt into `~/.local/bin` and shows whether that dir
+is on the login PATH; a "system-wide" Settings action upgrades to
+`/usr/local/bin` (admin prompt, macOS only). The installed command name is
+build-aware - `termic` (release), `termic-dev` (debug, targets the `termic_dev`
+data dir), `termic-beta` (beta bundle) - so dev, beta, and prod coexist on
+PATH; the on-disk sidecar is always `termic-cli`, only the symlink name varies.
+
+The CLI's `--version` reports the APP version, not the crate version: it is
+injected at build time via `TERMIC_APP_VERSION` (set by `src-tauri/build.rs`
+and `scripts/build-cli.mjs`, read through `option_env!` with the crate version
+as the dev fallback), so a bundled CLI is always versioned with the app it
+ships in. The hello handshake carries a protocol version anyway, so a later
+Homebrew formula (CLI-only installs, version skew becomes real) needs no
+protocol change.
 
 ## Phasing
 
@@ -589,10 +614,11 @@ Merged is not live; exposure is controlled independently of review:
 - Verbs are gated behind an "Enable CLI" setting (default off initially).
   The server always binds once its phase ships and answers hello/status
   regardless, so a disabled CLI fails fast with "Termic is running but the
-  CLI is disabled, enable it in Settings". The unauthenticated hello
-  intentionally discloses app-is-running plus protocol version to any
-  same-uid process; that disclosure is the price of the clear error and is
-  accepted. (The obvious alternative, bind
+  CLI is disabled, enable it in Settings". The unauthenticated surface is
+  `hello` (discloses app-is-running + protocol version) and `raise` (brings
+  the window to front, used by the single-instance handshake); neither leaks
+  anything sensitive to a same-uid process, and that disclosure is the price
+  of the clear error plus single-instance, and is accepted. (The obvious alternative, bind
   only when enabled, creates a first-run dead end: `termic new` auto-launches
   the app, polls a socket that will never bind, and times out with the WRONG
   error, "Termic did not start".) A merged phase is dormant behavior until

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -65,6 +65,18 @@ gate, not a CSP tweak, per the note below.
 **Before widening the CSP again, remember it is app-wide.** `connect-src` or
 `script-src` would be materially worse than `img-src` is.
 
+## Known gap: Monitor mode reaches the CLI control plane
+
+The CLI control socket (docs/plans/cli.md) is denied to `Enforce` /
+`EnforceFs` agents as the final SBPL rules (socket + data-dir denies). It
+is deliberately NOT denied in `Monitor` mode, whose contract is
+observe-never-block: a monitored agent renders `(allow default (with
+report))`, so if the CLI is enabled it can reach the socket and read the
+token, and that access simply shows up in the file-op / activity log. This
+is the accepted trade-off of Monitoring being a pure observer; the cage
+that actually enforces the boundary is `Enforce`/`EnforceFs`. (Same spirit
+as the webview gap above: a documented, accepted exposure, not a leak.)
+
 ## Do NOT
 
 - Sandbox AuxTerminal, setup, run, or archive scripts.

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Stage the `termic-cli` sidecar into src-tauri/binaries/ for whatever
+// triple `tauri build` is about to bundle. Runs from beforeBuildCommand.
+//
+// src-tauri/build.rs already produces the per-triple sidecar during every
+// plain cargo compile (and lipos the universal one when both arch files
+// exist). This hook is the belt-and-braces for `tauri build`, which does
+// NOT reliably expose the requested --target to beforeBuildCommand: rather
+// than guess, we build every macOS arch whose rustc target is installed
+// (plus the host triple) and lipo the universal fat binary when both mac
+// arches are present. Whatever triple tauri then asks tauri-build for,
+// aarch64 / x86_64 / universal, the file is already there.
+
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { platform } from "node:os";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const srcTauri = resolve(root, "src-tauri");
+const binaries = resolve(srcTauri, "binaries");
+const targetDir = resolve(srcTauri, "target", "cli-sidecar");
+
+// Version the bundled CLI with the app (see src-tauri/build.rs for the
+// matching injection). termic-cli reads TERMIC_APP_VERSION via option_env!,
+// so `termic --version` prints the app version rather than the crate one.
+const appVersion = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8")).version;
+
+const run = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, {
+    stdio: "inherit",
+    cwd: srcTauri,
+    ...opts,
+    env: { ...process.env, TERMIC_APP_VERSION: appVersion, ...(opts.env ?? {}) },
+  });
+
+const capture = (cmd, args) =>
+  execFileSync(cmd, args, { encoding: "utf8", cwd: srcTauri });
+
+const hostTriple = () => {
+  const m = capture("rustc", ["-vV"]).match(/^host: (.+)$/m);
+  if (!m) throw new Error("cannot determine host triple from rustc -vV");
+  return m[1].trim();
+};
+
+const installedTargets = () => {
+  try {
+    return new Set(capture("rustup", ["target", "list", "--installed"]).split(/\r?\n/).filter(Boolean));
+  } catch {
+    return new Set(); // no rustup (e.g. rustc-only) - host triple still builds
+  }
+};
+
+const buildOne = (triple) => {
+  run("cargo", [
+    "build", "--release", "-p", "termic-cli",
+    "--target", triple, "--target-dir", targetDir,
+  ]);
+  const built = resolve(targetDir, triple, "release", "termic-cli");
+  const dest = resolve(binaries, `termic-cli-${triple}`);
+  copyFileSync(built, dest);
+  console.log(`sidecar: ${dest}`);
+  return dest;
+};
+
+mkdirSync(binaries, { recursive: true });
+
+const host = hostTriple();
+const targets = new Set([host]);
+
+if (platform() === "darwin") {
+  // Build whichever mac arches are installed so a universal bundle finds
+  // both halves; the host arch is always buildable.
+  const installed = installedTargets();
+  const arches = ["aarch64-apple-darwin", "x86_64-apple-darwin"].filter(
+    (t) => t === host || installed.has(t),
+  );
+  arches.forEach((t) => targets.add(t));
+  targets.forEach(buildOne);
+  const a = resolve(binaries, "termic-cli-aarch64-apple-darwin");
+  const x = resolve(binaries, "termic-cli-x86_64-apple-darwin");
+  if (arches.includes("aarch64-apple-darwin") && arches.includes("x86_64-apple-darwin")) {
+    const u = resolve(binaries, "termic-cli-universal-apple-darwin");
+    run("lipo", ["-create", "-output", u, a, x]);
+    console.log(`sidecar (universal): ${u}`);
+  } else {
+    console.log(
+      "note: only one macOS arch installed; skipping the universal sidecar " +
+        "(a universal `tauri build` needs both aarch64 and x86_64 rustup targets).",
+    );
+  }
+} else {
+  buildOne(host);
+}

--- a/src-tauri/.gitignore
+++ b/src-tauri/.gitignore
@@ -21,3 +21,7 @@ notarytool-history.plist
 # someone else's machine + breaks reproducible builds). Build script
 # regenerates on each tauri:build via the recipe.
 resources/tinyproxy
+
+# termic-cli sidecar staging (built by src-tauri/build.rs / scripts/build-cli.mjs
+# into binaries/termic-cli-<triple>; arch-specific, never committed).
+/binaries/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -42,6 +42,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +554,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+ "terminal_size",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +602,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2044,6 +2141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2851,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -4075,6 +4184,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,7 +4746,37 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
+ "termic-proto",
  "uuid",
+]
+
+[[package]]
+name = "termic-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dirs 5.0.1",
+ "serde",
+ "serde_json",
+ "termic-proto",
+]
+
+[[package]]
+name = "termic-proto"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5144,6 +5294,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,3 +1,10 @@
+# Workspace root. The two CLI crates live BESIDE src-tauri (repo root)
+# per docs/plans/cli.md; keeping the workspace rooted here keeps
+# Cargo.lock and target/ where every script, CI cache key, and Makefile
+# path already expects them.
+[workspace]
+members = ["../termic-proto", "../termic-cli"]
+
 [package]
 name = "termic"
 version = "0.23.4"
@@ -54,6 +61,9 @@ base64 = "0.22"
 # it direct doesn't change resolution.
 percent-encoding = "2"
 tauri-plugin-clipboard-manager = "2.3.2"
+# Wire types + framing for the CLI control socket (cli_server.rs). The
+# same crate termic-cli links, so server and client cannot drift.
+termic-proto = { path = "../termic-proto" }
 
 # macOS-only: raw Objective-C bridge used to round the window's content
 # layer on macOS Tahoe (26+) so the WKWebView corners match the system's

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,94 @@
+use std::path::PathBuf;
+use std::process::Command;
+
 fn main() {
+    build_cli_sidecar();
     tauri_build::build()
+}
+
+/// Build the `termic-cli` sidecar BEFORE tauri_build runs: tauri-build
+/// hard-errors when a configured `externalBin` file is missing, and it
+/// runs on every `cargo check` / `cargo test` / `tauri dev` / `tauri
+/// build` of this crate, so the sidecar has to exist for all of them.
+/// Building it here (instead of a wrapper script) keeps plain cargo
+/// workflows green with zero extra steps.
+///
+/// The nested cargo build uses its OWN target dir (`target/cli-sidecar`)
+/// because the outer cargo holds a lock on the shared one; same-dir
+/// nesting deadlocks. The universal-macOS bundle case (both arches +
+/// lipo) is handled by scripts/build-cli.mjs in beforeBuildCommand,
+/// which runs unconditionally at bundle time; this hook covers every
+/// per-triple compile, including each arch pass of a universal build.
+fn build_cli_sidecar() {
+    // Rebuild the sidecar when the CLI crates change. Directory entries
+    // are watched recursively by cargo.
+    println!("cargo:rerun-if-changed=../termic-cli/src");
+    println!("cargo:rerun-if-changed=../termic-cli/Cargo.toml");
+    println!("cargo:rerun-if-changed=../termic-proto/src");
+    println!("cargo:rerun-if-changed=../termic-proto/Cargo.toml");
+
+    let target = std::env::var("TARGET").expect("cargo sets TARGET");
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let sidecar_target_dir = manifest_dir.join("target").join("cli-sidecar");
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+
+    // Build the sidecar in the SAME profile as the app so a debug
+    // `cargo check` / `make check` / `tauri dev` doesn't trigger a full
+    // release codegen of the CLI (clap+serde). The dev app gets a debug
+    // sidecar (which is what it wants anyway); a release `tauri build`
+    // gets a release one, matching scripts/build-cli.mjs.
+    let release = std::env::var("PROFILE").as_deref() == Ok("release");
+    let profile_dir = if release { "release" } else { "debug" };
+    let mut args: Vec<&str> = vec!["build", "-p", "termic-cli", "--target", &target];
+    if release {
+        args.push("--release");
+    }
+    args.extend(["--target-dir", sidecar_target_dir.to_str().expect("utf-8 target dir")]);
+
+    let status = Command::new(&cargo)
+        .current_dir(&manifest_dir)
+        .args(&args)
+        // Version the bundled CLI with the app: `termic --version` reads
+        // this at compile time (termic-cli reads TERMIC_APP_VERSION via
+        // option_env!). env!("CARGO_PKG_VERSION") here is the APP crate's
+        // version. Kept in sync with scripts/build-cli.mjs, which sets the
+        // same var for the `tauri build` sidecar.
+        .env("TERMIC_APP_VERSION", env!("CARGO_PKG_VERSION"))
+        // The outer build's target-dir override must not leak into the
+        // nested build (it would recreate the lock deadlock), and the
+        // jobserver env from make/cargo confuses a nested cargo.
+        .env_remove("CARGO_TARGET_DIR")
+        .env_remove("MAKEFLAGS")
+        .env_remove("CARGO_MAKEFLAGS")
+        .env_remove("MFLAGS")
+        .status()
+        .expect("failed to spawn cargo for the termic-cli sidecar");
+    assert!(status.success(), "building the termic-cli sidecar failed");
+
+    let built = sidecar_target_dir.join(&target).join(profile_dir).join("termic-cli");
+    let binaries = manifest_dir.join("binaries");
+    std::fs::create_dir_all(&binaries).expect("create src-tauri/binaries");
+    let dest = binaries.join(format!("termic-cli-{target}"));
+    std::fs::copy(&built, &dest)
+        .unwrap_or_else(|e| panic!("copy {} -> {}: {e}", built.display(), dest.display()));
+
+    // Universal-macOS convenience: once both arch sidecars exist, lipo
+    // them so a `--target universal-apple-darwin` bundle finds its file
+    // even without the beforeBuildCommand hook.
+    if target.ends_with("-apple-darwin") {
+        let a = binaries.join("termic-cli-aarch64-apple-darwin");
+        let x = binaries.join("termic-cli-x86_64-apple-darwin");
+        let u = binaries.join("termic-cli-universal-apple-darwin");
+        if a.exists() && x.exists() {
+            let ok = Command::new("lipo")
+                .args(["-create", "-output"])
+                .args([&u, &a, &x])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            if !ok {
+                println!("cargo:warning=lipo of the universal termic-cli sidecar failed");
+            }
+        }
+    }
 }

--- a/src-tauri/src/cli_server.rs
+++ b/src-tauri/src/cli_server.rs
@@ -1,0 +1,1496 @@
+//! Production control-plane socket server for the `termic` CLI.
+//!
+//! Unix socket at `<data_dir>/termic.sock` (mode 0600), NDJSON framing
+//! from `termic-proto`. Runs on its OWN thread, never the IPC/main
+//! thread (docs/ipc.md: sync IO on the WKWebView event-loop thread froze
+//! the Mac once already; the automation bridge's dedicated-thread model
+//! is the template).
+//!
+//! Security model (docs/plans/cli.md, Security):
+//! - The server ALWAYS binds; the unauthenticated surface is `hello`
+//!   only (app-is-running + protocol version). That disclosure is the
+//!   accepted price of the clear disabled-CLI error.
+//! - Everything else requires BOTH the "Enable CLI" setting AND the
+//!   per-boot token from `<data_dir>/cli-token` (0600, 244 random bits).
+//! - The token lives ONLY in this module's state, NEVER in the app
+//!   process environment: `pty_spawn` copies the full app env into every
+//!   child, caged included, so an env-stashed token would hand a full
+//!   sandbox escape to every agent.
+//! - `getpeereid` (SO_PEERCRED on Linux) same-uid check on every
+//!   connection, before a single byte is read.
+//! - Caged agents get NO CLI surface at all; the seatbelt profile
+//!   carries a final socket deny + data-dir read deny (sandbox.rs).
+//!
+//! Webview RPC: work-state (working / waiting / done) exists only in the
+//! webview, so `list`/`status` query it through a typed correlation-id
+//! channel: emit `cli-rpc://request`, the frontend registry
+//! (src/lib/cliRpc.ts, `window.__termic.rpc`) executes the handler and
+//! replies via the `cli_rpc_result` command. This is NEW hardened code
+//! that only borrows the debug bridge's correlation-id pattern; the
+//! bridge itself (automation.rs, `/eval`) is never armed or reused here.
+
+use std::collections::HashMap;
+use std::io::BufReader;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use tauri::{Emitter, Manager};
+use termic_proto as proto;
+use termic_proto::{Command, ErrorCode, Reply, ReplyData, Request};
+
+use crate::{dlog, Project, Task};
+
+/// Darwin's sockaddr_un.sun_path is 104 bytes including the NUL.
+const MAX_SUN_PATH: usize = 103;
+
+/// How long list/status wait for the webview before degrading to
+/// work_state = null. Wall-clock, never rAF: occluded windows freeze rAF
+/// (docs/automation.md) and for a CLI the window is always backgrounded.
+const WORK_STATE_TIMEOUT: Duration = Duration::from_millis(3000);
+/// `open` is user-visible feedback; give a busy webview a little longer.
+const OPEN_TIMEOUT: Duration = Duration::from_millis(10_000);
+
+// ───────────────────────────── lifecycle ─────────────────────────────
+
+/// Bind and serve. Called once from the app setup hook. Never panics the
+/// app: every failure path logs and returns (the CLI then reports
+/// "Termic did not start" / "not listening").
+pub fn start(app: tauri::AppHandle) {
+    std::thread::spawn(move || server_main(app));
+}
+
+/// Single instance per DATA DIR. If another termic already owns this data
+/// dir's control socket, ask it to come to front and return true so the
+/// caller exits before building a window. The data dir is the real unit:
+/// the socket AND projects.json/tasks/ are single-writer per data dir, so
+/// prod and beta (which share the release data dir) are mutually exclusive
+/// by design, dev has its own (termic_dev), and e2e runs isolate via a
+/// scratch TERMIC_DATA_DIR.
+///
+/// RELEASE only. Debug is newest-wins: relaunching `make dev` over a
+/// lingering instance should hand the socket to the FRESH build (server_main
+/// unlinks + rebinds), not defer to stale code.
+pub fn another_instance_running() -> bool {
+    if cfg!(debug_assertions) {
+        return false;
+    }
+    let Ok(dir) = crate::data_dir() else { return false };
+    raise_existing(&dir.join(proto::SOCKET_FILE))
+}
+
+/// Connect to `sock`; if a LIVE termic answers hello (not a stale socket
+/// file left by a crash), ask it to raise its window and report true.
+fn raise_existing(sock: &Path) -> bool {
+    let Ok(stream) = UnixStream::connect(sock) else { return false };
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+    let Ok(mut writer) = stream.try_clone() else { return false };
+    let mut reader = BufReader::new(stream);
+    // Confirm a live instance via hello. A parseable hello reply (any
+    // protocol) means a sibling is running and owns this data dir.
+    let hello = Request { id: "preflight".into(), token: None, cmd: Command::Hello };
+    if proto::write_msg(&mut writer, &hello).is_err() {
+        return false;
+    }
+    let alive = matches!(
+        proto::read_msg::<_, Reply>(&mut reader),
+        Ok(Some(reply)) if reply.ok && matches!(reply.data, Some(ReplyData::Hello(_)))
+    );
+    if !alive {
+        return false;
+    }
+    // Best-effort: bring the running instance to front, then let the caller
+    // exit. If the raise is dropped, single-instance still holds; the user
+    // just may need to click the running window.
+    let raise = Request { id: "preflight".into(), token: None, cmd: Command::Raise };
+    let _ = proto::write_msg(&mut writer, &raise);
+    let _ = proto::read_msg::<_, Reply>(&mut reader);
+    true
+}
+
+fn server_main(app: tauri::AppHandle) {
+    let dir = match crate::data_dir() {
+        Ok(d) => d,
+        Err(e) => {
+            dlog(&format!("[cli] no data dir, control socket disabled: {e}"));
+            return;
+        }
+    };
+    let sock = dir.join(proto::SOCKET_FILE);
+    if sock.as_os_str().as_bytes().len() > MAX_SUN_PATH {
+        dlog(&format!(
+            "[cli] socket path exceeds the {MAX_SUN_PATH}-byte unix limit, control socket disabled: {}",
+            sock.display()
+        ));
+        return;
+    }
+    // Stale socket from a previous boot (or a crashed instance): unlink
+    // before bind, the standard unix-daemon dance.
+    let _ = std::fs::remove_file(&sock);
+    let listener = match UnixListener::bind(&sock) {
+        Ok(l) => l,
+        Err(e) => {
+            dlog(&format!("[cli] bind {} failed: {e}", sock.display()));
+            return;
+        }
+    };
+    if let Err(e) = std::fs::set_permissions(&sock, {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::Permissions::from_mode(0o600)
+    }) {
+        dlog(&format!("[cli] chmod 0600 on {} failed: {e}", sock.display()));
+        return;
+    }
+    // Write the token only AFTER the socket is bound, so at startup the two
+    // appear together (we never advertise a token before a live socket).
+    // It is deliberately NOT removed on quit: a stale token then lingers
+    // until the next launch overwrites it, which is harmless (useless
+    // without a live server). On a write failure, unlink the socket we just
+    // bound so nothing dangling is left either.
+    let token = mint_token();
+    if let Err(e) = write_token_file(&dir.join(proto::TOKEN_FILE), &token) {
+        dlog(&format!("[cli] token file write failed, control socket disabled: {e}"));
+        let _ = std::fs::remove_file(&sock);
+        return;
+    }
+    dlog(&format!("[cli] listening on {}", sock.display()));
+    let host: Arc<dyn CliHost> = Arc::new(TauriHost { app, token });
+    serve_listener(listener, host);
+}
+
+/// Accept loop, decomposed from `server_main` so integration tests can
+/// drive a real socket with a stub host.
+fn serve_listener(listener: UnixListener, host: Arc<dyn CliHost>) {
+    // A transient accept error (EMFILE when the app is fd-heavy with many
+    // PTYs, ECONNABORTED, EINTR) must NOT kill the server thread: a dead
+    // listener also silently breaks the release single-instance guard (a
+    // second launch can't reach us, unlinks + rebinds, and two instances
+    // race the shared projects.json/tasks/). Log and keep serving; give up
+    // only if the listener is persistently broken.
+    let mut consecutive_errors = 0u32;
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                consecutive_errors = 0;
+                let host = host.clone();
+                std::thread::spawn(move || serve_conn(stream, &*host));
+            }
+            Err(e) => {
+                consecutive_errors += 1;
+                dlog(&format!("[cli] accept failed ({consecutive_errors}): {e}"));
+                if consecutive_errors > 64 {
+                    dlog("[cli] too many consecutive accept failures, stopping control socket");
+                    break;
+                }
+                // Brief backoff so a persistent condition (EMFILE) doesn't
+                // spin this thread hot while file descriptors free up.
+                std::thread::sleep(Duration::from_millis(100));
+            }
+        }
+    }
+}
+
+fn serve_conn(stream: UnixStream, host: &dyn CliHost) {
+    // Same-uid peer check BEFORE reading anything. Root is not exempted:
+    // there is no reason for another uid, root included, to be here.
+    if peer_uid(&stream) != Some(unsafe { libc::geteuid() }) {
+        return;
+    }
+    // A client that connects and never sends must not pin this thread.
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(30)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+    let mut writer = match stream.try_clone() {
+        Ok(w) => w,
+        Err(_) => return,
+    };
+    let mut reader = BufReader::new(stream);
+    loop {
+        let line = match proto::read_line(&mut reader) {
+            Ok(Some(line)) => line,
+            Ok(None) => return, // clean EOF
+            Err(_) => return,   // timeout / oversized / mid-line EOF
+        };
+        let reply = match serde_json::from_str::<Request>(&line) {
+            Ok(req) => handle_request(&req, host),
+            Err(e) => Reply::err("", ErrorCode::BadRequest, format!("malformed request: {e}")),
+        };
+        if proto::write_msg(&mut writer, &reply).is_err() {
+            return;
+        }
+    }
+}
+
+// ───────────────────────────── dispatch ──────────────────────────────
+
+/// Everything the request handler needs from the app, behind a trait so
+/// the dispatch + resolution logic is testable without a running Tauri.
+pub(crate) trait CliHost: Send + Sync {
+    fn cli_enabled(&self) -> bool;
+    fn token(&self) -> &str;
+    fn app_version(&self) -> String;
+    fn projects_tasks(&self) -> (Vec<Project>, Vec<Task>);
+    /// Webview work-state query. `None` = the webview did not answer
+    /// (busy, still booting); per-task entries may still be missing.
+    fn work_states(&self, ids: &[String]) -> Option<HashMap<String, WorkStateInfo>>;
+    fn open_task_in_ui(&self, task_id: &str) -> Result<(), String>;
+    fn raise_window(&self);
+    fn diff_stat(&self, task: &Task) -> Option<proto::DiffStat>;
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WorkStateInfo {
+    pub state: String,
+    pub tabs: u32,
+}
+
+pub(crate) fn handle_request(req: &Request, host: &dyn CliHost) -> Reply {
+    // Hello is the whole unauthenticated surface: app-running + protocol
+    // version. Nothing else leaks before the token check.
+    if let Command::Hello = req.cmd {
+        return Reply::ok(
+            &req.id,
+            ReplyData::Hello(proto::HelloData {
+                app: "termic".into(),
+                app_version: host.app_version(),
+                protocol: proto::PROTOCOL_VERSION,
+            }),
+        );
+    }
+    // Raise is the other unauthenticated verb: a second instance launching
+    // on this data dir asks the running one to come to front, then exits
+    // (single instance per data dir). Same trust tier as hello.
+    if let Command::Raise = req.cmd {
+        host.raise_window();
+        return Reply { id: req.id.clone(), ok: true, data: None, error: None };
+    }
+    if !host.cli_enabled() {
+        return Reply::err(&req.id, ErrorCode::CliDisabled, proto::CLI_DISABLED_MESSAGE);
+    }
+    // Constant-ish compare is not load-bearing against a same-uid local
+    // caller; possession of the 0600 file is the credential.
+    if req.token.as_deref() != Some(host.token()) {
+        return Reply::err(&req.id, ErrorCode::Auth, "invalid or missing CLI token");
+    }
+    match &req.cmd {
+        Command::Hello | Command::Raise => unreachable!("handled above"),
+        Command::List { project, quiet } => {
+            handle_list(&req.id, host, project.as_deref(), *quiet)
+        }
+        Command::Status { task, project } => {
+            handle_status(&req.id, host, task, project.as_deref())
+        }
+        Command::Open { task, project, cwd } => {
+            handle_open(&req.id, host, task.as_deref(), project.as_deref(), cwd.as_deref())
+        }
+    }
+}
+
+fn handle_list(id: &str, host: &dyn CliHost, project: Option<&str>, quiet: bool) -> Reply {
+    let (projects, mut tasks) = host.projects_tasks();
+    tasks.retain(|t| !t.archived);
+    if let Some(name) = project {
+        let Some(p) = find_project(&projects, name) else {
+            return Reply::err(id, ErrorCode::NotFound, format!("no project named \"{name}\""));
+        };
+        let pid = p.id.clone();
+        tasks.retain(|t| t.project_id == pid);
+    }
+    // `-q` prints ids only, so skip the two expensive per-list costs the
+    // output never uses: the webview work-state round-trip and the
+    // per-task git diff (2 subprocesses each).
+    let states = if quiet {
+        None
+    } else {
+        let ids: Vec<String> = tasks.iter().map(|t| t.id.clone()).collect();
+        host.work_states(&ids)
+    };
+    let mut rows: Vec<proto::TaskSummary> = tasks
+        .iter()
+        .map(|t| {
+            let diff = if quiet { None } else { host.diff_stat(t) };
+            summarize(t, &projects, states.as_ref(), diff)
+        })
+        .collect();
+    rows.sort_by(|a, b| (&a.project, &a.name).cmp(&(&b.project, &b.name)));
+    Reply::ok(id, ReplyData::List(proto::ListData { tasks: rows }))
+}
+
+fn handle_status(id: &str, host: &dyn CliHost, task: &str, project: Option<&str>) -> Reply {
+    let (projects, tasks) = host.projects_tasks();
+    let t = match resolve_by_name(&projects, &tasks, task, project) {
+        Ok(t) => t,
+        Err(e) => return Reply { id: id.into(), ok: false, data: None, error: Some(e) },
+    };
+    let states = host.work_states(std::slice::from_ref(&t.id));
+    let diff = host.diff_stat(t);
+    let summary = summarize(t, &projects, states.as_ref(), diff.clone());
+    let sandbox = sandbox_mode_str(t);
+    let sessions = (t.persisted_tabs.len() + t.right_split_tabs.len()) as u32;
+    let dirty_files = diff.map(|d| d.files_changed + d.untracked);
+    Reply::ok(
+        id,
+        ReplyData::Status(proto::StatusData {
+            task: proto::TaskStatus { summary, sandbox, sessions, dirty_files },
+        }),
+    )
+}
+
+fn handle_open(
+    id: &str,
+    host: &dyn CliHost,
+    task: Option<&str>,
+    project: Option<&str>,
+    cwd: Option<&str>,
+) -> Reply {
+    let (projects, tasks) = host.projects_tasks();
+    let resolved: Option<&Task> = match task {
+        Some(name) => match resolve_by_name(&projects, &tasks, name, project) {
+            Ok(t) => Some(t),
+            Err(e) => return Reply { id: id.into(), ok: false, data: None, error: Some(e) },
+        },
+        None => match cwd {
+            Some(cwd) => match resolve_by_cwd(&projects, &tasks, cwd) {
+                Ok(t) => t,
+                Err(e) => return Reply { id: id.into(), ok: false, data: None, error: Some(e) },
+            },
+            None => None,
+        },
+    };
+    if let Some(t) = resolved {
+        if let Err(e) = host.open_task_in_ui(&t.id) {
+            host.raise_window();
+            return Reply::err(
+                id,
+                ErrorCode::Internal,
+                format!("could not select the task in Termic ({e})"),
+            );
+        }
+    }
+    host.raise_window();
+    let summary = resolved.map(|t| summarize(t, &projects, None, None));
+    Reply::ok(id, ReplyData::Open(proto::OpenData { task: summary, raised: true }))
+}
+
+fn summarize(
+    task: &Task,
+    projects: &[Project],
+    states: Option<&HashMap<String, WorkStateInfo>>,
+    diff: Option<proto::DiffStat>,
+) -> proto::TaskSummary {
+    let project = projects
+        .iter()
+        .find(|p| p.id == task.project_id)
+        .map(|p| p.name.clone())
+        .unwrap_or_else(|| task.project_id.clone());
+    let info = states.and_then(|m| m.get(&task.id));
+    proto::TaskSummary {
+        id: task.id.clone(),
+        name: task.name.clone(),
+        project,
+        agent: task.cli.clone(),
+        branch: task.branch.clone(),
+        base_branch: task.base_branch.clone(),
+        path: task.path.clone(),
+        is_main_checkout: task.is_main_checkout,
+        created: task.created.clone(),
+        work_state: info.map(|i| i.state.clone()),
+        open_tabs: info.map(|i| i.tabs),
+        diff,
+    }
+}
+
+fn sandbox_mode_str(task: &Task) -> String {
+    serde_json::to_value(task.effective_sandbox_mode())
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_else(|| "off".into())
+}
+
+// ───────────────────────────── resolution ────────────────────────────
+
+fn find_project<'a>(projects: &'a [Project], name: &str) -> Option<&'a Project> {
+    projects
+        .iter()
+        .find(|p| p.name.eq_ignore_ascii_case(name))
+        .or_else(|| projects.iter().find(|p| p.id == name))
+}
+
+fn qualified(projects: &[Project], task: &Task) -> String {
+    let p = projects
+        .iter()
+        .find(|p| p.id == task.project_id)
+        .map(|p| p.name.as_str())
+        .unwrap_or("?");
+    format!("{p}/{}", task.name)
+}
+
+/// Resolve a task by name, id, or qualified `project/name`; `--project`
+/// filters first. A name matching tasks in more than one project errors
+/// listing the candidates (docs/plans/cli.md).
+pub(crate) fn resolve_by_name<'a>(
+    projects: &[Project],
+    tasks: &'a [Task],
+    raw: &str,
+    project: Option<&str>,
+) -> Result<&'a Task, proto::ErrorBody> {
+    let not_found = |what: &str| proto::ErrorBody {
+        code: ErrorCode::NotFound,
+        message: what.to_string(),
+    };
+    let live: Vec<&Task> = tasks.iter().filter(|t| !t.archived).collect();
+
+    let scoped: Vec<&Task> = match project {
+        Some(pname) => {
+            let Some(p) = find_project(projects, pname) else {
+                return Err(not_found(&format!("no project named \"{pname}\"")));
+            };
+            live.iter().copied().filter(|t| t.project_id == p.id).collect()
+        }
+        None => live.clone(),
+    };
+
+    let matches = |candidates: &[&'a Task], name: &str| -> Vec<&'a Task> {
+        candidates
+            .iter()
+            .copied()
+            .filter(|t| t.name.eq_ignore_ascii_case(name) || t.id == name)
+            .collect()
+    };
+
+    let mut found = matches(&scoped, raw);
+    // Qualified project/name, tried after the literal name so a task
+    // whose NAME contains a slash still resolves.
+    if found.is_empty() && project.is_none() {
+        if let Some((pname, tname)) = raw.split_once('/') {
+            if let Some(p) = find_project(projects, pname) {
+                let in_project: Vec<&Task> =
+                    live.iter().copied().filter(|t| t.project_id == p.id).collect();
+                found = matches(&in_project, tname);
+            }
+        }
+    }
+    match found.len() {
+        0 => Err(not_found(&match project {
+            Some(p) => format!("no task named \"{raw}\" in project \"{p}\""),
+            None => format!("no task named \"{raw}\""),
+        })),
+        1 => Ok(found[0]),
+        _ => {
+            let mut names: Vec<String> = found.iter().map(|t| qualified(projects, t)).collect();
+            names.sort();
+            Err(proto::ErrorBody {
+                code: ErrorCode::Ambiguous,
+                message: format!(
+                    "task \"{raw}\" exists in more than one project: {}. Disambiguate with --project or project/name.",
+                    names.join(", ")
+                ),
+            })
+        }
+    }
+}
+
+fn canon(p: &str) -> String {
+    std::fs::canonicalize(p)
+        .map(|c| c.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| p.to_string())
+}
+
+fn under(path: &str, base: &str) -> bool {
+    !base.is_empty()
+        && (path == base
+            || (path.len() > base.len()
+                && path.starts_with(base)
+                && path.as_bytes()[base.len()] == b'/'))
+}
+
+/// cwd resolution, worktree first then longest project-path prefix
+/// (docs/plans/cli.md, Traps): a path can be inside a project repo AND a
+/// task worktree of another project. Main-checkout tasks live at the
+/// project root, so the project-prefix stage IS the main-checkout stage;
+/// several of them can share one checkout, which is the ambiguous case.
+pub(crate) fn resolve_by_cwd<'a>(
+    projects: &[Project],
+    tasks: &'a [Task],
+    cwd: &str,
+) -> Result<Option<&'a Task>, proto::ErrorBody> {
+    let cwd = canon(cwd);
+    let live: Vec<&Task> = tasks.iter().filter(|t| !t.archived).collect();
+
+    let best_by = |candidates: &[(&'a Task, String)]| -> (usize, Vec<&'a Task>) {
+        let mut best_len = 0usize;
+        let mut best: Vec<&'a Task> = Vec::new();
+        for (t, base) in candidates {
+            if under(&cwd, base) && base.len() >= best_len {
+                if base.len() > best_len {
+                    best.clear();
+                    best_len = base.len();
+                }
+                if !best.iter().any(|b| b.id == t.id) {
+                    best.push(t);
+                }
+            }
+        }
+        (best_len, best)
+    };
+
+    // Stage 1: worktree tasks (their own dir + composition member dirs).
+    let worktree_paths: Vec<(&Task, String)> = live
+        .iter()
+        .copied()
+        .filter(|t| !t.is_main_checkout)
+        .flat_map(|t| {
+            std::iter::once((t, canon(&t.path))).chain(
+                t.composition
+                    .iter()
+                    .filter(|m| !m.path.is_empty())
+                    .map(move |m| (t, canon(&m.path))),
+            )
+        })
+        .collect();
+    let (_, found) = best_by(&worktree_paths);
+    match found.len() {
+        1 => return Ok(Some(found[0])),
+        n if n > 1 => {
+            let mut names: Vec<String> = found.iter().map(|t| qualified(projects, t)).collect();
+            names.sort();
+            return Err(proto::ErrorBody {
+                code: ErrorCode::Ambiguous,
+                message: format!(
+                    "this directory belongs to more than one task: {}. Name the task explicitly.",
+                    names.join(", ")
+                ),
+            });
+        }
+        _ => {}
+    }
+
+    // Stage 2: main-checkout tasks by project-path prefix.
+    let main_paths: Vec<(&Task, String)> = live
+        .iter()
+        .copied()
+        .filter(|t| t.is_main_checkout)
+        .map(|t| (t, canon(&t.path)))
+        .collect();
+    let (_, found) = best_by(&main_paths);
+    match found.len() {
+        0 => Ok(None),
+        1 => Ok(Some(found[0])),
+        _ => {
+            let mut names: Vec<String> = found.iter().map(|t| qualified(projects, t)).collect();
+            names.sort();
+            Err(proto::ErrorBody {
+                code: ErrorCode::Ambiguous,
+                message: format!(
+                    "this checkout is shared by more than one task: {}. Name the task explicitly.",
+                    names.join(", ")
+                ),
+            })
+        }
+    }
+}
+
+// ───────────────────────────── token ─────────────────────────────────
+
+/// 244 random bits as 64 hex chars (two v4 uuids; the spec floor is
+/// 128). Exists only here and in the 0600 file the CLI reads.
+fn mint_token() -> String {
+    format!(
+        "{}{}",
+        uuid::Uuid::new_v4().simple(),
+        uuid::Uuid::new_v4().simple()
+    )
+}
+
+fn write_token_file(path: &Path, token: &str) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    // Recreate rather than truncate so the 0600 mode is guaranteed even
+    // if an old file existed with different permissions.
+    let _ = std::fs::remove_file(path);
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)?;
+    f.write_all(token.as_bytes())?;
+    f.flush()
+}
+
+fn peer_uid(stream: &UnixStream) -> Option<u32> {
+    use std::os::fd::AsRawFd;
+    let fd = stream.as_raw_fd();
+    #[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd"))]
+    {
+        let mut uid: libc::uid_t = 0;
+        let mut gid: libc::gid_t = 0;
+        // SAFETY: valid fd from a live UnixStream; out-params are plain ints.
+        if unsafe { libc::getpeereid(fd, &mut uid, &mut gid) } == 0 {
+            Some(uid)
+        } else {
+            None
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let mut cred = libc::ucred { pid: 0, uid: 0, gid: 0 };
+        let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+        // SAFETY: valid fd; SO_PEERCRED fills a ucred of exactly this size.
+        let ok = unsafe {
+            libc::getsockopt(
+                fd,
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                &mut cred as *mut _ as *mut libc::c_void,
+                &mut len,
+            )
+        } == 0;
+        if ok { Some(cred.uid) } else { None }
+    }
+}
+
+// ───────────────────────────── Tauri host ────────────────────────────
+
+struct TauriHost {
+    app: tauri::AppHandle,
+    token: String,
+}
+
+impl CliHost for TauriHost {
+    fn cli_enabled(&self) -> bool {
+        // Re-read per request so the Settings toggle applies live.
+        crate::load_settings_inner().cli_enabled
+    }
+    fn token(&self) -> &str {
+        &self.token
+    }
+    fn app_version(&self) -> String {
+        env!("CARGO_PKG_VERSION").into()
+    }
+    fn projects_tasks(&self) -> (Vec<Project>, Vec<Task>) {
+        (crate::load_projects(), crate::load_tasks())
+    }
+    fn work_states(&self, ids: &[String]) -> Option<HashMap<String, WorkStateInfo>> {
+        let value = webview_rpc(
+            &self.app,
+            "work_state",
+            serde_json::json!({ "taskIds": ids }),
+            WORK_STATE_TIMEOUT,
+        )
+        .ok()?;
+        parse_work_states(&value)
+    }
+    fn open_task_in_ui(&self, task_id: &str) -> Result<(), String> {
+        webview_rpc(
+            &self.app,
+            "open_task",
+            serde_json::json!({ "taskId": task_id }),
+            OPEN_TIMEOUT,
+        )
+        .map(|_| ())
+    }
+    fn raise_window(&self) {
+        if let Some(win) = self.app.get_webview_window("main") {
+            let _ = win.unminimize();
+            let _ = win.show();
+            let _ = win.set_focus();
+        }
+    }
+    fn diff_stat(&self, task: &Task) -> Option<proto::DiffStat> {
+        diff_stat(task)
+    }
+}
+
+/// Parse the webview's work-state RPC reply. A single malformed entry is
+/// SKIPPED, never fatal: one bad row must not collapse the whole map to
+/// `None` and degrade every task to "UI did not answer". `None` only when
+/// the top-level shape is wrong (no `states` object).
+fn parse_work_states(value: &serde_json::Value) -> Option<HashMap<String, WorkStateInfo>> {
+    let states = value.get("states")?.as_object()?;
+    let mut out = HashMap::new();
+    for (id, v) in states {
+        let Some(state) = v.get("state").and_then(|s| s.as_str()) else { continue };
+        let tabs = v.get("tabs").and_then(|t| t.as_u64()).unwrap_or(0) as u32;
+        out.insert(id.clone(), WorkStateInfo { state: state.to_string(), tabs });
+    }
+    Some(out)
+}
+
+/// Cheap diff stat vs the base branch: one `git diff --numstat` plus one
+/// untracked-file listing. Deliberately NOT `task_diff_inner`, which
+/// renders a full unified diff and shells out per untracked file; `list`
+/// runs this for every task.
+fn diff_stat(task: &Task) -> Option<proto::DiffStat> {
+    if task.base_branch.is_empty() {
+        return None;
+    }
+    let wt = Path::new(&task.path);
+    let numstat =
+        crate::git(&["--no-pager", "diff", "--numstat", &task.base_branch], wt).ok()?;
+    let mut files_changed = 0u64;
+    let mut insertions = 0u64;
+    let mut deletions = 0u64;
+    for line in numstat.lines().filter(|l| !l.trim().is_empty()) {
+        let mut cols = line.split('\t');
+        insertions += cols.next().and_then(|c| c.parse::<u64>().ok()).unwrap_or(0);
+        deletions += cols.next().and_then(|c| c.parse::<u64>().ok()).unwrap_or(0);
+        files_changed += 1;
+    }
+    let untracked = crate::git(&["ls-files", "--others", "--exclude-standard", "-z"], wt)
+        .map(|s| s.split('\0').filter(|x| !x.is_empty()).count() as u64)
+        .unwrap_or(0);
+    Some(proto::DiffStat { files_changed, insertions, deletions, untracked })
+}
+
+// ───────────────────────────── webview RPC ───────────────────────────
+
+/// Pending RPCs: correlation id -> channel the socket thread blocks on.
+fn pending() -> &'static Mutex<HashMap<String, mpsc::SyncSender<String>>> {
+    static PENDING: OnceLock<Mutex<HashMap<String, mpsc::SyncSender<String>>>> = OnceLock::new();
+    PENDING.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn webview_rpc(
+    app: &tauri::AppHandle,
+    method: &str,
+    params: serde_json::Value,
+    timeout: Duration,
+) -> Result<serde_json::Value, String> {
+    let id = uuid::Uuid::new_v4().simple().to_string();
+    let (tx, rx) = mpsc::sync_channel::<String>(1);
+    pending().lock().unwrap().insert(id.clone(), tx);
+    let payload = serde_json::json!({ "id": id, "method": method, "params": params });
+    if let Err(e) = app.emit("cli-rpc://request", payload) {
+        pending().lock().unwrap().remove(&id);
+        return Err(format!("emit failed: {e}"));
+    }
+    match rx.recv_timeout(timeout) {
+        Ok(raw) => {
+            let v: serde_json::Value =
+                serde_json::from_str(&raw).map_err(|e| format!("bad rpc payload: {e}"))?;
+            if v.get("ok").and_then(|b| b.as_bool()) == Some(true) {
+                Ok(v.get("value").cloned().unwrap_or(serde_json::Value::Null))
+            } else {
+                Err(v
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("webview handler failed")
+                    .to_string())
+            }
+        }
+        Err(_) => {
+            pending().lock().unwrap().remove(&id);
+            Err(format!("the Termic UI did not answer within {}ms", timeout.as_millis()))
+        }
+    }
+}
+
+/// Callback target for the frontend RPC registry (src/lib/cliRpc.ts).
+/// Unknown ids are ignored, so nothing can be injected into a request
+/// that is not currently waiting.
+#[tauri::command]
+pub fn cli_rpc_result(id: String, payload: String) -> Result<(), String> {
+    if let Some(tx) = pending().lock().unwrap().remove(&id) {
+        let _ = tx.send(payload);
+    }
+    Ok(())
+}
+
+// ───────────────────────────── PATH install ──────────────────────────
+
+/// Where the bundled sidecar lives: next to the app binary
+/// (Contents/MacOS/termic-cli in a bundle, target/<profile>/termic-cli
+/// in dev, both placed by tauri's externalBin machinery).
+fn bundled_cli_path() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let dir = exe.parent().ok_or("app binary has no parent dir")?;
+    let p = dir.join("termic-cli");
+    if p.is_file() {
+        Ok(p)
+    } else {
+        Err(format!("the termic-cli binary was not found at {}", p.display()))
+    }
+}
+
+/// The command name to install on PATH, per build flavor, so dev, beta,
+/// and prod can all coexist:
+///   - debug build  -> `termic-dev`  (talks to the termic_dev data dir)
+///   - beta bundle   -> `termic-beta` (identifier ends in ".beta")
+///   - release       -> `termic`
+/// The on-disk sidecar is always `termic-cli`; only the LINK name varies,
+/// so `replaceable` still recognizes our links by their target basename.
+fn install_name(identifier: &str) -> &'static str {
+    if cfg!(debug_assertions) {
+        "termic-dev"
+    } else if identifier.ends_with(".beta") {
+        "termic-beta"
+    } else {
+        "termic"
+    }
+}
+
+fn user_bin() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".local/bin"))
+}
+
+fn install_targets(name: &str) -> Vec<PathBuf> {
+    let mut v = vec![PathBuf::from(format!("/usr/local/bin/{name}"))];
+    if let Some(bin) = user_bin() {
+        v.push(bin.join(name));
+    }
+    v
+}
+
+/// Is `dir` on the user's LOGIN-SHELL PATH (not the app's launchd PATH)?
+/// That is what a fresh terminal resolves commands against, so it is the
+/// honest "will `termic` be found" check. Uses the same resolved PATH the
+/// PTY spawn uses (shell_env), so the answer matches the real shell.
+fn dir_on_login_path(dir: &Path) -> bool {
+    let path = crate::shell_env::resolved_path();
+    std::env::split_paths(&path).any(|p| p == dir)
+}
+
+/// A symlink we may replace: anything whose target basename is
+/// `termic-cli` (a previous install, possibly from an older app path).
+/// A real file or a foreign symlink is never touched.
+fn replaceable(link: &Path) -> Result<bool, String> {
+    match std::fs::symlink_metadata(link) {
+        Err(_) => Ok(true), // absent
+        Ok(md) if md.file_type().is_symlink() => {
+            let target = std::fs::read_link(link).map_err(|e| e.to_string())?;
+            Ok(target.file_name().is_some_and(|n| n == "termic-cli"))
+        }
+        Ok(_) => Ok(false),
+    }
+}
+
+fn symlink_replacing(src: &Path, link: &Path) -> std::io::Result<()> {
+    if std::fs::symlink_metadata(link).is_ok() {
+        std::fs::remove_file(link)?;
+    }
+    std::os::unix::fs::symlink(src, link)
+}
+
+/// Install the CLI onto PATH. `system=false` is the no-prompt path used
+/// automatically when the CLI is enabled: it symlinks into ~/.local/bin
+/// (created if needed) and never asks for a password. `system=true` is
+/// the explicit "install system-wide" button: /usr/local/bin via an admin
+/// prompt, falling back to ~/.local/bin if that is declined. Returns a
+/// human-readable result line that already states whether the location is
+/// on the user's PATH.
+#[tauri::command]
+pub async fn cli_install_symlink(app: tauri::AppHandle, system: bool) -> Result<String, String> {
+    let name = install_name(&app.config().identifier);
+    tauri::async_runtime::spawn_blocking(move || install_inner(name, system))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn install_user(src: &Path, name: &str) -> Result<PathBuf, String> {
+    let bin = user_bin().ok_or("no home directory")?;
+    std::fs::create_dir_all(&bin).map_err(|e| e.to_string())?;
+    let link = bin.join(name);
+    if !replaceable(&link)? {
+        return Err(format!(
+            "{} exists and was not installed by Termic, refusing to replace it",
+            link.display()
+        ));
+    }
+    symlink_replacing(src, &link).map_err(|e| e.to_string())?;
+    Ok(link)
+}
+
+fn on_path_suffix(dir: &Path) -> String {
+    if dir_on_login_path(dir) {
+        String::new()
+    } else {
+        format!(" (add {} to your PATH, or use Install system-wide)", dir.display())
+    }
+}
+
+fn install_inner(name: &str, system: bool) -> Result<String, String> {
+    let src = bundled_cli_path()?;
+
+    if system {
+        let primary = PathBuf::from(format!("/usr/local/bin/{name}"));
+        if !replaceable(&primary)? {
+            return Err(format!(
+                "{} exists and was not installed by Termic, refusing to replace it",
+                primary.display()
+            ));
+        }
+        let already = std::fs::read_link(&primary).ok().as_deref() == Some(src.as_path());
+        if already || symlink_replacing(&src, &primary).is_ok() {
+            return Ok(format!("installed at {}", primary.display()));
+        }
+        #[cfg(target_os = "macos")]
+        if admin_symlink(&src, name).is_ok() {
+            return Ok(format!("installed at {}", primary.display()));
+        }
+        // Admin declined / unavailable: fall back to the user dir.
+        let link = install_user(&src, name)?;
+        let dir = link.parent().unwrap_or(&link).to_path_buf();
+        return Ok(format!("installed at {}{}", link.display(), on_path_suffix(&dir)));
+    }
+
+    // No-prompt user install (the on-enable path).
+    let link = install_user(&src, name)?;
+    let dir = link.parent().unwrap_or(&link).to_path_buf();
+    Ok(format!("installed at {}{}", link.display(), on_path_suffix(&dir)))
+}
+
+/// `ln -shf` through an osascript administrator prompt, the VS Code
+/// precedent for writing into /usr/local/bin.
+#[cfg(target_os = "macos")]
+fn admin_symlink(src: &Path, name: &str) -> Result<(), String> {
+    let quoted = format!("'{}'", src.to_string_lossy().replace('\'', r"'\''"));
+    let shell = format!("mkdir -p /usr/local/bin && ln -shf {quoted} /usr/local/bin/{name}");
+    let script = format!(
+        "do shell script \"{}\" with prompt \"Termic wants to install the {name} command.\" with administrator privileges",
+        shell.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    let ok = std::process::Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .map(|o| o.status.success())
+        .map_err(|e| e.to_string())?;
+    if ok { Ok(()) } else { Err("administrator prompt declined".into()) }
+}
+
+/// Current install state for the Settings UI: where the CLI is installed
+/// (a symlink of ours that still resolves), the command name for this
+/// build, and whether that location is on the user's login PATH.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct CliInstallStatus {
+    /// Absolute path of the installed symlink, or null when not installed.
+    pub path: Option<String>,
+    /// The command name for this build (termic / termic-dev / termic-beta).
+    pub name: String,
+    /// True when the installed location is on the user's login PATH.
+    pub on_path: bool,
+}
+
+#[tauri::command]
+pub fn cli_install_status(app: tauri::AppHandle) -> CliInstallStatus {
+    let name = install_name(&app.config().identifier);
+    for link in install_targets(name) {
+        if let Ok(md) = std::fs::symlink_metadata(&link) {
+            let ours = md.file_type().is_symlink()
+                && std::fs::read_link(&link)
+                    .ok()
+                    .is_some_and(|t| t.file_name().is_some_and(|n| n == "termic-cli"))
+                && link.exists();
+            if ours {
+                let on_path = link.parent().is_some_and(dir_on_login_path);
+                return CliInstallStatus {
+                    path: Some(link.to_string_lossy().into_owned()),
+                    name: name.to_string(),
+                    on_path,
+                };
+            }
+        }
+    }
+    CliInstallStatus { path: None, name: name.to_string(), on_path: false }
+}
+
+// ───────────────────────────── tests ─────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn project(id: &str, name: &str, root: &str) -> Project {
+        Project {
+            id: id.into(),
+            name: name.into(),
+            root_path: root.into(),
+            ..Default::default()
+        }
+    }
+
+    fn task(id: &str, name: &str, project_id: &str, path: &str) -> Task {
+        Task {
+            id: id.into(),
+            name: name.into(),
+            project_id: project_id.into(),
+            path: path.into(),
+            branch: name.into(),
+            base_branch: "main".into(),
+            cli: "claude".into(),
+            ..Default::default()
+        }
+    }
+
+    struct StubHost {
+        enabled: bool,
+        token: String,
+        projects: Vec<Project>,
+        tasks: Vec<Task>,
+        states: Option<HashMap<String, WorkStateInfo>>,
+        opened: Mutex<Vec<String>>,
+        raised: Mutex<u32>,
+    }
+
+    impl Default for StubHost {
+        fn default() -> Self {
+            let projects = vec![project("p1", "web", "/repo/web"), project("p2", "api", "/repo/api")];
+            let tasks = vec![
+                task("w1", "fix-auth", "p1", "/tasks/web/fix-auth"),
+                task("w2", "fix-auth", "p2", "/tasks/api/fix-auth"),
+                task("w3", "solo", "p1", "/tasks/web/solo"),
+            ];
+            StubHost {
+                enabled: true,
+                token: "tok".into(),
+                projects,
+                tasks,
+                states: None,
+                opened: Mutex::new(Vec::new()),
+                raised: Mutex::new(0),
+            }
+        }
+    }
+
+    impl CliHost for StubHost {
+        fn cli_enabled(&self) -> bool {
+            self.enabled
+        }
+        fn token(&self) -> &str {
+            &self.token
+        }
+        fn app_version(&self) -> String {
+            "0.0.0-test".into()
+        }
+        fn projects_tasks(&self) -> (Vec<Project>, Vec<Task>) {
+            (self.projects.clone(), self.tasks.clone())
+        }
+        fn work_states(&self, _ids: &[String]) -> Option<HashMap<String, WorkStateInfo>> {
+            self.states.as_ref().map(|m| {
+                m.iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect()
+            })
+        }
+        fn open_task_in_ui(&self, task_id: &str) -> Result<(), String> {
+            self.opened.lock().unwrap().push(task_id.to_string());
+            Ok(())
+        }
+        fn raise_window(&self) {
+            *self.raised.lock().unwrap() += 1;
+        }
+        fn diff_stat(&self, _task: &Task) -> Option<proto::DiffStat> {
+            None
+        }
+    }
+
+    fn req(cmd: Command, token: Option<&str>) -> Request {
+        Request { id: "r".into(), token: token.map(str::to_string), cmd }
+    }
+
+    // ── auth / gating ────────────────────────────────────────────────
+
+    #[test]
+    fn hello_needs_no_token_and_reports_protocol() {
+        let host = StubHost { enabled: false, ..Default::default() };
+        let reply = handle_request(&req(Command::Hello, None), &host);
+        assert!(reply.ok);
+        match reply.data {
+            Some(ReplyData::Hello(h)) => assert_eq!(h.protocol, proto::PROTOCOL_VERSION),
+            other => panic!("expected hello, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn raise_needs_no_token_and_brings_the_window_to_front() {
+        // Raise is unauthenticated (the single-instance handshake) and
+        // must work even when the CLI is disabled.
+        let host = StubHost { enabled: false, ..Default::default() };
+        let reply = handle_request(&req(Command::Raise, None), &host);
+        assert!(reply.ok);
+        assert!(reply.data.is_none());
+        assert_eq!(*host.raised.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn disabled_cli_gets_the_exact_error_before_any_token_check() {
+        let host = StubHost { enabled: false, ..Default::default() };
+        let reply = handle_request(&req(Command::List { project: None, quiet: false }, Some("tok")), &host);
+        let err = reply.error.expect("error");
+        assert_eq!(err.code, ErrorCode::CliDisabled);
+        assert_eq!(err.message, proto::CLI_DISABLED_MESSAGE);
+    }
+
+    #[test]
+    fn bad_or_missing_token_is_refused() {
+        let host = StubHost::default();
+        for token in [None, Some("wrong")] {
+            let reply = handle_request(&req(Command::List { project: None, quiet: false }, token), &host);
+            assert_eq!(reply.error.expect("error").code, ErrorCode::Auth);
+        }
+    }
+
+    // ── verbs ────────────────────────────────────────────────────────
+
+    #[test]
+    fn list_returns_tasks_sorted_and_degrades_without_webview() {
+        let host = StubHost::default();
+        let reply = handle_request(&req(Command::List { project: None, quiet: false }, Some("tok")), &host);
+        match reply.data {
+            Some(ReplyData::List(l)) => {
+                let names: Vec<String> =
+                    l.tasks.iter().map(|t| format!("{}/{}", t.project, t.name)).collect();
+                assert_eq!(names, ["api/fix-auth", "web/fix-auth", "web/solo"]);
+                assert!(l.tasks.iter().all(|t| t.work_state.is_none()));
+            }
+            other => panic!("expected list, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn list_filters_by_project_and_rejects_unknown() {
+        let host = StubHost::default();
+        let reply = handle_request(
+            &req(Command::List { project: Some("api".into()), quiet: false }, Some("tok")),
+            &host,
+        );
+        match reply.data {
+            Some(ReplyData::List(l)) => {
+                assert_eq!(l.tasks.len(), 1);
+                assert_eq!(l.tasks[0].project, "api");
+            }
+            other => panic!("expected list, got {other:?}"),
+        }
+        let reply = handle_request(
+            &req(Command::List { project: Some("nope".into()), quiet: false }, Some("tok")),
+            &host,
+        );
+        assert_eq!(reply.error.expect("error").code, ErrorCode::NotFound);
+    }
+
+    #[test]
+    fn list_carries_webview_work_state_when_available() {
+        let mut states = HashMap::new();
+        states.insert("w3".to_string(), WorkStateInfo { state: "working".into(), tabs: 2 });
+        let host = StubHost { states: Some(states), ..Default::default() };
+        let reply = handle_request(&req(Command::List { project: None, quiet: false }, Some("tok")), &host);
+        let Some(ReplyData::List(l)) = reply.data else { panic!() };
+        let solo = l.tasks.iter().find(|t| t.name == "solo").unwrap();
+        assert_eq!(solo.work_state.as_deref(), Some("working"));
+        assert_eq!(solo.open_tabs, Some(2));
+        // Tasks the webview did not report stay unknown, not "idle".
+        let other = l.tasks.iter().find(|t| t.project == "api").unwrap();
+        assert!(other.work_state.is_none());
+    }
+
+    #[test]
+    fn parse_work_states_skips_malformed_entries() {
+        // One bad entry must NOT collapse the whole map (which would
+        // degrade every task to "UI did not answer").
+        let v = serde_json::json!({
+            "states": {
+                "w1": { "state": "working", "tabs": 2 },
+                "w2": { "state": 123 },       // state not a string -> skip
+                "w3": { "tabs": 1 },          // no state -> skip
+                "w4": { "state": "idle" },    // ok; tabs defaults to 0
+            }
+        });
+        let out = parse_work_states(&v).unwrap();
+        assert_eq!(out.len(), 2);
+        assert_eq!(out["w1"].state, "working");
+        assert_eq!(out["w1"].tabs, 2);
+        assert_eq!(out["w4"].state, "idle");
+        assert_eq!(out["w4"].tabs, 0);
+        assert!(!out.contains_key("w2"));
+        assert!(!out.contains_key("w3"));
+        // Only a wrong top-level shape (no `states` object) yields None.
+        assert!(parse_work_states(&serde_json::json!({})).is_none());
+    }
+
+    #[test]
+    fn status_resolves_and_reports_depth_fields() {
+        let host = StubHost::default();
+        let reply = handle_request(
+            &req(Command::Status { task: "solo".into(), project: None }, Some("tok")),
+            &host,
+        );
+        match reply.data {
+            Some(ReplyData::Status(s)) => {
+                assert_eq!(s.task.summary.name, "solo");
+                assert_eq!(s.task.sandbox, "off");
+                assert_eq!(s.task.sessions, 0);
+                assert!(s.task.dirty_files.is_none());
+            }
+            other => panic!("expected status, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_by_name_selects_and_raises() {
+        let host = StubHost::default();
+        let reply = handle_request(
+            &req(
+                Command::Open { task: Some("solo".into()), project: None, cwd: None },
+                Some("tok"),
+            ),
+            &host,
+        );
+        let Some(ReplyData::Open(o)) = reply.data else { panic!() };
+        assert!(o.raised);
+        assert_eq!(o.task.unwrap().id, "w3");
+        assert_eq!(*host.opened.lock().unwrap(), vec!["w3".to_string()]);
+    }
+
+    #[test]
+    fn open_without_match_still_raises() {
+        let host = StubHost::default();
+        let reply = handle_request(
+            &req(
+                Command::Open { task: None, project: None, cwd: Some("/elsewhere".into()) },
+                Some("tok"),
+            ),
+            &host,
+        );
+        let Some(ReplyData::Open(o)) = reply.data else { panic!() };
+        assert!(o.raised);
+        assert!(o.task.is_none());
+        assert!(host.opened.lock().unwrap().is_empty());
+    }
+
+    // ── name resolution ──────────────────────────────────────────────
+
+    #[test]
+    fn ambiguous_name_lists_candidates() {
+        let host = StubHost::default();
+        let err = resolve_by_name(&host.projects, &host.tasks, "fix-auth", None).unwrap_err();
+        assert_eq!(err.code, ErrorCode::Ambiguous);
+        assert!(err.message.contains("api/fix-auth"));
+        assert!(err.message.contains("web/fix-auth"));
+    }
+
+    #[test]
+    fn project_flag_and_qualified_name_disambiguate() {
+        let host = StubHost::default();
+        let t = resolve_by_name(&host.projects, &host.tasks, "fix-auth", Some("api")).unwrap();
+        assert_eq!(t.id, "w2");
+        let t = resolve_by_name(&host.projects, &host.tasks, "web/fix-auth", None).unwrap();
+        assert_eq!(t.id, "w1");
+    }
+
+    #[test]
+    fn id_matches_and_archived_tasks_are_invisible() {
+        let mut host = StubHost::default();
+        let t = resolve_by_name(&host.projects, &host.tasks, "w2", None).unwrap();
+        assert_eq!(t.name, "fix-auth");
+        host.tasks[2].archived = true;
+        let err = resolve_by_name(&host.projects, &host.tasks, "solo", None).unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotFound);
+    }
+
+    // ── cwd resolution ───────────────────────────────────────────────
+
+    #[test]
+    fn cwd_resolves_worktree_by_longest_prefix() {
+        let host = StubHost::default();
+        let t = resolve_by_cwd(&host.projects, &host.tasks, "/tasks/web/solo/src/deep")
+            .unwrap()
+            .unwrap();
+        assert_eq!(t.id, "w3");
+        // Sibling dir with a shared prefix but no path-segment boundary.
+        assert!(resolve_by_cwd(&host.projects, &host.tasks, "/tasks/web/solo2")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn cwd_prefers_worktree_over_main_checkout() {
+        let mut host = StubHost::default();
+        // A main-checkout task at a path that is ALSO an ancestor of a
+        // worktree task path: worktree wins (worktree-first rule).
+        let mut main = task("m1", "root", "p1", "/tasks/web");
+        main.is_main_checkout = true;
+        host.tasks.push(main);
+        let t = resolve_by_cwd(&host.projects, &host.tasks, "/tasks/web/solo").unwrap().unwrap();
+        assert_eq!(t.id, "w3");
+        let t = resolve_by_cwd(&host.projects, &host.tasks, "/tasks/web").unwrap().unwrap();
+        assert_eq!(t.id, "m1");
+    }
+
+    #[test]
+    fn cwd_resolves_composition_members() {
+        let mut host = StubHost::default();
+        host.tasks[2].composition = vec![crate::TaskMember {
+            path: "/members/api-wt".into(),
+            ..Default::default()
+        }];
+        let t = resolve_by_cwd(&host.projects, &host.tasks, "/members/api-wt/src")
+            .unwrap()
+            .unwrap();
+        assert_eq!(t.id, "w3");
+    }
+
+    #[test]
+    fn shared_main_checkout_is_ambiguous() {
+        let mut host = StubHost::default();
+        for (id, name) in [("m1", "root-a"), ("m2", "root-b")] {
+            let mut t = task(id, name, "p1", "/repo/web");
+            t.is_main_checkout = true;
+            host.tasks.push(t);
+        }
+        let err = resolve_by_cwd(&host.projects, &host.tasks, "/repo/web/src").unwrap_err();
+        assert_eq!(err.code, ErrorCode::Ambiguous);
+        assert!(err.message.contains("web/root-a"));
+        assert!(err.message.contains("web/root-b"));
+    }
+
+    // ── token hygiene ────────────────────────────────────────────────
+
+    #[test]
+    fn token_is_long_random_and_never_in_the_app_env() {
+        let t1 = mint_token();
+        let t2 = mint_token();
+        assert_ne!(t1, t2);
+        assert!(t1.len() >= 32, "128+ bits required, got {} chars", t1.len());
+        // The app-env invariant pty_spawn depends on: the token must
+        // never appear in this process's environment, under any name.
+        // (Textual assertion for ABSENCE, per the testing rules.)
+        for (k, v) in std::env::vars() {
+            assert_ne!(v, t1, "token leaked into env var {k}");
+            assert!(
+                !k.eq_ignore_ascii_case("TERMIC_CLI_TOKEN"),
+                "a token-shaped env var exists: {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn token_file_is_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join(proto::TOKEN_FILE);
+        // Pre-existing file with sloppy permissions must be replaced.
+        std::fs::write(&p, "old").unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+        write_token_file(&p, "newtoken").unwrap();
+        let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+        assert_eq!(std::fs::read_to_string(&p).unwrap(), "newtoken");
+    }
+
+    // ── real-socket integration (stub host, no app) ──────────────────
+
+    fn spawn_server(host: StubHost) -> (PathBuf, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join(proto::SOCKET_FILE);
+        let listener = UnixListener::bind(&sock).unwrap();
+        let host: Arc<dyn CliHost> = Arc::new(host);
+        std::thread::spawn(move || serve_listener(listener, host));
+        (sock, dir)
+    }
+
+    fn roundtrip_on(sock: &Path, req: &Request) -> Reply {
+        let mut stream = UnixStream::connect(sock).unwrap();
+        proto::write_msg(&mut stream, req).unwrap();
+        let mut reader = BufReader::new(stream);
+        proto::read_msg::<_, Reply>(&mut reader).unwrap().unwrap()
+    }
+
+    /// Like `spawn_server` but keeps a concrete handle to the host so a
+    /// test can observe side effects (e.g. raise_window calls).
+    fn spawn_server_arc(host: StubHost) -> (PathBuf, tempfile::TempDir, Arc<StubHost>) {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join(proto::SOCKET_FILE);
+        let listener = UnixListener::bind(&sock).unwrap();
+        let arc = Arc::new(host);
+        let dynamic: Arc<dyn CliHost> = arc.clone();
+        std::thread::spawn(move || serve_listener(listener, dynamic));
+        (sock, dir, arc)
+    }
+
+    #[test]
+    fn preflight_raises_a_live_sibling_and_ignores_a_dead_socket() {
+        let (sock, guard, host) = spawn_server_arc(StubHost::default());
+        // A live sibling answers hello, so the preflight raises it and
+        // reports true (the second instance should exit). raise_existing
+        // reads the raise reply, so the raise_window call has already run.
+        assert!(raise_existing(&sock));
+        assert_eq!(*host.raised.lock().unwrap(), 1);
+        // No server behind the path: not a live sibling, so we would bind.
+        let dead = guard.path().join("nobody.sock");
+        assert!(!raise_existing(&dead));
+    }
+
+    #[test]
+    fn preflight_treats_a_stale_socket_file_as_no_sibling() {
+        // A leftover socket FILE with nothing listening (crash) must not
+        // be mistaken for a live instance: connect() fails fast.
+        let dir = tempfile::tempdir().unwrap();
+        let stale = dir.path().join(proto::SOCKET_FILE);
+        let listener = UnixListener::bind(&stale).unwrap();
+        drop(listener); // socket file may linger, but nothing listens
+        assert!(!raise_existing(&stale));
+    }
+
+    #[test]
+    fn socket_serves_hello_and_authenticated_list() {
+        let (sock, _guard) = spawn_server(StubHost::default());
+        let hello = roundtrip_on(&sock, &req(Command::Hello, None));
+        assert!(hello.ok);
+        let list = roundtrip_on(&sock, &req(Command::List { project: None, quiet: false }, Some("tok")));
+        assert!(list.ok);
+        let denied = roundtrip_on(&sock, &req(Command::List { project: None, quiet: false }, Some("bad")));
+        assert_eq!(denied.error.unwrap().code, ErrorCode::Auth);
+    }
+
+    #[test]
+    fn socket_handles_multiple_requests_per_connection() {
+        let (sock, _guard) = spawn_server(StubHost::default());
+        let mut stream = UnixStream::connect(&sock).unwrap();
+        proto::write_msg(&mut stream, &req(Command::Hello, None)).unwrap();
+        proto::write_msg(&mut stream, &req(Command::List { project: None, quiet: false }, Some("tok")))
+            .unwrap();
+        let mut reader = BufReader::new(stream);
+        let first: Reply = proto::read_msg(&mut reader).unwrap().unwrap();
+        let second: Reply = proto::read_msg(&mut reader).unwrap().unwrap();
+        assert!(matches!(first.data, Some(ReplyData::Hello(_))));
+        assert!(matches!(second.data, Some(ReplyData::List(_))));
+    }
+
+    #[test]
+    fn install_name_is_build_aware() {
+        // In this test binary cfg!(debug_assertions) is true, so the name
+        // is always the dev one regardless of identifier - which is
+        // exactly the invariant we want (a debug build installs
+        // `termic-dev`, never colliding with a prod `termic`).
+        assert_eq!(install_name("com.simion.termic"), "termic-dev");
+        assert_eq!(install_name("com.simion.termic.beta"), "termic-dev");
+        // The release/beta arms are unreachable here; assert the pure
+        // suffix rule they use so a rename is caught.
+        assert!("com.simion.termic.beta".ends_with(".beta"));
+        assert!(!"com.simion.termic".ends_with(".beta"));
+    }
+
+    #[test]
+    fn install_targets_use_the_name() {
+        let t = install_targets("termic-dev");
+        assert_eq!(t[0], PathBuf::from("/usr/local/bin/termic-dev"));
+        assert!(t.iter().any(|p| p.ends_with(".local/bin/termic-dev")));
+    }
+
+    #[test]
+    fn socket_survives_garbage_lines() {
+        let (sock, _guard) = spawn_server(StubHost::default());
+        let mut stream = UnixStream::connect(&sock).unwrap();
+        stream.write_all(b"this is not json\n").unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let reply: Reply = proto::read_msg(&mut reader).unwrap().unwrap();
+        assert_eq!(reply.error.unwrap().code, ErrorCode::BadRequest);
+        // The connection stays usable afterwards.
+        proto::write_msg(&mut stream, &req(Command::Hello, None)).unwrap();
+        let reply: Reply = proto::read_msg(&mut reader).unwrap().unwrap();
+        assert!(reply.ok);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ mod proxy;
 mod repo_config;
 mod shell_env;
 mod automation;
+mod cli_server;
 use sandbox::SandboxBundle;
 
 // ───────────────────────────── data model ─────────────────────────────
@@ -7794,6 +7795,13 @@ pub struct Settings {
     /// clone stop cluttering the picker without deleting it.
     #[serde(default)]
     pub discovery_dismissed: Vec<String>,
+    /// "Enable CLI" (Settings, General): gates every authenticated verb of
+    /// the `termic` control socket. Default OFF; the server always binds and
+    /// answers hello regardless, so a disabled CLI fails fast with a clear
+    /// error instead of a launch-then-timeout dead end (docs/plans/cli.md,
+    /// Landing). Re-read per request, so flipping it applies live.
+    #[serde(default)]
+    pub cli_enabled: bool,
     /// Repo-root config dirs symlinked into each NEW worktree task (when the
     /// checkout didn't already provide them). `.claude/` and friends hold a
     /// project's subagents / skills / commands, which are commonly gitignored
@@ -9020,6 +9028,15 @@ pub fn run() {
         })
         .manage(PtyManager::default())
         .setup(|app| {
+            // Single instance per data dir (release only): if another
+            // termic already owns this data dir's control socket, raise it
+            // and exit BEFORE building a window, so a second launch (prod
+            // vs beta, a direct binary run) never opens a duplicate that
+            // races the shared projects.json/tasks/. Debug is newest-wins.
+            // See cli_server::another_instance_running.
+            if cli_server::another_instance_running() {
+                std::process::exit(0);
+            }
             // Resolve the user's login-shell PATH off the main thread
             // so the first PTY spawn doesn't wait on shell startup.
             shell_env::warm();
@@ -9128,6 +9145,10 @@ pub fn run() {
             // TERMIC_AUTOMATION=1) - lets an agent drive this instance
             // over localhost HTTP. See automation.rs.
             automation::start(app.handle().clone());
+            // Production CLI control socket (own thread, always binds;
+            // verbs stay behind the "Enable CLI" setting + per-boot
+            // token). See cli_server.rs + docs/plans/cli.md.
+            cli_server::start(app.handle().clone());
             let _ = win.set_focus();
             #[cfg(target_os = "macos")]
             {
@@ -9169,6 +9190,9 @@ pub fn run() {
             settings_load, settings_save, discovery_dismiss, agents_save, agents_defaults, run_capture_command, discover_repos, detect_clis,
             automation::automation_result,
             automation::automation_armed,
+            cli_server::cli_rpc_result,
+            cli_server::cli_install_symlink,
+            cli_server::cli_install_status,
             list_monospace_fonts, list_font_families,
             themes_list, themes_dir,
         ])

--- a/src-tauri/src/sandbox.rs
+++ b/src-tauri/src/sandbox.rs
@@ -893,13 +893,64 @@ fn subst_path(raw: &str, home: &str, task_path: &str) -> String {
     s
 }
 
+/// Control-plane paths the ENFORCING profiles must deny (docs/plans/cli.md,
+/// Security). `None` fields mean the app has no data dir at all, in which
+/// case no socket or token exists to protect either.
+pub struct ControlPlanePaths {
+    /// The app data dir: holds the CLI token, projects.json, tasks/.
+    pub data_dir: Option<String>,
+    /// The control socket path inside it.
+    pub socket: Option<String>,
+}
+
+/// Resolve the REAL control-plane paths. Canonicalized because seatbelt
+/// evaluates canonical paths.
+pub fn control_plane_paths() -> ControlPlanePaths {
+    match crate::data_dir() {
+        Ok(d) => {
+            let dd = canonicalize_or_keep(&d.to_string_lossy());
+            ControlPlanePaths {
+                socket: Some(format!("{dd}/{}", termic_proto::SOCKET_FILE)),
+                data_dir: Some(dd),
+            }
+        }
+        Err(_) => ControlPlanePaths { data_dir: None, socket: None },
+    }
+}
+
 pub fn render_profile(task: &Task, proxy_port: u16, agent_override: Option<&str>, mode: SandboxMode) -> Result<String> {
+    // Per-agent allowed paths from the agent registry (Settings → Agents).
+    // Resolved here so render_profile_with is a pure function of its
+    // arguments - the behavioral sandbox tests inject hostile lists
+    // through the same seam the real layers flow through.
+    let effective_cli = agent_override.unwrap_or(&task.cli).to_string();
+    let settings = crate::load_settings_inner();
+    let agent_paths: Vec<String> = settings
+        .agents
+        .iter()
+        .find(|a| a.id == effective_cli)
+        .map(|a| a.sandbox_allowed_paths.clone())
+        .unwrap_or_default();
+    render_profile_with(task, proxy_port, &effective_cli, &agent_paths, mode, &control_plane_paths())
+}
+
+pub(crate) fn render_profile_with(
+    task: &Task,
+    proxy_port: u16,
+    effective_cli: &str,
+    agent_paths: &[String],
+    mode: SandboxMode,
+    control: &ControlPlanePaths,
+) -> Result<String> {
     // MONITORING: allow everything but ask the kernel to REPORT every
     // operation (so the path watcher can log it), while still forcing
     // all network through the logging proxy. The would-block decision is
-    // computed app-side (MonitorPolicy), not by the kernel.
+    // computed app-side (MonitorPolicy), not by the kernel. Monitor's
+    // contract is observe-never-block, so the control-plane denies below
+    // deliberately do NOT apply: a monitored agent reaches the socket by
+    // design, and its token read shows up in the file-op log.
     if mode == SandboxMode::Monitor {
-        return Ok(render_monitor_profile(proxy_port, agent_override.unwrap_or(&task.cli)));
+        return Ok(render_monitor_profile(proxy_port, effective_cli));
     }
     let home = dirs::home_dir()
         .ok_or_else(|| anyhow!("no home dir"))?
@@ -977,19 +1028,12 @@ pub fn render_profile(task: &Task, proxy_port: u16, agent_override: Option<&str>
     // into the allow-list whenever that agent's CLI is launched in this
     // task. The user CANNOT remove them per-task — to drop an
     // entry they have to edit the agent (which affects every task
-    // using that agent). settings_load is best-effort: if the file is
-    // missing or corrupt, the registry falls back to seeded defaults via
-    // crate::load_settings_inner, which still returns the three built-ins.
+    // using that agent). Resolved by render_profile from the registry
+    // (best-effort settings load with seeded defaults) and passed in.
     let mut agent_allowed: Vec<String> = Vec::new();
     let mut agent_allowed_regexes: Vec<String> = Vec::new();
-    let settings = crate::load_settings_inner();
-    // Use the tab-specific agent override if the caller passed one
-    // (multi-CLI tasks); fall back to the task's primary CLI.
-    let effective_cli = agent_override.unwrap_or(&task.cli);
-    if let Some(a) = settings.agents.iter().find(|a| a.id == effective_cli) {
-        for p in &a.sandbox_allowed_paths {
-            split_regex(p, &mut agent_allowed, &mut agent_allowed_regexes);
-        }
+    for p in agent_paths {
+        split_regex(p, &mut agent_allowed, &mut agent_allowed_regexes);
     }
     dedupe(&mut agent_allowed);
     dedupe(&mut agent_allowed_regexes);
@@ -1169,6 +1213,38 @@ pub fn render_profile(task: &Task, proxy_port: u16, agent_override: Option<&str>
     // allow-list. Anything not carved out above is denied by the
     // header's `(deny default)` — including metadata/existence — so
     // there is nothing to "re-open" and nothing to back-stop.
+    //
+    // ONE exception, and it is load-bearing (docs/plans/cli.md,
+    // Security): the CLI control plane. Default-denied is NOT
+    // guaranteed-denied - the allow-list above is user-, repo-, and
+    // agent-extensible, so one broad ancestor entry (~, ~/Library,
+    // ~/Library/Application Support) silently places the CLI token and
+    // projects.json/tasks/ under an allowed subpath, and a caged agent
+    // holding the token has escaped the sandbox. SBPL is last-match-wins,
+    // so these MUST stay the FINAL filesystem rules of both enforcing
+    // branches - a deny placed before the allows would be silently
+    // overridden. The write deny also closes the rename/re-bind MITM on
+    // the socket path. Verified behaviorally in tests (a textual check
+    // cannot catch a rule rendered in a position where last-match-wins
+    // makes it inert).
+    if let Some(dd) = &control.data_dir {
+        out.push_str("\n;; --- Termic control plane: data dir (CLI token, projects.json,\n");
+        out.push_str(";;     tasks/) is NEVER accessible to caged agents. FINAL filesystem\n");
+        out.push_str(";;     rules; last-match-wins beats any ancestor allow above. ---\n");
+        out.push_str(&format!("(deny file-write* (subpath \"{}\"))\n", sbpl_escape(dd)));
+        out.push_str(&format!("(deny file-read* (subpath \"{}\"))\n", sbpl_escape(dd)));
+    }
+
+    // Control-plane socket deny, emitted per-branch below: it must be the
+    // FINAL network rule AFTER every allow that could match (the broad
+    // unix-socket allow, EnforceFs's `(allow network*)`, and the agy
+    // special case's blanket outbound allow).
+    let socket_deny = control.socket.as_ref().map(|sock| {
+        format!(
+            ";; --- Termic control plane: caged agents get NO CLI surface.\n;;     FINAL network rule; last-match-wins beats the allows above. ---\n(deny network-outbound (remote unix-socket (path-literal \"{}\")))\n",
+            sbpl_escape(sock)
+        )
+    });
 
     if mode == SandboxMode::EnforceFs {
         // FILESYSTEM-ONLY ENFORCE: the file cage above is identical to
@@ -1179,6 +1255,13 @@ pub fn render_profile(task: &Task, proxy_port: u16, agent_override: Option<&str>
         // leave egress to the user's own controls.
         out.push_str("\n;; --- Network: UNRESTRICTED (filesystem-only enforce) ---\n");
         out.push_str("(allow network*)\n");
+        // The socket deny applies in EnforceFs too: the network sandbox
+        // is off here, so without it the control socket is reachable
+        // from inside the FS cage.
+        if let Some(deny) = &socket_deny {
+            out.push('\n');
+            out.push_str(deny);
+        }
         return Ok(out);
     }
 
@@ -1192,10 +1275,16 @@ pub fn render_profile(task: &Task, proxy_port: u16, agent_override: Option<&str>
     out.push_str("(allow network-bind     (local  ip \"localhost:*\"))\n");
     out.push_str("(allow network-inbound  (local  ip \"localhost:*\"))\n");
 
-    let agent = agent_override.unwrap_or(&task.cli);
-    if agent == "agy" {
+    if effective_cli == "agy" {
         out.push_str("\n;; --- Antigravity: allow direct outbound connections to Google APIs ---\n");
         out.push_str("(allow network-outbound)\n");
+    }
+
+    // MUST stay last: after the broad unix-socket allow and the agy
+    // blanket outbound allow above.
+    if let Some(deny) = &socket_deny {
+        out.push('\n');
+        out.push_str(deny);
     }
 
     Ok(out)
@@ -2474,5 +2563,293 @@ mod tests {
             "enforce must pin outbound to the loopback proxy port");
         assert!(!profile.contains("\n(allow network*)"),
             "enforce must NOT blanket-allow network");
+    }
+
+    // ─── Control-plane containment (BEHAVIORAL) ──────────────────────────
+    //
+    // docs/plans/cli.md, Testing: a textual profile check cannot catch a
+    // deny rendered where last-match-wins makes it inert, nor an allow-
+    // listed ANCESTOR re-exposing a path whose literal never appears in
+    // the list. So these run REAL `sandbox-exec` and observe the outcome.
+    // Only ABSENCE is asserted textually (the token secret never appears);
+    // reachability is proven by running connect()/open() in the cage.
+
+    use crate::{SandboxMode, Task};
+    use std::os::unix::net::UnixListener;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    /// macOS + sandbox-exec + the toolchain-free binaries the in-cage
+    /// probes need. Deliberately NOT /usr/bin/python3 or /usr/bin/git:
+    /// those are xcrun shims that dlopen the Xcode/CLT toolchain, which
+    /// the FS cage blocks (the whole point). `/bin/cat` reads a file,
+    /// `/usr/bin/nc -U` connects a unix socket; both are plain Mach-O.
+    fn cage_available() -> bool {
+        available()
+            && Path::new("/bin/cat").exists()
+            && Path::new("/usr/bin/nc").exists()
+    }
+
+    /// A hostile fixture: a canonical temp tree standing in for `~/Library`,
+    /// with the app data dir (token, socket, projects.json) nested inside
+    /// it, plus a sibling file to serve as the positive control.
+    struct Fixture {
+        tmp: tempfile::TempDir,
+        ancestor: String,      // the ~/Library stand-in we allow-list
+        data_dir: String,      // <ancestor>/Application Support/termic
+        token_path: String,
+        socket_path: String,
+        control_file: String,  // <ancestor>/allowed.txt (readable proof)
+        control_socket: String, // a peer socket, NOT the control plane
+        secret: String,
+    }
+
+    fn fixture() -> Fixture {
+        let tmp = tempfile::tempdir().unwrap();
+        // Canonicalize: seatbelt evaluates canonical paths, and macOS
+        // TMPDIR is /var/folders -> /private/var/folders. Everything below
+        // must therefore be canonical to match, and the allow-list entries
+        // must be too (subst_path does not canonicalize user paths).
+        let root = tmp.path().canonicalize().unwrap();
+        // Short nesting: the macOS TMPDIR prefix is already ~55 chars and
+        // the socket path must stay under the 104-byte sun_path limit. The
+        // containment property only needs data_dir nested UNDER the
+        // allow-listed ancestor; `lib`/`d` stand in for the real
+        // `~/Library` / `Application Support/termic` layout.
+        let ancestor = root.join("lib");
+        let data_dir = ancestor.join("d");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        let secret = "S3CRET-cli-token-do-not-leak".to_string();
+        let token_path = data_dir.join(termic_proto::TOKEN_FILE);
+        std::fs::write(&token_path, &secret).unwrap();
+        let control_file = ancestor.join("allowed.txt");
+        std::fs::write(&control_file, "readable proof").unwrap();
+        // A live control-plane socket + an unrelated peer socket.
+        let socket_path = data_dir.join(termic_proto::SOCKET_FILE);
+        let _sock = UnixListener::bind(&socket_path).unwrap();
+        let control_socket = root.join("peer.sock");
+        let _peer = UnixListener::bind(&control_socket).unwrap();
+        // Leak the listeners for the test's lifetime (dropping would unlink
+        // the socket files). The TempDir cleans everything on drop.
+        std::mem::forget(_sock);
+        std::mem::forget(_peer);
+        let s = |p: PathBuf| p.to_string_lossy().into_owned();
+        Fixture {
+            tmp,
+            ancestor: s(ancestor),
+            data_dir: s(data_dir.clone()),
+            token_path: s(token_path),
+            socket_path: s(socket_path),
+            control_file: s(control_file),
+            control_socket: s(control_socket),
+            secret,
+        }
+    }
+
+    /// Render a hostile ENFORCING profile: `~/Library` is allow-listed
+    /// through BOTH render_profile seams at once - the task list (where
+    /// live_sandbox_lists deposits the global, task, project.json and
+    /// .termic.yaml layers, all concatenated) and the agent-registry list
+    /// (agent_sandbox_add_allowed_path). That covers every one of the four
+    /// unioned extension layers the spec names. Writes the profile to a
+    /// temp .sb and returns its path.
+    fn hostile_profile(fx: &Fixture, mode: SandboxMode) -> PathBuf {
+        let task = Task {
+            cli: "claude".into(),
+            path: format!("{}/worktree", fx.ancestor),
+            base_branch: "main".into(),
+            // The task allow-list layer (global + task + project layers all
+            // land here at spawn) allow-lists the ancestor as a subpath.
+            sandbox_rw_paths: vec![fx.ancestor.clone()],
+            ..Default::default()
+        };
+        // The agent-registry layer ALSO allow-lists it, as a subpath and a
+        // broad regex, exercising both emit forms.
+        let agent_paths = vec![
+            fx.ancestor.clone(),
+            format!("regex:^{}(/.*)?$", regex::escape(&fx.ancestor)),
+        ];
+        let control = ControlPlanePaths {
+            data_dir: Some(fx.data_dir.clone()),
+            socket: Some(fx.socket_path.clone()),
+        };
+        // A valid loopback proxy port: Enforce emits (remote ip
+        // "localhost:<port>"), which sandbox-exec rejects if it is 0.
+        // EnforceFs ignores the port (no proxy).
+        let profile =
+            render_profile_with(&task, 51999, "claude", &agent_paths, mode, &control).unwrap();
+        // Sanity: the ancestor really is allow-listed (so a pass proves the
+        // deny won, not that the path was simply never granted).
+        assert!(
+            profile.contains(&format!("(subpath \"{}\")", fx.ancestor)),
+            "fixture must allow-list the ancestor"
+        );
+        // Write the profile INSIDE this fixture's own TempDir, never a
+        // shared temp_dir()/<pid>-<mode>.sb: each test builds its own
+        // Fixture, so a per-fixture path can't be create/truncate/deleted
+        // out from under a parallel libtest thread (that race could make a
+        // security test spuriously report a containment breach). The
+        // TempDir cleans it up on drop, so no manual removal is needed.
+        let out = fx.tmp.path().join(format!("profile-{mode:?}.sb"));
+        std::fs::write(&out, profile).unwrap();
+        out
+    }
+
+    /// `/bin/cat <path>` inside the cage.
+    fn caged_cat(profile: &Path, path: &str) -> std::process::Output {
+        Command::new("/usr/bin/sandbox-exec")
+            .args(["-f".as_ref(), profile.as_os_str(), "/bin/cat".as_ref(), path.as_ref()])
+            .output()
+            .expect("spawn sandbox-exec cat")
+    }
+
+    /// `/usr/bin/nc -U -w1 <sock> </dev/null` inside the cage: exit 0 on a
+    /// successful connect, non-zero when seatbelt refuses it.
+    fn caged_connect(profile: &Path, sock: &str) -> std::process::Output {
+        use std::process::Stdio;
+        Command::new("/usr/bin/sandbox-exec")
+            .args([
+                "-f".as_ref(),
+                profile.as_os_str(),
+                "/usr/bin/nc".as_ref(),
+                "-U".as_ref(),
+                "-w1".as_ref(),
+                sock.as_ref(),
+            ])
+            .stdin(Stdio::null())
+            .output()
+            .expect("spawn sandbox-exec nc")
+    }
+
+    #[test]
+    fn caged_agent_cannot_read_the_cli_token_even_with_library_allowlisted() {
+        if !cage_available() {
+            return;
+        }
+        let fx = fixture();
+        for mode in [SandboxMode::Enforce, SandboxMode::EnforceFs] {
+            let profile = hostile_profile(&fx, mode);
+
+            // Positive control: a sibling file under the SAME allow-listed
+            // ancestor IS readable, proving the allow-list is live and the
+            // final data-dir deny is what blocks the token.
+            let ok = caged_cat(&profile, &fx.control_file);
+            assert!(
+                ok.status.success(),
+                "{mode:?}: control file under the allow-listed ancestor should be readable; stderr={}",
+                String::from_utf8_lossy(&ok.stderr)
+            );
+
+            // The token read must be refused.
+            let denied = caged_cat(&profile, &fx.token_path);
+            assert!(
+                !denied.status.success(),
+                "{mode:?}: reading the CLI token must be denied inside the cage"
+            );
+            // Absence assertion (the only kind the spec permits here): the
+            // secret must not have leaked to stdout.
+            assert!(
+                !String::from_utf8_lossy(&denied.stdout).contains(&fx.secret),
+                "{mode:?}: token secret leaked out of the cage"
+            );
+        }
+    }
+
+    #[test]
+    fn caged_agent_cannot_connect_to_the_control_socket() {
+        if !cage_available() {
+            return;
+        }
+        let fx = fixture();
+        for mode in [SandboxMode::Enforce, SandboxMode::EnforceFs] {
+            let profile = hostile_profile(&fx, mode);
+
+            // Positive control: an unrelated peer unix socket IS reachable,
+            // proving unix sockets are allowed in general and only the
+            // control-plane path is denied (last-match-wins, after the
+            // broad unix-socket allow / EnforceFs's blanket allow).
+            let ok = caged_connect(&profile, &fx.control_socket);
+            assert!(
+                ok.status.success(),
+                "{mode:?}: a non-control unix socket should be connectable; stderr={}",
+                String::from_utf8_lossy(&ok.stderr)
+            );
+
+            let denied = caged_connect(&profile, &fx.socket_path);
+            assert!(
+                !denied.status.success(),
+                "{mode:?}: connect() to the control socket must be denied inside the cage"
+            );
+        }
+    }
+
+    #[test]
+    fn caged_spawn_env_carries_no_token() {
+        if !cage_available() {
+            return;
+        }
+        let fx = fixture();
+        // Guards the app-env invariant: pty_spawn copies the whole app env
+        // into every caged child, so the token must live ONLY in the
+        // server's memory, never in the process environment. We inherit
+        // THIS process's env (the app-process stand-in) into the caged
+        // `env` dump; the freshly-written token must not appear, because
+        // nothing ever exported it. Absence-only assertion, per spec.
+        let profile = hostile_profile(&fx, SandboxMode::Enforce);
+        let out = Command::new("/usr/bin/sandbox-exec")
+            .arg("-f")
+            .arg(&profile)
+            .arg("/usr/bin/env")
+            .output()
+            .expect("spawn env in cage");
+        let env_dump = String::from_utf8_lossy(&out.stdout);
+        assert!(
+            !env_dump.contains(&fx.secret),
+            "the CLI token must never reach a caged spawn's environment"
+        );
+        // And no token-shaped variable name exists either.
+        for line in env_dump.lines() {
+            let key = line.split('=').next().unwrap_or("");
+            assert!(
+                !(key.contains("TERMIC") && key.contains("TOKEN")),
+                "a token-shaped env var reached the cage: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn socket_deny_is_the_final_network_rule_in_both_enforcing_modes() {
+        // Structural backstop to the behavioral tests: the deny for the
+        // control socket must textually FOLLOW every network allow in both
+        // enforcing branches (last-match-wins). Not a substitute for the
+        // behavioral checks - a complement that pins the ordering.
+        let fx = fixture();
+        let control = ControlPlanePaths {
+            data_dir: Some(fx.data_dir.clone()),
+            socket: Some(fx.socket_path.clone()),
+        };
+        for (mode, agent) in
+            [(SandboxMode::Enforce, "claude"), (SandboxMode::EnforceFs, "claude"), (SandboxMode::Enforce, "agy")]
+        {
+            let task = Task { cli: agent.into(), ..Default::default() };
+            let profile =
+                render_profile_with(&task, 5, agent, &[], mode, &control).unwrap();
+            let deny_tok = format!("(path-literal \"{}\")", sbpl_escape(&fx.socket_path));
+            let deny_at = profile.find(&deny_tok).expect("socket deny must be present");
+            // No network ALLOW may appear after the deny.
+            let after = &profile[deny_at + deny_tok.len()..];
+            assert!(
+                !after.contains("(allow network"),
+                "{mode:?}/{agent}: a network allow follows the socket deny (would make it inert)"
+            );
+            // And the data-dir read deny is the final filesystem rule: no
+            // file allow after it.
+            let dd_deny = format!("(deny file-read* (subpath \"{}\"))", sbpl_escape(&fx.data_dir));
+            let dd_at = profile.find(&dd_deny).expect("data-dir read deny must be present");
+            assert!(
+                !profile[dd_at + dd_deny.len()..].contains("(allow file-"),
+                "{mode:?}/{agent}: a file allow follows the data-dir deny"
+            );
+        }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../dist",
     "devUrl": "http://localhost:1420",
     "beforeDevCommand": "npm run dev",
-    "beforeBuildCommand": "npm run build"
+    "beforeBuildCommand": "npm run build && node scripts/build-cli.mjs"
   },
   "app": {
     "withGlobalTauri": false,
@@ -20,6 +20,9 @@
     "active": true,
     "targets": "all",
     "createUpdaterArtifacts": true,
+    "externalBin": [
+      "binaries/termic-cli"
+    ],
     "resources": [
       "resources/sounds/choo_choo.caf"
     ],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useApp } from "@/store/app";
 import { taskSpotlightStatus } from "@/lib/ipc";
 import { installPointerEventsGuard } from "@/lib/pointerEventsGuard";
+import { initCliRpc } from "@/lib/cliRpc";
 import { cn } from "@/lib/utils";
 import { Sidebar } from "@/components/sidebar/Sidebar";
 import { UnifiedBar } from "@/components/UnifiedBar";
@@ -82,6 +83,9 @@ export function App() {
       "spotlight://status",
       ev => useApp.getState().setSpotlight(ev.payload.project_id, ev.payload.ws_id),
     );
+    // Answer the `termic` CLI control socket's work-state / open-task RPCs
+    // (src-tauri/src/cli_server.rs). Idempotent; runs in release builds.
+    const unlistenCliRpc = initCliRpc();
     const onFocus = () => {
       loadAll();
       // Restore focus to whichever terminal/editor was last active when the
@@ -111,6 +115,7 @@ export function App() {
     return () => {
       window.removeEventListener("focus", onFocus);
       unlistenStatus.then(u => u());
+      unlistenCliRpc.then(u => u());
     };
   }, [loadAll]);
 

--- a/src/components/settings/GeneralSection.tsx
+++ b/src/components/settings/GeneralSection.tsx
@@ -4,8 +4,8 @@
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { TextareaHTMLAttributes } from "react";
-import { settingsLoad, settingsSave, ensureNotifyPermission, previewCompletionSound } from "@/lib/ipc";
-import type { Settings } from "@/lib/types";
+import { settingsLoad, settingsSave, ensureNotifyPermission, previewCompletionSound, cliInstallSymlink, cliInstallStatus } from "@/lib/ipc";
+import type { Settings, CliInstallStatus } from "@/lib/types";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
@@ -43,6 +43,15 @@ export function GeneralSection() {
   // Pre-create base fetch (GH #79). Backend Settings field; saved immediately
   // on toggle. Absent in settings = on.
   const [fetchBeforeCreate, setFetchBeforeCreate] = useState(true);
+  // "Enable CLI": backend Settings field, saved immediately on toggle.
+  // Absent = off. Gates every authenticated verb of the `termic` control
+  // socket (docs/plans/cli.md).
+  const [cliEnabled, setCliEnabled] = useState(false);
+  // Install state (path / command name / PATH-awareness), plus the
+  // in-flight flag + last result line of an install action.
+  const [cliInstall, setCliInstall] = useState<CliInstallStatus | null>(null);
+  const [cliInstalling, setCliInstalling] = useState(false);
+  const [cliInstallMsg, setCliInstallMsg] = useState<string | null>(null);
 
   const desktopNotifications = usePrefs(s => s.desktopNotifications);
   const setDesktopNotifications = usePrefs(s => s.setDesktopNotifications);
@@ -106,8 +115,50 @@ export function GeneralSection() {
       setSymlinkPaths(links);
       setSymlinkPathsOriginal(links);
       setFetchBeforeCreate(s.fetch_before_create !== false);
+      setCliEnabled(s.cli_enabled === true);
     }).catch(() => {});
+    cliInstallStatus().then(setCliInstall).catch(() => {});
   }, []);
+
+  async function saveCliEnabled(v: boolean) {
+    // Ignore clicks until settings have loaded, so the toggle never flips
+    // visually without persisting.
+    if (!settings) return;
+    setCliEnabled(v);
+    const next: Settings = { ...settings, cli_enabled: v };
+    setSettings(next);
+    try {
+      await settingsSave(next);
+    } catch {
+      // Persist failed: revert rather than show a state we did not save.
+      setCliEnabled(!v);
+      setSettings(settings);
+      return;
+    }
+    // Enabling should hand you a working command with no extra step: do a
+    // no-prompt install into ~/.local/bin, then reflect whether it landed
+    // on PATH. Only auto-install when not already installed so re-enabling
+    // never resurrects a link the user removed on purpose.
+    if (v) {
+      const cur = await cliInstallStatus().catch(() => null);
+      if (!cur?.path) await installCli(false);
+      else setCliInstall(cur);
+    }
+  }
+
+  async function installCli(system: boolean) {
+    setCliInstalling(true);
+    setCliInstallMsg(null);
+    try {
+      const msg = await cliInstallSymlink(system);
+      setCliInstallMsg(msg);
+      setCliInstall(await cliInstallStatus());
+    } catch (e) {
+      setCliInstallMsg(String(e));
+    } finally {
+      setCliInstalling(false);
+    }
+  }
 
   // Persist the fetch-before-create toggle immediately (backend Settings),
   // merging into the cached object so we don't clobber other fields.
@@ -220,6 +271,60 @@ export function GeneralSection() {
           value={fetchBeforeCreate}
           onChange={saveFetchBeforeCreate}
         />
+      </div>
+
+      {/* termic CLI control plane. Off by default: the socket always binds
+          and answers hello, but every verb stays refused until this is on.
+          Enabling auto-installs the command (no prompt) into ~/.local/bin;
+          the button upgrades it to a system-wide /usr/local/bin install. */}
+      <div className="border-t border-[var(--color-border-soft)] pt-6">
+        <Toggle
+          label="Enable CLI"
+          hint="Let the termic command control this app from any shell (list tasks, check a task, focus the window). Off by default. Agents in an enforced sandbox never get access. Turning this off refuses every command immediately (the command stays installed)."
+          value={cliEnabled}
+          onChange={saveCliEnabled}
+        />
+        <div className={cn("mt-3", !cliEnabled && "pointer-events-none opacity-50 select-none")}>
+          {cliInstall?.path ? (
+            <p className="text-[12.5px] text-[var(--color-fg-dim)]">
+              <code className="font-mono">{cliInstall.name}</code> is installed at{" "}
+              <code className="font-mono">{cliInstall.path}</code>.{" "}
+              {cliInstall.on_path
+                ? <>Run <code className="font-mono">{cliInstall.name} list</code> from any shell.</>
+                : <span className="text-[var(--color-warn,inherit)]">That location is not on your PATH, so use Install system-wide below, or add <code className="font-mono">~/.local/bin</code> to your PATH.</span>}
+            </p>
+          ) : (
+            <p className="text-[12.5px] text-[var(--color-fg-dim)]">
+              Enabling installs <code className="font-mono">{cliInstall?.name ?? "termic"}</code> into <code className="font-mono">~/.local/bin</code> automatically.
+            </p>
+          )}
+          {/* The system-wide install is only a REQUIRED step when the
+              auto-install did not land on PATH. When it did (the common
+              case), keep it as a de-emphasized optional action so it does
+              not read as "you still need to do this". */}
+          {cliInstall?.path && cliInstall.on_path ? (
+            <button
+              type="button"
+              disabled={cliInstalling}
+              onClick={() => installCli(true)}
+              className="mt-2 text-[12px] text-[var(--color-fg-faint)] underline decoration-dotted underline-offset-2 hover:text-[var(--color-fg-dim)] disabled:opacity-50"
+            >
+              {cliInstalling ? "Installing…" : "Install system-wide instead (optional, uses /usr/local/bin)"}
+            </button>
+          ) : (
+            <div className="mt-2 flex items-center gap-2">
+              <Button variant="secondary" size="md" disabled={cliInstalling} onClick={() => installCli(true)}>
+                {cliInstalling ? "Installing…" : "Install system-wide"}
+              </Button>
+              <span className="text-[12px] text-[var(--color-fg-faint)]">
+                symlinks into <code className="font-mono">/usr/local/bin</code> (asks for your password)
+              </span>
+            </div>
+          )}
+          {cliInstallMsg && (
+            <p className="mt-2 text-[12px] text-[var(--color-fg-faint)]">{cliInstallMsg}</p>
+          )}
+        </div>
       </div>
 
       <div className="border-t border-[var(--color-border-soft)] pt-6">

--- a/src/lib/cliRpc.test.ts
+++ b/src/lib/cliRpc.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocks must be declared before the module under test is imported.
+// cliRpc pulls in the tauri event/core APIs at module load, and useApp
+// (via @/store/app) pulls in ipc/tabFocus/agents. Stub them all so the
+// aggregation logic can be tested in the node/happy-dom env.
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn().mockResolvedValue(() => {}) }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("@/lib/ipc", () => ({
+  projectsList: vi.fn().mockResolvedValue([]),
+  tasksList: vi.fn().mockResolvedValue([]),
+  settingsLoad: vi.fn().mockResolvedValue({ agents: [] }),
+  detectClis: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/tabFocus", () => ({
+  focusTerminalTab: vi.fn(),
+  focusMainTab: vi.fn(),
+  focusPaneTab: vi.fn(),
+}));
+vi.mock("@/lib/agents", () => ({ agentDisplayName: vi.fn((cli: string) => cli) }));
+
+import { workStateHandler } from "@/lib/cliRpc";
+import { useApp } from "@/store/app";
+import type { Tab, TerminalTab } from "@/lib/types";
+
+function term(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: crypto.randomUUID(),
+    type: "terminal",
+    cli: "claude",
+    title: "t",
+    ...overrides,
+  } as TerminalTab;
+}
+
+/** Set the store's tabs for a set of tasks and query their states. */
+function statesFor(tabs: Record<string, Tab[]>): Record<string, { state: string; tabs: number }> {
+  useApp.setState({ tabs });
+  return workStateHandler({ taskIds: Object.keys(tabs) }).states;
+}
+
+describe("workStateHandler aggregation", () => {
+  beforeEach(() => useApp.setState({ tabs: {} }));
+
+  it("follows the sidebar precedence: working > attention > done > idle", () => {
+    const s = statesFor({
+      working: [term({ workState: "done" }), term({ workState: "working" })],
+      waiting: [term({ workState: "done" }), term({ unread: { reason: "attention" } })],
+      done: [term({ workState: "idle" }), term({ workState: "done" })],
+      idle: [term({ workState: "idle" })],
+    });
+    expect(s.working.state).toBe("working");
+    expect(s.waiting.state).toBe("waiting");
+    expect(s.done.state).toBe("done");
+    expect(s.idle.state).toBe("idle");
+  });
+
+  it("reports 'inactive' with 0 tabs when a task has no live terminal tabs", () => {
+    const s = statesFor({ dormant: [] });
+    expect(s.dormant).toEqual({ state: "inactive", tabs: 0 });
+  });
+
+  it("counts only terminal tabs and reports the count", () => {
+    const editor = { id: "e", type: "editor" } as unknown as Tab;
+    const s = statesFor({ mixed: [term({ workState: "idle" }), editor, term({ workState: "idle" })] });
+    expect(s.mixed).toEqual({ state: "idle", tabs: 2 });
+  });
+
+  it("ignores non-string task ids and returns an empty map for none", () => {
+    useApp.setState({ tabs: { a: [term({ workState: "idle" })] } });
+    expect(workStateHandler({ taskIds: [1, null, {}] }).states).toEqual({});
+    expect(workStateHandler({}).states).toEqual({});
+  });
+});

--- a/src/lib/cliRpc.ts
+++ b/src/lib/cliRpc.ts
@@ -1,0 +1,119 @@
+// Production RPC bridge for the `termic` CLI control socket.
+//
+// Work-state (working / waiting / done / idle) lives ONLY in the webview
+// (store/app.ts tab.workState + tab.unread), and selecting a task is a UI
+// action. The Rust socket server (src-tauri/src/cli_server.rs) reaches
+// those by emitting `cli-rpc://request` with a correlation id; this module
+// runs the handler against the SAME store the GUI uses and replies via the
+// `cli_rpc_result` command. It is NEW hardened code that only borrows the
+// dev automation bridge's correlation-id pattern (automation.rs) - the
+// debug bridge itself is never armed or reused here, and unlike it, this
+// listener runs in RELEASE builds (the whole feature is dead otherwise).
+//
+// Only these two typed handlers exist; there is no eval. An unknown method
+// replies with an error, and the server ignores replies whose id is not
+// waiting, so nothing can be injected into an in-flight request.
+
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { useApp } from "@/store/app";
+import type { TerminalTab } from "@/lib/types";
+
+interface RpcRequest {
+  id: string;
+  method: string;
+  params: unknown;
+}
+
+type Handler = (params: unknown) => Promise<unknown> | unknown;
+
+/** Aggregate a task's terminal tabs into one work state, matching the
+ *  sidebar's own signal (see lib/waitingAgents.ts): working wins, then a
+ *  tab blocked on the user (attention), then a finished turn (done),
+ *  else idle. A task with NO live terminal tabs reports "inactive" (it
+ *  exists on disk but no agent is running in the app) rather than being
+ *  omitted, so the CLI can say "no agent open" instead of the misleading
+ *  "UI did not answer" (which now means only a genuine timeout). */
+export function workStateHandler(params: unknown): { states: Record<string, { state: string; tabs: number }> } {
+  const taskIds = Array.isArray((params as { taskIds?: unknown })?.taskIds)
+    ? ((params as { taskIds: unknown[] }).taskIds.filter((x): x is string => typeof x === "string"))
+    : [];
+  const s = useApp.getState();
+  const states: Record<string, { state: string; tabs: number }> = {};
+  for (const id of taskIds) {
+    const term = (s.tabs[id] ?? []).filter((t): t is TerminalTab => t.type === "terminal");
+    if (term.length === 0) {
+      states[id] = { state: "inactive", tabs: 0 };
+      continue;
+    }
+    let state = "idle";
+    if (term.some(t => t.workState === "working")) state = "working";
+    else if (term.some(t => t.unread?.reason === "attention")) state = "waiting";
+    else if (term.some(t => t.workState === "done")) state = "done";
+    states[id] = { state, tabs: term.length };
+  }
+  return { states };
+}
+
+/** Select a task in the UI (window raise is done Rust-side). Loads the
+ *  task set first if the store has not seen this id yet (a task created
+ *  in another way since the last refresh). */
+async function openTaskHandler(params: unknown): Promise<null> {
+  const taskId = (params as { taskId?: unknown })?.taskId;
+  if (typeof taskId !== "string" || !taskId) {
+    throw new Error("open_task requires a taskId");
+  }
+  const app = useApp.getState();
+  if (!app.tasks.some(t => t.id === taskId)) {
+    await app.loadAll();
+  }
+  const fresh = useApp.getState();
+  if (!fresh.tasks.some(t => t.id === taskId)) {
+    throw new Error("no such task");
+  }
+  fresh.setActiveTask(taskId);
+  return null;
+}
+
+const handlers: Record<string, Handler> = {
+  work_state: workStateHandler,
+  open_task: openTaskHandler,
+};
+
+async function dispatch(req: RpcRequest): Promise<void> {
+  let payload: string;
+  try {
+    const handler = handlers[req.method];
+    if (!handler) throw new Error(`unknown method "${req.method}"`);
+    const value = await handler(req.params);
+    payload = JSON.stringify({ ok: true, value: value ?? null });
+  } catch (e) {
+    payload = JSON.stringify({ ok: false, error: String((e as Error)?.message ?? e) });
+  }
+  // Fire-and-forget: if the server already timed out and dropped the id,
+  // the result is discarded harmlessly.
+  invoke("cli_rpc_result", { id: req.id, payload }).catch(() => {});
+}
+
+let started = false;
+
+/** Register the control-socket RPC listener. Idempotent; safe to call on
+ *  every mount. Returns an unlisten for teardown. The returned unlisten
+ *  clears the latch, so a teardown-then-remount (or a re-run mount effect)
+ *  re-registers instead of silently leaving the RPC channel dead. */
+export function initCliRpc(): Promise<UnlistenFn> {
+  if (started) return Promise.resolve(() => {});
+  started = true;
+  return listen<RpcRequest>("cli-rpc://request", ev => {
+    void dispatch(ev.payload);
+  })
+    .then(unlisten => () => {
+      started = false;
+      unlisten();
+    })
+    .catch(err => {
+      // A failed registration must not wedge the latch on forever.
+      started = false;
+      throw err;
+    });
+}

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -7,7 +7,7 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import type {
   Project, ProjectMember, Task, CreateTaskArgs, CreateMultiArgs, Settings, DiscoveredRepo,
   ImportableWorktree, CliInfo, ChangeFile, Changes, GitStatus, CheckoutResult, UpdateMode, UpdateResult, UpdateInfo, FileEntry, Agent, RepoConfig,
-  SandboxMode, TaskDiffSummary,
+  SandboxMode, TaskDiffSummary, CliInstallStatus,
 } from "./types";
 import type { CustomThemeFile } from "./customTheme";
 import {
@@ -481,6 +481,18 @@ export const discoverRepos = (dir: string) => invoke<DiscoveredRepo[]>("discover
 export const discoveryDismiss = (path: string, dismissed: boolean) =>
   invoke<void>("discovery_dismiss", { path, dismissed });
 export const detectClis    = () => invoke<CliInfo[]>("detect_clis");
+
+// ───────────────────────────── CLI control plane ─────────────────────
+/** Symlink the bundled CLI onto PATH. `system=false` (the on-enable path)
+ *  installs into ~/.local/bin with no prompt; `system=true` installs into
+ *  /usr/local/bin via an admin prompt, falling back to ~/.local/bin.
+ *  Returns a human-readable result line; rejects with an error string. */
+export const cliInstallSymlink = (system: boolean) =>
+  invoke<string>("cli_install_symlink", { system });
+/** Where the CLI is installed for this build, the command name
+ *  (termic / termic-dev / termic-beta), and whether that location is on
+ *  the user's login PATH. */
+export const cliInstallStatus  = () => invoke<CliInstallStatus>("cli_install_status");
 export const listMonospaceFonts = () => invoke<string[]>("list_monospace_fonts");
 /** Every installed font family, unfiltered — for hiding curated picker
  *  entries whose font isn't installed. See list_font_families in lib.rs

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -416,6 +416,11 @@ export interface Settings {
    *  commit instead of a stale local `origin/*` (GH #79). Absent = on; set
    *  false to opt out. The fetch is always time-bounded and non-fatal. */
   fetch_before_create?: boolean;
+  /** "Enable CLI": gates every authenticated verb of the `termic` control
+   *  socket. Default off. The socket always binds and answers hello, so a
+   *  disabled CLI fails fast with a clear error rather than a launch
+   *  timeout. See docs/plans/cli.md. */
+  cli_enabled?: boolean;
   /** Canonical repo paths hidden from the Add Project discovery list.
    *  Discovery still finds them; the picker filters them out until restored. */
   discovery_dismissed?: string[];
@@ -424,6 +429,16 @@ export interface Settings {
    *  omits it). Pre-filled with the common agent dirs; an empty list disables
    *  the linking. Absent = the pre-filled defaults, not off. */
   worktree_symlink_paths?: string[];
+}
+
+/** Install state of the bundled CLI on PATH (cli_install_status). */
+export interface CliInstallStatus {
+  /** Absolute path of the installed symlink, or null when not installed. */
+  path: string | null;
+  /** Command name for this build: `termic`, `termic-dev`, or `termic-beta`. */
+  name: string;
+  /** True when the installed location is on the user's login PATH. */
+  on_path: boolean;
 }
 
 export interface DiscoveredRepo {

--- a/termic-cli/Cargo.toml
+++ b/termic-cli/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "termic-cli"
+version = "0.1.0"
+description = "Thin client for the Termic app's control socket. Bundled in Termic.app as a sidecar; installed onto PATH as `termic`."
+edition = "2021"
+license = "AGPL-3.0-or-later"
+publish = false
+workspace = "../src-tauri"
+
+# The on-disk binary is `termic-cli`, NOT `termic`: tauri-build rejects a
+# sidecar named like the app's cargo package, and `Termic` vs `termic`
+# would collide inside Contents/MacOS on case-insensitive APFS anyway.
+# The PATH install symlinks it as `termic`; clap's display name is
+# "termic" regardless of argv[0].
+[[bin]]
+name = "termic-cli"
+path = "src/main.rs"
+
+[lib]
+name = "termic_cli"
+path = "src/lib.rs"
+
+# Links ONLY termic-proto, never the app's lib.rs (docs/plans/cli.md).
+# Keep this list short: the CLI must stay milliseconds-fast and
+# dependency-light.
+[dependencies]
+termic-proto = { path = "../termic-proto" }
+serde = "1"
+serde_json = "1"
+clap = { version = "4", features = ["derive", "wrap_help"] }
+dirs = "5"

--- a/termic-cli/build.rs
+++ b/termic-cli/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // `termic --version` reports the APP version, injected via
+    // TERMIC_APP_VERSION by src-tauri/build.rs and scripts/build-cli.mjs so
+    // the bundled CLI is versioned with the app it ships in. Track the env
+    // var so a version bump rebuilds the CLI with the new value; without a
+    // value set, the crate version is the dev fallback.
+    println!("cargo:rerun-if-env-changed=TERMIC_APP_VERSION");
+}

--- a/termic-cli/src/client.rs
+++ b/termic-cli/src/client.rs
@@ -1,0 +1,309 @@
+//! Socket discovery, connect-or-launch, and the request/reply exchange.
+//!
+//! Rules from docs/plans/cli.md this module enforces:
+//! - The CLI NEVER touches termic's data files (no offline mode); the
+//!   only file it reads is the per-boot token, which is the credential.
+//! - No socket means "launch the app and poll with a deadline", never a
+//!   hang; `--no-launch` swaps the launch for an immediate error.
+//! - After a connection exists, any IO failure is "connection lost"
+//!   (exit 8), distinct from "app not running" (exit 4).
+
+use crate::CliError;
+use std::io::{BufReader, Read};
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::time::Duration;
+use termic_proto as proto;
+use termic_proto::exit_code;
+
+/// Where the socket and token live. `custom` is set when TERMIC_SOCKET
+/// overrode discovery; auto-launch is disabled then (the override points
+/// at a specific instance, launching the installed app would be wrong).
+pub struct SocketPaths {
+    pub socket: PathBuf,
+    pub token_file: PathBuf,
+    pub custom: bool,
+}
+
+/// Mirror of the app's data-dir choice (src-tauri/src/lib.rs `APP_DIR`):
+/// debug builds use `termic_dev` and honor TERMIC_DATA_DIR, release uses
+/// `termic`. Used only to locate the socket + token, never to read data.
+fn default_data_dir() -> Option<PathBuf> {
+    const APP_DIR: &str = if cfg!(debug_assertions) { "termic_dev" } else { "termic" };
+    if cfg!(debug_assertions) {
+        if let Ok(d) = std::env::var("TERMIC_DATA_DIR") {
+            if !d.trim().is_empty() {
+                return Some(PathBuf::from(d));
+            }
+        }
+    }
+    dirs::data_local_dir().map(|p| p.join(APP_DIR))
+}
+
+pub fn socket_paths() -> SocketPaths {
+    socket_paths_from(std::env::var("TERMIC_SOCKET").ok(), default_data_dir())
+}
+
+/// Pure resolution, split out for tests.
+pub fn socket_paths_from(socket_env: Option<String>, data_dir: Option<PathBuf>) -> SocketPaths {
+    if let Some(s) = socket_env.filter(|s| !s.trim().is_empty()) {
+        let socket = PathBuf::from(s);
+        let token_file =
+            socket.parent().map(|p| p.join(proto::TOKEN_FILE)).unwrap_or_else(|| {
+                PathBuf::from(proto::TOKEN_FILE)
+            });
+        return SocketPaths { socket, token_file, custom: true };
+    }
+    // No data dir at all is a broken environment; point at a path that
+    // will fail to connect with a clear error rather than panicking.
+    let dir = data_dir.unwrap_or_else(|| PathBuf::from("/nonexistent/termic"));
+    SocketPaths {
+        socket: dir.join(proto::SOCKET_FILE),
+        token_file: dir.join(proto::TOKEN_FILE),
+        custom: false,
+    }
+}
+
+pub struct Conn {
+    reader: BufReader<UnixStream>,
+    writer: UnixStream,
+}
+
+fn try_connect(paths: &SocketPaths) -> std::io::Result<Conn> {
+    let stream = UnixStream::connect(&paths.socket)?;
+    // Replies for these read verbs are quick; the generous ceiling only
+    // exists so a wedged app can never hang a script forever.
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(30)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+    let reader = BufReader::new(stream.try_clone()?);
+    Ok(Conn { reader, writer: stream })
+}
+
+pub fn connect_or_launch(paths: &SocketPaths, no_launch: bool) -> Result<Conn, CliError> {
+    match try_connect(paths) {
+        Ok(c) => return Ok(c),
+        Err(_) if no_launch => {
+            return Err(CliError::new(
+                exit_code::APP_NOT_RUNNING,
+                "Termic must be open (--no-launch given)",
+            ));
+        }
+        Err(_) if paths.custom => {
+            return Err(CliError::new(
+                exit_code::APP_NOT_RUNNING,
+                format!("Termic is not listening on TERMIC_SOCKET ({})", paths.socket.display()),
+            ));
+        }
+        Err(_) => {}
+    }
+
+    // Auto-launch is a RELEASE-build convenience only. `open -ga Termic`
+    // can start just the INSTALLED release app, which serves the release
+    // data dir (<data>/termic). A DEBUG cli targets <data>/termic_dev, so
+    // launching the release app would poll a socket it never binds and
+    // time out with a misleading "Termic did not start" - and worse, pop
+    // open the prod app while you are testing a `make dev` instance. In
+    // debug (and on non-macOS) fail fast and point at the fix instead.
+    #[cfg(all(target_os = "macos", not(debug_assertions)))]
+    {
+        // Background launch without focus steal, then poll with a
+        // deadline. Concurrent invocations racing `open -ga` are deduped
+        // by LaunchServices (docs/plans/cli.md).
+        let launched = std::process::Command::new("open")
+            .args(["-ga", "Termic"])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if !launched {
+            return Err(CliError::new(
+                exit_code::APP_NOT_RUNNING,
+                "Termic is not running and could not be launched (is Termic.app installed?)",
+            ));
+        }
+        // `Instant` is only used on this release-only path; qualify it
+        // inline so a debug build has no unused import.
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        while std::time::Instant::now() < deadline {
+            if let Ok(c) = try_connect(paths) {
+                return Ok(c);
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        Err(CliError::new(exit_code::APP_NOT_RUNNING, "Termic did not start"))
+    }
+    #[cfg(not(all(target_os = "macos", not(debug_assertions))))]
+    {
+        Err(CliError::new(
+            exit_code::APP_NOT_RUNNING,
+            format!(
+                "Termic is not running at {}. Start Termic, or point TERMIC_SOCKET at its termic.sock.",
+                paths.socket.display()
+            ),
+        ))
+    }
+}
+
+fn lost(e: impl std::fmt::Display) -> CliError {
+    CliError::new(exit_code::CONNECTION_LOST, format!("connection to Termic lost ({e})"))
+}
+
+fn exchange(conn: &mut Conn, req: &proto::Request) -> Result<proto::Reply, CliError> {
+    proto::write_msg(&mut conn.writer, req).map_err(lost)?;
+    match proto::read_msg::<_, proto::Reply>(&mut conn.reader) {
+        Ok(Some(reply)) => Ok(reply),
+        Ok(None) => Err(lost("server closed the connection")),
+        Err(e) => Err(lost(e)),
+    }
+}
+
+/// Unauthenticated hello: proves the app is up and gates on the protocol
+/// version before anything else is attempted.
+pub fn hello(conn: &mut Conn) -> Result<proto::HelloData, CliError> {
+    let reply = exchange(
+        conn,
+        &proto::Request { id: "hello".into(), token: None, cmd: proto::Command::Hello },
+    )?;
+    match reply.data {
+        Some(proto::ReplyData::Hello(h)) => {
+            proto::check_protocol(h.protocol)
+                .map_err(|msg| CliError::new(exit_code::ERROR, msg))?;
+            Ok(h)
+        }
+        _ => Err(CliError::new(exit_code::ERROR, "unexpected reply to hello")),
+    }
+}
+
+/// Read the per-boot token. Running uncaged in the user's shell this
+/// always works while the app is up; failure means an old app version
+/// (no server) or deliberate lockdown.
+pub fn read_token(paths: &SocketPaths) -> Result<String, CliError> {
+    let mut buf = String::new();
+    std::fs::File::open(&paths.token_file)
+        .and_then(|mut f| f.read_to_string(&mut buf))
+        .map_err(|e| {
+            CliError::new(
+                exit_code::REFUSED,
+                format!("cannot read the CLI token at {} ({e})", paths.token_file.display()),
+            )
+        })?;
+    let token = buf.trim().to_string();
+    if token.is_empty() {
+        return Err(CliError::new(
+            exit_code::REFUSED,
+            format!("the CLI token at {} is empty", paths.token_file.display()),
+        ));
+    }
+    Ok(token)
+}
+
+/// Send one authenticated verb and unwrap the reply.
+pub fn request(
+    conn: &mut Conn,
+    cmd: proto::Command,
+    token: &str,
+) -> Result<proto::ReplyData, CliError> {
+    let reply = exchange(
+        conn,
+        &proto::Request { id: "1".into(), token: Some(token.to_string()), cmd },
+    )?;
+    reply_to_result(reply)
+}
+
+/// Map a reply envelope onto the exit-code contract. Pure, unit-tested.
+pub fn reply_to_result(reply: proto::Reply) -> Result<proto::ReplyData, CliError> {
+    if let Some(err) = reply.error {
+        return Err(CliError::new(err.code.exit_code(), err.message));
+    }
+    reply
+        .data
+        .ok_or_else(|| CliError::new(exit_code::ERROR, "empty reply from Termic"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use termic_proto::{ErrorCode, Reply, ReplyData};
+
+    #[test]
+    fn socket_env_overrides_and_disables_launch() {
+        let p = socket_paths_from(Some("/x/y/termic.sock".into()), Some(PathBuf::from("/data")));
+        assert!(p.custom);
+        assert_eq!(p.socket, PathBuf::from("/x/y/termic.sock"));
+        assert_eq!(p.token_file, PathBuf::from("/x/y/cli-token"));
+    }
+
+    #[test]
+    fn default_paths_come_from_the_data_dir() {
+        let p = socket_paths_from(None, Some(PathBuf::from("/data/termic")));
+        assert!(!p.custom);
+        assert_eq!(p.socket, PathBuf::from("/data/termic/termic.sock"));
+        assert_eq!(p.token_file, PathBuf::from("/data/termic/cli-token"));
+    }
+
+    #[test]
+    fn empty_socket_env_is_ignored() {
+        let p = socket_paths_from(Some("  ".into()), Some(PathBuf::from("/data/termic")));
+        assert!(!p.custom);
+    }
+
+    #[test]
+    fn disabled_cli_maps_to_exit_5_with_the_exact_message() {
+        let err = reply_to_result(Reply::err(
+            "1",
+            ErrorCode::CliDisabled,
+            proto::CLI_DISABLED_MESSAGE,
+        ))
+        .unwrap_err();
+        assert_eq!(err.code, 5);
+        assert_eq!(err.message, proto::CLI_DISABLED_MESSAGE);
+    }
+
+    #[test]
+    fn auth_failure_maps_to_exit_6() {
+        let err =
+            reply_to_result(Reply::err("1", ErrorCode::Auth, "invalid or missing CLI token"))
+                .unwrap_err();
+        assert_eq!(err.code, 6);
+    }
+
+    #[test]
+    fn not_found_and_ambiguous_map_to_exit_1() {
+        for code in [ErrorCode::NotFound, ErrorCode::Ambiguous, ErrorCode::Internal] {
+            let err = reply_to_result(Reply::err("1", code, "x")).unwrap_err();
+            assert_eq!(err.code, 1);
+        }
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn debug_build_fails_fast_without_launching() {
+        // A debug CLI must NEVER shell out to `open -ga Termic` (that
+        // launches the RELEASE app, a different data dir): a missing
+        // socket returns APP_NOT_RUNNING immediately, not after a
+        // 15s launch+poll. cargo test runs in debug, so this branch is
+        // the one compiled here.
+        let paths = SocketPaths {
+            socket: PathBuf::from("/nonexistent/termic_dev/termic.sock"),
+            token_file: PathBuf::from("/nonexistent/termic_dev/cli-token"),
+            custom: false,
+        };
+        let start = std::time::Instant::now();
+        let err = match connect_or_launch(&paths, false) {
+            Err(e) => e,
+            Ok(_) => panic!("expected APP_NOT_RUNNING, not a connection"),
+        };
+        assert_eq!(err.code, exit_code::APP_NOT_RUNNING);
+        assert!(err.message.contains("TERMIC_SOCKET"));
+        assert!(start.elapsed() < Duration::from_secs(2), "debug must not launch+poll");
+    }
+
+    #[test]
+    fn ok_reply_yields_data() {
+        let data = reply_to_result(Reply::ok(
+            "1",
+            ReplyData::Open(proto::OpenData { task: None, raised: true }),
+        ))
+        .unwrap();
+        assert!(matches!(data, ReplyData::Open(_)));
+    }
+}

--- a/termic-cli/src/lib.rs
+++ b/termic-cli/src/lib.rs
@@ -1,0 +1,338 @@
+//! `termic`: thin client for the Termic app's control socket.
+//!
+//! Phase 0 verbs: `list` (alias `ls`), `status`, `open`. The app is the
+//! daemon; this binary holds no state, reads none of termic's data
+//! files, and links only `termic-proto` (docs/plans/cli.md). Exit codes
+//! and `--output-format json` shapes are a public contract: see
+//! `termic_proto::exit_code` and the per-command help.
+
+use clap::{Parser, Subcommand, ValueEnum};
+use termic_proto as proto;
+use termic_proto::exit_code;
+
+pub mod client;
+pub mod output;
+
+/// The version `termic --version` prints. It is the APP version, injected
+/// at build time via `TERMIC_APP_VERSION` (src-tauri/build.rs and
+/// scripts/build-cli.mjs), so a bundled CLI matches the app it ships in. A
+/// bare `cargo build -p termic-cli` with no env set falls back to the crate
+/// version. See build.rs for the rebuild tracking.
+const VERSION: &str = match option_env!("TERMIC_APP_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};
+
+/// One error the binary exits on: pinned code + message for stderr.
+#[derive(Debug, PartialEq)]
+pub struct CliError {
+    pub code: i32,
+    pub message: String,
+}
+
+impl CliError {
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        CliError { code, message: message.into() }
+    }
+}
+
+/// Exit-code contract, shown in --help so scripts can branch on it
+/// without reading the source. 3, 7, 9 and 10 are pinned for later
+/// phases and never repurposed.
+const EXIT_CODES_HELP: &str = "Exit codes:
+  0   success
+  1   error (bad task or project name, ambiguity, server failure)
+  2   usage error (reserved for argument parsing)
+  4   Termic is not running (--no-launch), or did not start after launch
+  5   the CLI is disabled in Termic Settings
+  6   refused: bad or missing token, or this shell is inside a sandboxed task
+  8   connection to Termic lost mid-command
+Pinned for later phases: 3 agent needs input, 7 wait timeout,
+9 prompt not delivered, 10 apply left main conflicted.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OutputFormat {
+    Text,
+    Json,
+}
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "termic",
+    bin_name = "termic",
+    version = VERSION,
+    about = "Control the Termic app from any shell: list tasks, check one task, focus the window.",
+    long_about = "Control the Termic app from any shell. The app is the daemon: every command \
+talks to the running Termic over a local socket and fails fast when it cannot. \
+Requires the CLI to be enabled in Termic Settings (General).",
+    after_help = EXIT_CODES_HELP
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub cmd: Cmd,
+
+    /// Output format for read verbs. `json` prints exactly one JSON
+    /// object on stdout; its fields only ever grow (additive contract).
+    #[arg(long, global = true, value_enum, default_value_t = OutputFormat::Text)]
+    pub output_format: OutputFormat,
+
+    /// Shorthand for --output-format json.
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    /// Fail (exit 4) instead of auto-launching Termic when it is not running.
+    #[arg(long, global = true)]
+    pub no_launch: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Cmd {
+    /// List tasks: name, project, agent, work state, diff stat, branch.
+    #[command(
+        visible_alias = "ls",
+        after_help = "Prints one row per task on stdout; with -q, task ids only. \
+With --output-format json, one object: {\"tasks\": [...]} where each task carries \
+id, name, project, agent, branch, base_branch, path, work_state (\"working\", \
+\"waiting\", \"done\", \"idle\", or null when the UI could not answer), open_tabs \
+and diff {files_changed, insertions, deletions, untracked}.
+
+Exit codes: 0 success, 1 unknown project, 4 app not running, 5 CLI disabled, \
+6 refused, 8 connection lost."
+    )]
+    List {
+        /// Print task ids only, one per line.
+        #[arg(short, long)]
+        quiet: bool,
+        /// Only tasks of this project (name).
+        #[arg(long)]
+        project: Option<String>,
+    },
+
+    /// Show one task in depth: agent state, branch, dirty file count, sessions.
+    #[command(
+        after_help = "Prints `key: value` lines on stdout. With --output-format json, one \
+object: {\"task\": {...}} with the list fields plus sandbox, sessions and \
+dirty_files. Use --project (or project/name) when the name exists in more \
+than one project.
+
+Exit codes: 0 success, 1 unknown or ambiguous task, 4 app not running, \
+5 CLI disabled, 6 refused, 8 connection lost."
+    )]
+    Status {
+        /// Task name, task id, or qualified project/name.
+        task: String,
+        /// Project name, to disambiguate.
+        #[arg(long)]
+        project: Option<String>,
+    },
+
+    /// Raise the Termic window and select a task (current directory aware).
+    #[command(
+        after_help = "Without <TASK>, resolves the task from the current directory: task \
+worktrees first, then the longest registered project path (main-checkout \
+tasks). When nothing resolves, the window is still raised. Prints what was \
+opened on stdout; with --output-format json, one object: {\"task\": {...}|null, \
+\"raised\": true}.
+
+Exit codes: 0 success, 1 unknown or ambiguous task, 4 app not running, \
+5 CLI disabled, 6 refused, 8 connection lost."
+    )]
+    Open {
+        /// Task name, task id, or qualified project/name.
+        task: Option<String>,
+        /// Project name, to disambiguate. Only meaningful with a task name,
+        /// so it requires one (it cannot select a task on its own).
+        #[arg(long, requires = "task")]
+        project: Option<String>,
+    },
+}
+
+pub fn run() -> i32 {
+    // clap exits 2 on usage/parse errors itself; 2 stays reserved for it.
+    let cli = Cli::parse();
+    match execute(&cli) {
+        Ok(stdout) => {
+            if !stdout.is_empty() {
+                println!("{stdout}");
+            }
+            exit_code::OK
+        }
+        Err(e) => {
+            eprintln!("termic: {}", e.message);
+            e.code
+        }
+    }
+}
+
+fn execute(cli: &Cli) -> Result<String, CliError> {
+    // In-cage pre-check (docs/plans/cli.md, Security DX): caged agents
+    // get NO CLI surface. TERMIC_SANDBOX=1 is injected into every caged
+    // spawn, so fail with the real reason instead of a token error.
+    if std::env::var("TERMIC_SANDBOX").is_ok_and(|v| v == "1") {
+        return Err(CliError::new(
+            exit_code::REFUSED,
+            "this shell is inside a sandboxed termic task, the control plane is unavailable",
+        ));
+    }
+
+    let format = if cli.json { OutputFormat::Json } else { cli.output_format };
+    let paths = client::socket_paths();
+    let mut conn = client::connect_or_launch(&paths, cli.no_launch)?;
+    client::hello(&mut conn)?;
+    let token = client::read_token(&paths)?;
+
+    let cwd = std::env::current_dir().ok().map(|p| p.to_string_lossy().into_owned());
+    let cmd = to_wire_command(&cli.cmd, format, cwd);
+    let data = client::request(&mut conn, cmd, &token)?;
+    render(&cli.cmd, format, data)
+}
+
+/// Map the parsed subcommand + effective output format to the wire
+/// command. Pure so the format-dependent `quiet` logic is unit-testable.
+pub fn to_wire_command(cmd: &Cmd, format: OutputFormat, cwd: Option<String>) -> proto::Command {
+    match cmd {
+        Cmd::List { project, quiet } => proto::Command::List {
+            project: project.clone(),
+            // `quiet` tells the server to SKIP the work-state query + diff.
+            // Only do that when the text `-q` path (ids only) is what
+            // renders. JSON always emits full objects, so it needs those
+            // fields; blanking them there would read, per the contract, as
+            // "the UI could not answer" - a different meaning entirely.
+            quiet: *quiet && format == OutputFormat::Text,
+        },
+        Cmd::Status { task, project } => {
+            proto::Command::Status { task: task.clone(), project: project.clone() }
+        }
+        Cmd::Open { task, project } => proto::Command::Open {
+            task: task.clone(),
+            project: project.clone(),
+            cwd,
+        },
+    }
+}
+
+/// Turn a successful reply into stdout text. Pure, unit-tested.
+pub fn render(cmd: &Cmd, format: OutputFormat, data: proto::ReplyData) -> Result<String, CliError> {
+    let unexpected =
+        |what: &str| CliError::new(exit_code::ERROR, format!("unexpected reply to {what}"));
+    match (cmd, data) {
+        (Cmd::List { quiet, .. }, proto::ReplyData::List(list)) => Ok(match format {
+            OutputFormat::Json => output::json(&list),
+            OutputFormat::Text if *quiet => output::list_quiet(&list.tasks),
+            OutputFormat::Text => output::list_text(&list.tasks),
+        }),
+        (Cmd::Status { .. }, proto::ReplyData::Status(status)) => Ok(match format {
+            OutputFormat::Json => output::json(&status),
+            OutputFormat::Text => output::status_text(&status.task),
+        }),
+        (Cmd::Open { .. }, proto::ReplyData::Open(open)) => Ok(match format {
+            OutputFormat::Json => output::json(&open),
+            OutputFormat::Text => output::open_text(&open),
+        }),
+        (Cmd::List { .. }, _) => Err(unexpected("list")),
+        (Cmd::Status { .. }, _) => Err(unexpected("status")),
+        (Cmd::Open { .. }, _) => Err(unexpected("open")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clap_definition_is_coherent() {
+        use clap::CommandFactory;
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn open_project_requires_a_task() {
+        // `--project` only disambiguates a named task, so it cannot be used
+        // without one (silently ignoring it would be the worst outcome).
+        assert!(Cli::try_parse_from(["termic", "open", "--project", "web"]).is_err());
+        // The valid forms still parse.
+        assert!(Cli::try_parse_from(["termic", "open"]).is_ok());
+        assert!(Cli::try_parse_from(["termic", "open", "foo"]).is_ok());
+        assert!(Cli::try_parse_from(["termic", "open", "foo", "--project", "web"]).is_ok());
+    }
+
+    #[test]
+    fn help_carries_no_em_dashes() {
+        use clap::CommandFactory;
+        let mut cmd = Cli::command();
+        let mut all = format!("{}", cmd.render_long_help());
+        for sub in ["list", "status", "open"] {
+            let mut c = Cli::command();
+            let s = c.find_subcommand_mut(sub).unwrap();
+            all.push_str(&format!("{}", s.render_long_help()));
+        }
+        assert!(!all.contains('\u{2014}'), "copy rule: no em dashes in help text");
+        let _ = cmd;
+    }
+
+    #[test]
+    fn render_list_json_shape() {
+        let list = proto::ListData {
+            tasks: vec![proto::TaskSummary { id: "a".into(), name: "n".into(), ..Default::default() }],
+        };
+        let out = render(
+            &Cmd::List { quiet: false, project: None },
+            OutputFormat::Json,
+            proto::ReplyData::List(list),
+        )
+        .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["tasks"][0]["id"], "a");
+        // The wire's internal "kind" tag must not leak into CLI output.
+        assert!(v.get("kind").is_none());
+    }
+
+    #[test]
+    fn render_quiet_lists_ids_only() {
+        let list = proto::ListData {
+            tasks: vec![
+                proto::TaskSummary { id: "id-1".into(), name: "one".into(), ..Default::default() },
+                proto::TaskSummary { id: "id-2".into(), name: "two".into(), ..Default::default() },
+            ],
+        };
+        let out = render(
+            &Cmd::List { quiet: true, project: None },
+            OutputFormat::Text,
+            proto::ReplyData::List(list),
+        )
+        .unwrap();
+        assert_eq!(out, "id-1\nid-2");
+    }
+
+    #[test]
+    fn quiet_skips_server_work_only_for_text_output() {
+        let list = |quiet| Cmd::List { quiet, project: None };
+        // -q in text: ask the server to skip work_state + diff (ids only).
+        assert!(matches!(
+            to_wire_command(&list(true), OutputFormat::Text, None),
+            proto::Command::List { quiet: true, .. }
+        ));
+        // -q with JSON must NOT skip: the JSON emits full objects, and a
+        // blanked work_state/diff would read as "UI could not answer".
+        assert!(matches!(
+            to_wire_command(&list(true), OutputFormat::Json, None),
+            proto::Command::List { quiet: false, .. }
+        ));
+        // No -q: never quiet on the wire.
+        assert!(matches!(
+            to_wire_command(&list(false), OutputFormat::Text, None),
+            proto::Command::List { quiet: false, .. }
+        ));
+    }
+
+    #[test]
+    fn render_mismatched_reply_is_an_error() {
+        let err = render(
+            &Cmd::List { quiet: false, project: None },
+            OutputFormat::Text,
+            proto::ReplyData::Open(proto::OpenData { task: None, raised: true }),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, exit_code::ERROR);
+    }
+}

--- a/termic-cli/src/main.rs
+++ b/termic-cli/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(termic_cli::run());
+}

--- a/termic-cli/src/output.rs
+++ b/termic-cli/src/output.rs
@@ -1,0 +1,269 @@
+//! Text renderers for the read verbs. Pure string builders so the
+//! output contract is golden-testable. Copy rule: no em dashes in any
+//! CLI output.
+
+use serde::Serialize;
+use termic_proto::{DiffStat, OpenData, TaskStatus, TaskSummary};
+
+/// One JSON object, compact, exactly as documented in each verb's help.
+pub fn json<T: Serialize>(v: &T) -> String {
+    serde_json::to_string(v).unwrap_or_else(|_| "{}".into())
+}
+
+pub fn list_quiet(tasks: &[TaskSummary]) -> String {
+    tasks.iter().map(|t| t.id.as_str()).collect::<Vec<_>>().join("\n")
+}
+
+pub fn diff_cell(diff: &Option<DiffStat>) -> String {
+    match diff {
+        None => "-".into(),
+        Some(d) => {
+            let mut s = format!("{}f +{} -{}", d.files_changed, d.insertions, d.deletions);
+            if d.untracked > 0 {
+                s.push_str(&format!(" {}u", d.untracked));
+            }
+            s
+        }
+    }
+}
+
+pub fn state_cell(state: &Option<String>) -> String {
+    state.clone().unwrap_or_else(|| "-".into())
+}
+
+pub fn list_text(tasks: &[TaskSummary]) -> String {
+    if tasks.is_empty() {
+        return "no tasks".into();
+    }
+    // Project then task, matching how tasks are addressed everywhere else
+    // (`status project/task`, the `project/name` ambiguity errors). Rows
+    // arrive already sorted by (project, name), so this reads top-down.
+    let header = ["PROJECT", "TASK", "AGENT", "STATE", "DIFF", "BRANCH"];
+    let rows: Vec<[String; 6]> = tasks
+        .iter()
+        .map(|t| {
+            [
+                t.project.clone(),
+                t.name.clone(),
+                t.agent.clone(),
+                state_cell(&t.work_state),
+                diff_cell(&t.diff),
+                t.branch.clone(),
+            ]
+        })
+        .collect();
+    // Width by CHARACTER count, not bytes: Rust's `{:width$}` pads strings
+    // by chars, so a byte-length width over-pads any multi-byte name and
+    // skews the table. (Still not display-width-aware for CJK, but names
+    // are normally ASCII slugs.)
+    let cells = |s: &str| s.chars().count();
+    let mut widths: Vec<usize> = header.iter().map(|h| cells(h)).collect();
+    for row in &rows {
+        for (i, cell) in row.iter().enumerate() {
+            widths[i] = widths[i].max(cells(cell));
+        }
+    }
+    let fmt_row = |cells: &[String]| -> String {
+        cells
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                if i == cells.len() - 1 {
+                    c.clone()
+                } else {
+                    format!("{:w$}", c, w = widths[i])
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("  ")
+            .trim_end()
+            .to_string()
+    };
+    let mut out = vec![fmt_row(&header.map(String::from))];
+    out.extend(rows.iter().map(|r| fmt_row(r)));
+    out.join("\n")
+}
+
+pub fn status_text(t: &TaskStatus) -> String {
+    let s = &t.summary;
+    let mut lines: Vec<String> = Vec::new();
+    let mut push = |k: &str, v: String| lines.push(format!("{k:<13}{v}"));
+    push("name:", s.name.clone());
+    push("project:", s.project.clone());
+    push("agent:", s.agent.clone());
+    let state = match (s.work_state.as_deref(), s.open_tabs) {
+        // No answer from the webview at all (busy, or still booting).
+        (None, _) => "unknown (Termic UI did not answer)".into(),
+        // Known to the app, but no agent is running for it.
+        (Some("inactive"), _) => "inactive (no agent open)".into(),
+        (Some(st), Some(n)) if n > 0 => format!("{st} ({n} tabs open)"),
+        (Some(st), _) => st.to_string(),
+    };
+    push("state:", state);
+    let branch = if s.base_branch.is_empty() {
+        s.branch.clone()
+    } else {
+        format!("{} (from {})", s.branch, s.base_branch)
+    };
+    push("branch:", branch);
+    push("path:", s.path.clone());
+    push("sandbox:", t.sandbox.clone());
+    push("sessions:", t.sessions.to_string());
+    let dirty = match (&t.dirty_files, &s.diff) {
+        (Some(n), Some(d)) => format!(
+            "{n} ({} changed, +{} -{}, {} untracked)",
+            d.files_changed, d.insertions, d.deletions, d.untracked
+        ),
+        (Some(n), None) => n.to_string(),
+        (None, _) => "unknown (not a git checkout?)".into(),
+    };
+    push("dirty files:", dirty);
+    push("created:", s.created.clone());
+    if s.is_main_checkout {
+        push("checkout:", "main checkout (shared with other main-checkout tasks)".into());
+    }
+    lines.join("\n")
+}
+
+pub fn open_text(d: &OpenData) -> String {
+    match &d.task {
+        Some(t) => format!("opened {}/{} in Termic", t.project, t.name),
+        None => "raised the Termic window (no task matched here)".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary() -> TaskSummary {
+        TaskSummary {
+            id: "id-1".into(),
+            name: "fix-auth".into(),
+            project: "web".into(),
+            agent: "claude".into(),
+            branch: "fix-auth".into(),
+            base_branch: "main".into(),
+            path: "/w/fix-auth".into(),
+            is_main_checkout: false,
+            created: "2026-01-01T00:00:00Z".into(),
+            work_state: Some("working".into()),
+            open_tabs: Some(2),
+            diff: Some(DiffStat { files_changed: 3, insertions: 10, deletions: 2, untracked: 1 }),
+        }
+    }
+
+    #[test]
+    fn list_text_golden() {
+        let out = list_text(&[summary(), TaskSummary {
+            name: "longer-task-name".into(),
+            project: "api".into(),
+            agent: "codex".into(),
+            branch: "b2".into(),
+            ..Default::default()
+        }]);
+        let expected = "\
+PROJECT  TASK              AGENT   STATE    DIFF          BRANCH
+web      fix-auth          claude  working  3f +10 -2 1u  fix-auth
+api      longer-task-name  codex   -        -             b2";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn list_text_empty() {
+        assert_eq!(list_text(&[]), "no tasks");
+    }
+
+    #[test]
+    fn list_text_width_is_char_not_byte_based() {
+        // "café" (4 chars / 5 bytes) is the widest TASK, tying the header
+        // "TASK" (4). Char-based width => the TASK column is 4 wide, so the
+        // name is followed by exactly the 2-space column separator; a
+        // byte-based width (the old bug) would size it to 5 and add a space.
+        let t = TaskSummary {
+            name: "café".into(),
+            project: "web".into(),
+            agent: "a".into(),
+            branch: "b".into(),
+            ..Default::default()
+        };
+        let out = list_text(&[t]);
+        let row = out.lines().nth(1).unwrap();
+        assert!(row.contains("café  a"), "misaligned row: {row:?}");
+    }
+
+    #[test]
+    fn status_text_golden() {
+        let t = TaskStatus {
+            summary: summary(),
+            sandbox: "enforce".into(),
+            sessions: 2,
+            dirty_files: Some(4),
+        };
+        let expected = "\
+name:        fix-auth
+project:     web
+agent:       claude
+state:       working (2 tabs open)
+branch:      fix-auth (from main)
+path:        /w/fix-auth
+sandbox:     enforce
+sessions:    2
+dirty files: 4 (3 changed, +10 -2, 1 untracked)
+created:     2026-01-01T00:00:00Z";
+        assert_eq!(status_text(&t), expected);
+    }
+
+    #[test]
+    fn status_text_inactive_reads_as_no_agent_not_unknown() {
+        let mut s = summary();
+        s.work_state = Some("inactive".into());
+        s.open_tabs = Some(0);
+        let t = TaskStatus { summary: s, sandbox: "off".into(), sessions: 1, dirty_files: Some(4) };
+        let out = status_text(&t);
+        assert!(out.contains("state:       inactive (no agent open)"), "{out}");
+        assert!(!out.contains("did not answer"));
+        assert!(!out.contains("0 tabs open"));
+    }
+
+    #[test]
+    fn status_text_degrades_when_webview_and_git_are_silent() {
+        let mut s = summary();
+        s.work_state = None;
+        s.open_tabs = None;
+        s.diff = None;
+        let t = TaskStatus { summary: s, sandbox: "off".into(), sessions: 0, dirty_files: None };
+        let out = status_text(&t);
+        assert!(out.contains("state:       unknown (Termic UI did not answer)"));
+        assert!(out.contains("dirty files: unknown (not a git checkout?)"));
+    }
+
+    #[test]
+    fn open_text_variants() {
+        assert_eq!(
+            open_text(&OpenData { task: Some(summary()), raised: true }),
+            "opened web/fix-auth in Termic"
+        );
+        assert_eq!(
+            open_text(&OpenData { task: None, raised: true }),
+            "raised the Termic window (no task matched here)"
+        );
+    }
+
+    #[test]
+    fn output_carries_no_em_dashes() {
+        let t = TaskStatus {
+            summary: summary(),
+            sandbox: "enforce".into(),
+            sessions: 2,
+            dirty_files: Some(4),
+        };
+        for s in [
+            list_text(&[summary()]),
+            status_text(&t),
+            open_text(&OpenData { task: None, raised: true }),
+        ] {
+            assert!(!s.contains('\u{2014}'), "em dash in output: {s}");
+        }
+    }
+}

--- a/termic-proto/Cargo.toml
+++ b/termic-proto/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "termic-proto"
+version = "0.1.0"
+description = "Wire types for the termic CLI <-> app control socket (NDJSON framing, protocol version, exit codes)."
+edition = "2021"
+license = "AGPL-3.0-or-later"
+publish = false
+workspace = "../src-tauri"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/termic-proto/src/lib.rs
+++ b/termic-proto/src/lib.rs
@@ -1,0 +1,469 @@
+//! Wire protocol for the termic CLI <-> app control socket.
+//!
+//! Shared by the app's socket server (src-tauri) and the `termic-cli`
+//! binary, and by NOTHING else. Deliberately tiny: serde types, the
+//! protocol version, NDJSON framing helpers, and the pinned exit-code
+//! contract. termic-cli links only this crate, never the app's lib.rs
+//! (docs/plans/cli.md), so keep it dependency-light.
+//!
+//! Compatibility rules (public API once shipped, docs/plans/cli.md):
+//! - The hello handshake carries `protocol`; on mismatch the CLI fails
+//!   with a clear message instead of mis-parsing.
+//! - Reply/payload shapes evolve ADDITIVELY only: new fields may appear,
+//!   nothing is renamed or removed. Deserializers must therefore
+//!   tolerate unknown fields (serde's default) - never add
+//!   `deny_unknown_fields` here.
+
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::io::{self, BufRead, Read, Write};
+
+/// Bumped whenever the wire shape changes incompatibly. The unauthenticated
+/// hello carries it so a CLI left resolved in an old shell fails with
+/// "Termic updated, rerun your command" instead of garbage.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Socket + token file names inside the app's data dir.
+pub const SOCKET_FILE: &str = "termic.sock";
+pub const TOKEN_FILE: &str = "cli-token";
+
+/// Exact user-facing error for the disabled-CLI path (docs/plans/cli.md,
+/// Landing). The server sends it; the CLI prints it verbatim and exits
+/// with `exit_code::CLI_DISABLED`.
+pub const CLI_DISABLED_MESSAGE: &str =
+    "Termic is running but the CLI is disabled, enable it in Settings";
+
+/// Printed by the CLI when the server's protocol version differs.
+pub const VERSION_MISMATCH_MESSAGE: &str = "Termic updated, rerun your command";
+
+/// Hard cap on a single NDJSON line, both directions. A request or reply
+/// larger than this is a bug or an attack, not traffic.
+pub const MAX_LINE_BYTES: u64 = 1024 * 1024;
+
+/// The pinned exit-code contract (docs/plans/cli.md, Command surface).
+/// Public API once shipped: scripts branch on these numbers. 2 is
+/// RESERVED because clap already exits 2 on usage errors; domain codes
+/// start at 3 in the spec's order. Phase 0 only produces 0, 1, 2, 4, 5,
+/// 6 and 8; the rest are pinned now so later phases cannot renumber.
+pub mod exit_code {
+    /// Success (for `--wait` verbs later: agent settled done).
+    pub const OK: i32 = 0;
+    /// Generic error.
+    pub const ERROR: i32 = 1;
+    /// Usage / parse error. Reserved for clap; never used for domain errors.
+    pub const USAGE: i32 = 2;
+    /// Agent stopped needing input (attention), later phases.
+    pub const AGENT_NEEDS_INPUT: i32 = 3;
+    /// App not running (under --no-launch) or did not start after launch.
+    pub const APP_NOT_RUNNING: i32 = 4;
+    /// CLI disabled in Settings.
+    pub const CLI_DISABLED: i32 = 5;
+    /// Refused: auth or scope (bad/missing token, in-cage caller).
+    pub const REFUSED: i32 = 6;
+    /// --wait --timeout expiry, later phases.
+    pub const WAIT_TIMEOUT: i32 = 7;
+    /// Connection lost mid-command (app quit under us).
+    pub const CONNECTION_LOST: i32 = 8;
+    /// Prompt never delivered, later phases.
+    pub const PROMPT_NOT_DELIVERED: i32 = 9;
+    /// Apply left main conflicted, later phases.
+    pub const APPLY_CONFLICT: i32 = 10;
+}
+
+// ───────────────────────────── requests ─────────────────────────────
+
+/// One request line. `token` is absent only for `hello` (the
+/// unauthenticated surface); everything else requires the per-boot token
+/// read from `<data_dir>/cli-token`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Request {
+    /// Client-chosen correlation id, echoed on the reply.
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token: Option<String>,
+    #[serde(flatten)]
+    pub cmd: Command,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+pub enum Command {
+    /// Unauthenticated: app-is-running + protocol version. Nothing else.
+    Hello,
+    /// Unauthenticated: bring the running instance's window to front. Used
+    /// by a second instance launching on the same data dir (single
+    /// instance per data dir) to defer to the one already running. Same
+    /// trust tier as hello: it only raises a window, discloses nothing.
+    Raise,
+    /// Tasks with work-state and diff stat.
+    List {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project: Option<String>,
+        /// Ids only: the server skips the webview work-state query and the
+        /// per-task git diff, which `-q` output does not use. Absent =
+        /// false (an older CLI omits it), so the server does the full work.
+        #[serde(default)]
+        quiet: bool,
+    },
+    /// One task in depth.
+    Status {
+        task: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project: Option<String>,
+    },
+    /// Raise the window and select a task (cwd-aware when `task` absent).
+    Open {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project: Option<String>,
+        /// The CLI's working directory, for worktree-first resolution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
+    },
+}
+
+// ───────────────────────────── replies ──────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Reply {
+    /// Echo of the request id.
+    pub id: String,
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<ReplyData>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorBody>,
+}
+
+impl Reply {
+    pub fn ok(id: &str, data: ReplyData) -> Self {
+        Reply { id: id.to_string(), ok: true, data: Some(data), error: None }
+    }
+    pub fn err(id: &str, code: ErrorCode, message: impl Into<String>) -> Self {
+        Reply {
+            id: id.to_string(),
+            ok: false,
+            data: None,
+            error: Some(ErrorBody { code, message: message.into() }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ReplyData {
+    Hello(HelloData),
+    List(ListData),
+    Status(StatusData),
+    Open(OpenData),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HelloData {
+    pub app: String,
+    pub app_version: String,
+    pub protocol: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ListData {
+    pub tasks: Vec<TaskSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StatusData {
+    pub task: TaskStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OpenData {
+    /// The task that was selected, if any resolved. `None` means the
+    /// window was raised without selecting a task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<TaskSummary>,
+    pub raised: bool,
+}
+
+/// One task row for `list` (and embedded in `status` / `open`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct TaskSummary {
+    pub id: String,
+    pub name: String,
+    /// Owning project's display name.
+    pub project: String,
+    /// Agent CLI id (claude / gemini / codex / custom id).
+    pub agent: String,
+    pub branch: String,
+    pub base_branch: String,
+    /// Worktree absolute path (the shared checkout for main-checkout tasks).
+    pub path: String,
+    pub is_main_checkout: bool,
+    pub created: String,
+    /// Aggregated agent state from the webview: "working", "waiting",
+    /// "done", "idle", or "inactive" (the task exists but has no agent tab
+    /// open). `None` when the webview could not answer at all (busy, still
+    /// booting); consumers must treat `None` as unknown, not idle. New
+    /// values may be added (additive contract), so unknown strings should
+    /// be passed through, not rejected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub work_state: Option<String>,
+    /// Live terminal tabs open for this task, when the webview answered.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_tabs: Option<u32>,
+    /// Diff stat vs the base branch. `None` when git had nothing to say
+    /// (non-git project, git error).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub diff: Option<DiffStat>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct DiffStat {
+    pub files_changed: u64,
+    pub insertions: u64,
+    pub deletions: u64,
+    /// New untracked files (not folded into files_changed).
+    pub untracked: u64,
+}
+
+/// `status` detail: the summary plus depth fields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct TaskStatus {
+    #[serde(flatten)]
+    pub summary: TaskSummary,
+    /// Sandbox mode: "off", "monitor", "enforce" or "enforce-fs".
+    pub sandbox: String,
+    /// Persisted agent sessions (durable tabs that resume on relaunch).
+    pub sessions: u32,
+    /// files_changed + untracked, when the diff stat resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dirty_files: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ErrorBody {
+    pub code: ErrorCode,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// Malformed request line.
+    BadRequest,
+    /// "Enable CLI" is off in Settings.
+    CliDisabled,
+    /// Missing or wrong token.
+    Auth,
+    /// Task / project did not resolve.
+    NotFound,
+    /// A name matched tasks in more than one project.
+    Ambiguous,
+    /// Server-side failure.
+    Internal,
+}
+
+impl ErrorCode {
+    /// The pinned exit code the CLI uses for this error class.
+    pub fn exit_code(self) -> i32 {
+        match self {
+            ErrorCode::CliDisabled => exit_code::CLI_DISABLED,
+            ErrorCode::Auth => exit_code::REFUSED,
+            ErrorCode::BadRequest
+            | ErrorCode::NotFound
+            | ErrorCode::Ambiguous
+            | ErrorCode::Internal => exit_code::ERROR,
+        }
+    }
+}
+
+// ───────────────────────────── framing ──────────────────────────────
+
+/// Write one message as a single compact-JSON line. Compact encoding is
+/// mandated: newline framing dies on pretty-printed output.
+pub fn write_msg<W: Write, T: Serialize>(w: &mut W, msg: &T) -> io::Result<()> {
+    let mut line = serde_json::to_vec(msg).map_err(io::Error::other)?;
+    line.push(b'\n');
+    w.write_all(&line)?;
+    w.flush()
+}
+
+/// Read one NDJSON line, bounded by `MAX_LINE_BYTES`. Returns `Ok(None)`
+/// on clean EOF, an error on an oversized or truncated line.
+pub fn read_line<R: BufRead>(r: &mut R) -> io::Result<Option<String>> {
+    let mut buf: Vec<u8> = Vec::new();
+    let n = r.by_ref().take(MAX_LINE_BYTES + 1).read_until(b'\n', &mut buf)?;
+    if n == 0 {
+        return Ok(None);
+    }
+    if buf.last() != Some(&b'\n') {
+        if buf.len() as u64 > MAX_LINE_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "message exceeds the 1 MB line cap",
+            ));
+        }
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "connection closed mid-message",
+        ));
+    }
+    buf.pop();
+    String::from_utf8(buf)
+        .map(Some)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "message is not valid UTF-8"))
+}
+
+/// Read + decode one message.
+pub fn read_msg<R: BufRead, T: DeserializeOwned>(r: &mut R) -> io::Result<Option<T>> {
+    match read_line(r)? {
+        None => Ok(None),
+        Some(line) => serde_json::from_str(&line)
+            .map(Some)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+    }
+}
+
+/// Version-gate helper: the CLI calls this with the server's hello.
+pub fn check_protocol(server_protocol: u32) -> Result<(), String> {
+    if server_protocol == PROTOCOL_VERSION {
+        Ok(())
+    } else {
+        Err(VERSION_MISMATCH_MESSAGE.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::BufReader;
+
+    fn roundtrip<T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug>(v: &T) {
+        let mut buf: Vec<u8> = Vec::new();
+        write_msg(&mut buf, v).unwrap();
+        assert_eq!(buf.iter().filter(|b| **b == b'\n').count(), 1, "one line per message");
+        let mut r = BufReader::new(&buf[..]);
+        let back: T = read_msg(&mut r).unwrap().expect("one message");
+        assert_eq!(&back, v);
+        assert!(read_msg::<_, T>(&mut r).unwrap().is_none(), "clean EOF after");
+    }
+
+    #[test]
+    fn roundtrip_every_request() {
+        for cmd in [
+            Command::Hello,
+            Command::Raise,
+            Command::List { project: None, quiet: false },
+            Command::List { project: Some("web".into()), quiet: true },
+            Command::Status { task: "fix-auth".into(), project: Some("web".into()) },
+            Command::Open { task: None, project: None, cwd: Some("/tmp/x".into()) },
+            Command::Open { task: Some("fix-auth".into()), project: None, cwd: None },
+        ] {
+            roundtrip(&Request { id: "r1".into(), token: Some("t".into()), cmd });
+        }
+    }
+
+    #[test]
+    fn roundtrip_every_reply() {
+        let summary = TaskSummary {
+            id: "w1".into(),
+            name: "fix-auth".into(),
+            project: "web".into(),
+            agent: "claude".into(),
+            branch: "fix-auth".into(),
+            base_branch: "main".into(),
+            path: "/Users/x/termic/tasks/web/fix-auth".into(),
+            is_main_checkout: false,
+            created: "2026-01-01T00:00:00Z".into(),
+            work_state: Some("working".into()),
+            open_tabs: Some(2),
+            diff: Some(DiffStat { files_changed: 3, insertions: 10, deletions: 2, untracked: 1 }),
+        };
+        for data in [
+            ReplyData::Hello(HelloData {
+                app: "termic".into(),
+                app_version: "1.0.0".into(),
+                protocol: PROTOCOL_VERSION,
+            }),
+            ReplyData::List(ListData { tasks: vec![summary.clone()] }),
+            ReplyData::Status(StatusData {
+                task: TaskStatus {
+                    summary: summary.clone(),
+                    sandbox: "enforce".into(),
+                    sessions: 2,
+                    dirty_files: Some(4),
+                },
+            }),
+            ReplyData::Open(OpenData { task: Some(summary.clone()), raised: true }),
+            ReplyData::Open(OpenData { task: None, raised: true }),
+        ] {
+            roundtrip(&Reply::ok("r1", data));
+        }
+        roundtrip(&Reply::err("r1", ErrorCode::CliDisabled, CLI_DISABLED_MESSAGE));
+    }
+
+    #[test]
+    fn unknown_fields_are_tolerated() {
+        // Additive evolution: an older CLI must parse a newer server's
+        // replies (and vice versa) that carry extra fields.
+        let line = r#"{"id":"r1","ok":true,"data":{"kind":"hello","app":"termic","app_version":"9.9.9","protocol":1,"new_field":true},"future":42}"#;
+        let reply: Reply = serde_json::from_str(line).unwrap();
+        assert!(reply.ok);
+        match reply.data {
+            Some(ReplyData::Hello(h)) => assert_eq!(h.protocol, 1),
+            other => panic!("expected hello, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compact_encoding_no_newlines_inside() {
+        // A value containing a newline must stay one line on the wire.
+        let reply = Reply::err("r1", ErrorCode::Internal, "line1\nline2");
+        let mut buf = Vec::new();
+        write_msg(&mut buf, &reply).unwrap();
+        assert_eq!(buf.iter().filter(|b| **b == b'\n').count(), 1);
+        let mut r = BufReader::new(&buf[..]);
+        let back: Reply = read_msg(&mut r).unwrap().unwrap();
+        assert_eq!(back.error.unwrap().message, "line1\nline2");
+    }
+
+    #[test]
+    fn oversized_line_is_rejected() {
+        let mut big = vec![b'x'; (MAX_LINE_BYTES + 10) as usize];
+        big.push(b'\n');
+        let mut r = BufReader::new(&big[..]);
+        let err = read_line(&mut r).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn truncated_line_is_an_error_not_a_message() {
+        let mut r = BufReader::new(&b"{\"id\":\"r1\""[..]);
+        let err = read_line(&mut r).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn version_mismatch_message() {
+        assert!(check_protocol(PROTOCOL_VERSION).is_ok());
+        let msg = check_protocol(PROTOCOL_VERSION + 1).unwrap_err();
+        assert_eq!(msg, VERSION_MISMATCH_MESSAGE);
+        assert!(!msg.contains('\u{2014}'), "copy rule: no em dashes");
+    }
+
+    #[test]
+    fn error_codes_map_to_pinned_exits() {
+        assert_eq!(ErrorCode::CliDisabled.exit_code(), 5);
+        assert_eq!(ErrorCode::Auth.exit_code(), 6);
+        assert_eq!(ErrorCode::NotFound.exit_code(), 1);
+        assert_eq!(ErrorCode::Ambiguous.exit_code(), 1);
+    }
+
+    #[test]
+    fn canned_messages_obey_copy_rules() {
+        // Repo copy rule: no em dashes anywhere in user-visible text.
+        for s in [CLI_DISABLED_MESSAGE, VERSION_MISMATCH_MESSAGE] {
+            assert!(!s.contains('\u{2014}'), "em dash in {s:?}");
+        }
+    }
+}


### PR DESCRIPTION
This PR is **Phase 0** of the termic CLI (design: #125): a `termic` command that talks to the running app over a local Unix socket.

**What it does now:** three read-only commands (`list`, `status`, `open`) plus all the machinery underneath them (socket, token auth, connect-or-launch, the bundled binary, and PATH install). It cannot create or change anything.

**What it does not do yet:** create or drive tasks. Those verbs land in later PRs.

This is a self-contained phase that merges on its own, following the repo's "one phase, one PR into main" shape (#62, #84, #113). Later phases follow as separate PRs with no ordering constraint between them, and every phase leaves the app's build green and behaviorally unchanged for anyone who has not opted in. Opened as a draft for now; ready to flip once reviewed.

## Commands

| Verb | Phase | What it does |
|---|---|---|
| `list` / `ls` | **0 (this PR)** | List tasks: project, task, agent, work state, diff stat, branch. `-q` = ids only, `--project` filter |
| `status <task>` | **0 (this PR)** | One task in depth: state, branch, path, sandbox, session count, dirty files |
| `open [<task>]` | **0 (this PR)** | Raise the window and select a task (current-directory aware) |
| `new <name> [-p …]` | 1 | Create a task from the shell |
| `wait <task>` | 1 | Block until the agent is quiescent |
| `archive <task>` | 1 | Archive a task |
| `project add / list / remove` | 1 | Manage projects |
| `send <task> -p …` | 2 | Prompt a running agent |
| `apply <task>` | 2 | Send the task's diff to main |
| `attach <task>` | 2 | Attach a real TTY to the agent PTY |
| `path` / `diff <task>` | 2 | Print worktree path / show diff |

Everything in Phase 0 is read-only or window-focus. Unimplemented verbs are simply absent (clap prints "unrecognized subcommand"), never stubbed or half-working. Global flags: `--output-format text|json`, `--json`, `--no-launch`.

## Command name per build, and instances

The installed command name is build-aware, and the app permits **one instance per data dir** (the socket doubles as the lock). Because prod and beta share the release data dir, they are mutually exclusive by design: launching one while the other runs raises the running one and exits. Beta is long-term testing of prod, so you run one or the other, never both.

| Build | Command | Data dir | Instances |
|---|---|---|---|
| prod (release) | `termic` | `termic` | one; **shares the lock with beta** |
| beta | `termic-beta` | `termic` (shared with prod) | one; **mutually exclusive with prod** |
| dev (`make dev`) | `termic-dev` | `termic_dev` | own lock; newest-wins on relaunch |
| e2e (test rig) | uses the dev binary | scratch `TERMIC_DATA_DIR` | isolated, parallel-safe |

The on-disk sidecar is always `termic-cli`; only the symlink name varies, so all three coexist on PATH.

## Under the hood

- **Crates.** A cargo workspace with `termic-proto` (wire types, NDJSON framing, protocol version, pinned exit codes) and `termic-cli` (the `termic` binary), which links only `termic-proto`, never the app's `lib.rs`.
- **Socket server** on its own thread, never the IPC/main thread. `<data_dir>/termic.sock` (0600, sun_path guard, always binds). Unauthenticated surface is hello/raise only; every verb needs the "Enable CLI" setting (default off) AND the per-boot token from `<data_dir>/cli-token` (0600, in memory only, never in the app env that `pty_spawn` copies to children). `getpeereid` same-uid check per connection.
- **Webview RPC.** Work state comes from the webview over a new typed correlation-id channel (`cli-rpc://request` + `cli_rpc_result`), not the debug `/eval` bridge, which is never armed or reused.
- **Sandbox boundary.** The control socket is a privilege boundary: a caged agent that reaches it can escape. Enforcing profiles now emit the socket deny as the final network rule and the data-dir deny as the final filesystem rule, in both Enforce and EnforceFs. Verified behaviorally with real `sandbox-exec`.
- **Distribution.** `externalBin` sidecar so the binary ships in the `.app`; enabling the CLI auto-installs it (no prompt) into `~/.local/bin`, with a system-wide `/usr/local/bin` option (admin prompt on macOS). `termic --version` reports the **app** version, injected at build time, so the bundled CLI is always versioned with the app.

## Off by default

There is a single **Settings → General → "Enable CLI"** toggle, **off by default**. While it is off, every command is refused and the app behaves exactly as it does today, so this is invisible to anyone who does not turn it on. (Exit codes and `--json` output are a stable, additive-only contract, so scripts can rely on them once shipped.)

## Try it out

```sh
gh pr checkout 132     # or: git fetch <remote> && git checkout feature/cli-phase0
make dev               # launches the dev app on the termic_dev profile
                       # (first build after the Rust changes takes ~1-2 min)
```

In the running app: **Settings → General → "Enable CLI"** (toggle on). Enabling auto-installs the command as `termic-dev` into `~/.local/bin` (no password). Then from any shell:

```sh
termic-dev list                    # project, task, agent, state, diff, branch
termic-dev status <project/task>   # one task in depth
termic-dev open <task>             # raises the window and selects that task
termic-dev --json list             # machine-readable
```

The `-dev` name is deliberate so it never clashes with a real `termic` install. If `~/.local/bin` is not on your PATH, the Settings row says so, and `make cli-dev` is an alternative that builds and symlinks it for you. Toggling the setting off refuses every command immediately.

## Testing

- 226 Rust unit tests across the three crates: protocol round-trips and version-mismatch, exit-code and text/JSON output goldens, name and cwd resolution (worktree-first, longest-prefix, ambiguity), auth and gating, single-instance handshake, and behavioral `sandbox-exec` containment tests (in-cage connect refused, token read refused with `~/Library` allow-listed through each extension layer, caged env carries no token). Plus the existing frontend suite.
- CI runs `cargo test --workspace --lib`. A full release compile succeeds and stages the sidecar.
- Manual smoke over the socket: enable/disable, `list` / `status` / `open`, and every error path (disabled, bad/missing token, no-launch, in-cage refusal).

## Known / deferred

- The prod/beta simultaneous-launch bind race is accepted and deferred to the tmux-style flock fix, per the design doc.
- The behavioral `sandbox-exec` tests self-skip on the Ubuntu CI (macOS-only). A gated macOS CI job to run them for real is a follow-up.
- macOS is the primary target. On Linux the install falls back to `~/.local/bin` (no privilege prompt, since the `/usr/local/bin` elevation is macOS-only), and auto-launch is macOS-only; the sandbox boundary is macOS-only regardless (tasks are never caged on Linux).
