### PR TITLE
fix(settings): let the CLI getting-started commands be selected

### DIFF
--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -188,6 +188,23 @@ describe("settings rail", () => {
     expect(pane).toContain("enforced sandbox");
   });
 
+  it("lets the getting-started commands be selected for copying", async () => {
+    // index.css turns selection off app-wide, so these copy-me commands have to
+    // opt back in. Read off the command text, not the `data-selectable`
+    // attribute, so only losing selectability fails.
+    await clickRail("Termic CLI");
+    await waitForText("Getting started");
+    const selectable = await browser.execute(() => {
+      const cmd = [
+        ...document.querySelectorAll('[data-testid="settings-pane"] span'),
+      ].find((s) => s.textContent?.includes("fix the login redirect"));
+      if (!cmd) throw new Error("no getting-started command line");
+      // WKWebView only resolves the prefixed longhand.
+      return getComputedStyle(cmd).getPropertyValue("-webkit-user-select");
+    });
+    expect(selectable).toBe("text");
+  });
+
   it("keeps General short: task, sandbox and notification settings moved off it", async () => {
     await clickRail("General");
     await waitForText("Repos directory");

--- a/src/components/settings/CliSection.tsx
+++ b/src/components/settings/CliSection.tsx
@@ -131,7 +131,10 @@ export function CliSection() {
         <div className="mt-0.5 text-[12.5px] text-[var(--color-fg-dim)]">
           Run these from inside a registered repo. <code className="font-mono">{name} help</code> lists the full surface.
         </div>
-        <div className="mt-3 flex flex-col gap-2 rounded-lg border border-[var(--color-border-soft)] bg-[var(--color-bg)] px-3 py-2.5 font-mono text-[12.5px] text-[var(--color-fg-dim)]">
+        <div
+          data-selectable
+          className="mt-3 flex cursor-text flex-col gap-2 rounded-lg border border-[var(--color-border-soft)] bg-[var(--color-bg)] px-3 py-2.5 font-mono text-[12.5px] text-[var(--color-fg-dim)]"
+        >
           <div><span className="text-[var(--color-fg)]">{name} new fix-auth -p "fix the login redirect"</span></div>
           <div><span className="text-[var(--color-fg)]">{name} list</span></div>
           <div><span className="text-[var(--color-fg)]">{name} wait fix-auth</span></div>


### PR DESCRIPTION
## Problem

On Settings, Termic CLI, the "Getting started" block shows three commands I wanted to copy and paste, but you cannot select them.

`index.css` turns selection off app-wide (so sidebar rows, breadcrumbs and tab labels never smear into a selection), and re-enables it only for `.xterm`, `.cm-editor`, `[data-selectable]`, `pre`, `code`, and inputs. That block renders its commands as plain `div`/`span` with `font-mono`, so it matched none of those and stayed unselectable.

## Fix

Opt the block in with `data-selectable`, plus `cursor-text` so it reads as selectable text.

Both are existing conventions rather than new ones: `data-selectable` is how `NewTaskDialog.tsx:964` and `DiffPane.tsx:402` opt out of the same global rule, and `cursor-text` is already used for this at `RepositorySection.tsx:792` and `DiffPane.tsx:335`.

## Scope

Deliberately just this one block. The other non-`code` `font-mono` spans I checked (`WelcomeDialog.tsx:287,489,504`, `Dashboard.tsx:131`) are truncated labels inside clickable rows, where non-selectable is correct because clicking is the interaction. This is the only genuine copy-me code block in the settings dialog.

## Testing

`make check-all` clean. New case in `e2e/specs/settings.e2e.ts`, in the existing `settings rail` describe next to the other CLI-page tests so it reuses `clickRail`.

Two things a reviewer may want flagged up front:

1. **It asserts a computed CSS property**, which makes it the only spec in the suite that does (`getComputedStyle` otherwise appears only inside `helpers.ts:91`, as a visibility check). There is no store state for selectability and text content cannot express it, so this is the only tier that can verify the behaviour at all: the vitest project is `environment: "node"` with no DOM, so it cannot evaluate the cascade. Happy to drop the test if you would rather not set that precedent.
2. It reads `-webkit-user-select`, not `userSelect`. The unprefixed property reads back empty in WKWebView (WebKit 605), which is what my first version tripped over.

No `CHANGELOG.md` or version changes, per CONTRIBUTING. I think this is release-worthy as a small bug fix, but that entry is yours to write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYi3CGxP7nnvAGxgFz7mQ6
