### PR TITLE
feat(cli): termic quit, plus Phase 3 plan updates

### DIFF
--- a/docs/cli-agent-instructions.md
+++ b/docs/cli-agent-instructions.md
@@ -92,6 +92,13 @@ Rules that matter:
 - `"$TERMIC_CLI" project add <path>` - register a repo (needed once
   before creating tasks in it).
 
+DO NOT run `"$TERMIC_CLI" quit`. Its `about` in `help --json` says the
+same, so this block and the machine surface agree. It exists for the
+human at the keyboard, not for you. It kills EVERY agent in EVERY task, including the sibling
+agents you may be coordinating with and the session you are running in,
+and it reverts any active spotlight session, which force-checks-out the
+project's main checkout. `archive` is scoped to one task; this is not.
+
 (`attach` exists too, but it is interactive and needs a real TTY; as an
 agent you want `send`/`logs`/`result` instead.)
 

--- a/docs/plans/cli.md
+++ b/docs/plans/cli.md
@@ -11,10 +11,15 @@ advertisement (protocol v2). Phase 2 implemented on top - `send`
 (+`--shell`, backlog replay, detach keys, opt-in `--resize`), `apply`
 (exit 10 goes live), `diff`, `path`, and the result readers `logs`
 (per-PTY ring buffer) and `result` (claude transcript reader), protocol
-v3. Phase 3 in progress - windowless mode landed; Homebrew and
-`termic events --json` still pending. `termic mcp` stays parked under
-discussion and NOT approved (see Phasing). Sections below note where the
-implementation refined the original design.
+v4. Phase 3 in progress - windowless mode landed, `termic quit` landed;
+tab management (GH #138) specced and adopted, not yet built. Homebrew is
+settled, not pending: the cask ships, a CLI-only formula is a non-goal
+(see Distribution). `termic events --json` is deferred pending the Claude
+Code hooks path: a versioned public event stream built on heuristic settle
+detection is not something to support forever.
+`termic mcp` stays parked under discussion and NOT approved (see
+Phasing). Sections below note where the implementation refined the
+original design.
 
 A `termic` command that creates tasks, lists them with live agent state, focuses
 the GUI, injects prompts, and attaches a real TTY to an agent's PTY, from any
@@ -282,6 +287,17 @@ termic archive <task> [--yes]                 # kills the task's live PTYs FIRST
 termic project add|list|remove                # rare admin ops, namespaced; `project add .`
                                               # is the non-interactive registration path
                                               # scripts need (the y/N prompt is TTY-only)
+termic quit [--yes]                           # the only shell-side teardown for a
+                                              # windowless app. Kills every PTY, script
+                                              # group, grep AND reverts active spotlight
+                                              # sessions (force-checkout of MAIN), so the
+                                              # confirmation names what dies. Never
+                                              # launches; exits 0 if not running
+termic tab <task> [--agent <id>|--terminal <id>|--shell] [-p]  # GH #138. A tab INSIDE a
+                                              # running task: the "+" menu as a verb, and
+                                              # like that menu it distinguishes agent /
+                                              # custom-terminal / aux-shell kinds, because
+                                              # they differ in sandbox, resume and YOLO
 ```
 
 Two structural rules the surface depends on. First, task creation
@@ -339,6 +355,83 @@ streams setup-script output until spawn, then prints the task id/branch/path
 anything back: once `task_create` has committed, interrupting only stops
 watching ("task continues in Termic"), it does not cancel the task. Copy rule applies to all CLI output and help text:
 no em dashes.
+
+## Tabs inside a running task (GH #138)
+
+Everything above targets a TASK. A task is not one agent though: it is a tab
+strip, and the GUI's "+" menu opens more agent tabs beside the first plus an
+uncaged shell. The CLI cannot see any of that. Today the entire surface is one
+boolean, `attach --shell`, and every other verb silently means "the default
+agent tab" (`PtyRole.is_default`, already the target `attach`/`logs` resolve
+to). So a second claude tab is unreachable, and `status` reports a `sessions`
+COUNT with no way to ask what those sessions are.
+
+Adopted into Phase 3.
+
+**Picking what to open is the hard part, and it is not a binary.** The GUI's
+"+" menu already offers three distinct things and gates them: `kind: "agent"`
+registry entries (filtered by `visibleCliIds` to enabled AND detected-installed),
+`kind: "terminal"` custom entries (#27, which never resume and never take YOLO
+args, `isTerminalCli`), and the task's aux shell. A `--agent | --shell` binary
+would model none of that. So:
+
+- **`termic tab <task> --agent <id>`** resolves `<id>` against the registry and
+  fails if it is unknown, `disabled`, or not detected on PATH. The GUI simply
+  hides those; the CLI must say why rather than spawn a PTY that dies on exec.
+  The error lists the ids that WOULD work, since an agent driving this has no
+  menu to look at. `help --json` cannot carry the list (the registry is
+  per-user and mutable), so `status`/`list` are where it becomes discoverable.
+- **`--terminal <id>`** for `kind: "terminal"` entries, kept separate from
+  `--agent` for the same reason `--shell` is: the kinds differ in resume, YOLO
+  and sandbox behaviour, so one `--kind <string>` flag would let a typo land
+  you in the wrong semantics silently.
+- **`--shell`** stays the task's aux terminal, matching `attach --shell`.
+- **Omitted** = the task's own `cli`, i.e. "another one of what this task
+  already runs", which is the common case and matches what the `+` button
+  does before you pick anything.
+
+Sandbox follows kind, not flag: an agent tab inherits the task's sandbox pin,
+`terminal`/`shell` tabs are uncaged exactly as the GUI's are (only the agent
+CLI PTY is the threat model, docs/sandbox.md). That asymmetry is the whole
+reason the kinds are separate flags.
+
+Then the targeting half:
+
+- **`--tab <n|title>` on `send` / `wait` / `attach` / `logs`.** Absent = the
+  default agent tab, so every existing invocation keeps its meaning.
+- **`status` lists tabs**: index, kind, agent, title, work state. Additive
+  fields on `TaskStatus`, which already flattens `TaskSummary`.
+
+Open questions, deliberately not settled here:
+
+- **Selector stability.** Index is what the user sees in the tab strip but
+  shifts when a tab closes; title is agent-authored and changes mid-turn (it
+  is the same OSC stream the work-done classifier reads, lib/terminalTitle.ts).
+  Neither is a stable id. A stable per-tab id exists app-side and is the
+  honest thing for scripts, with index/title as human conveniences that
+  resolve to it. Note this is NOT free: `PtyRole` is `{task_id, kind,
+  is_default}` with no id and no title, and titles live in the webview store,
+  so exposing one means extending the role or adding a webview RPC. That is an
+  IPC change on top of the protocol change, and it partly answers the question:
+  whatever id is exposed has to be plumbed into the role anyway.
+- **Ambiguity is an error, not a guess.** Two tabs titled `claude` must fail
+  with both selectors printed, the same shape as the existing ambiguous-task
+  error, rather than picking the lower index.
+- **`attach --shell` becomes redundant** once `--tab` exists. Keep it as an
+  alias for "the aux terminal" (it is shipped surface and reads better than
+  `--tab shell`), and say so rather than quietly supporting two spellings.
+- **Resuming a closed tab.** The `+` menu offers it (`closedTabs`), and the
+  CLI has no equivalent at any level. Out of scope here, but it is the obvious
+  next ask once tabs are addressable, and `--tab` selectors are what it would
+  hang off.
+- **Whether `tab` waits.** `new` has `--wait` and a delivery-confirmation
+  contract; `tab -p` would need the same or it inherits the silently-dropped
+  prompt problem Phase 1 exists to avoid. Cheapest answer is to reuse
+  `send`'s path outright: open the tab, then deliver through the confirmed
+  route rather than a second injection recipe.
+
+Protocol impact is additive (a new verb plus optional fields), so this is a
+version bump when it lands, not a breaking change.
 
 ## Agents as users (discoverability)
 
@@ -566,9 +659,26 @@ The CLI's `--version` reports the APP version, not the crate version: it is
 injected at build time via `TERMIC_APP_VERSION` (set by `src-tauri/build.rs`
 and `scripts/build-cli.mjs`, read through `option_env!` with the crate version
 as the dev fallback), so a bundled CLI is always versioned with the app it
-ships in. The hello handshake carries a protocol version anyway, so a later
-Homebrew formula (CLI-only installs, version skew becomes real) needs no
-protocol change.
+ships in. The hello handshake carries a protocol version anyway, so a
+CLI-only Homebrew formula would need no protocol change. It is still not
+being built (see below).
+
+### Homebrew
+
+- **Cask: done.** `brew install --cask simion/termic/termic` ships the app;
+  `release.yml` bumps its version + sha256 in the tap on every release.
+- **CLI-only formula: not doing it.** `brew install termic` would hand you a
+  client with no server. The app IS the daemon, so a standalone CLI has
+  nothing to talk to and cannot even auto-launch one. It would also break
+  `--version` reporting the app version, and reintroduce the version skew
+  this design avoids by bundling.
+- **Not a cask `binary` stanza either.** That would put `termic` on PATH for
+  everyone, which Landing rules out: the binary stays off PATH until the user
+  runs the install action.
+
+If CLI-first distribution is ever wanted, it means the rejected pattern-2
+architecture (standalone CLI over a shared core), not a formula wrapping a
+client whose server is missing.
 
 ## Phasing
 
@@ -691,12 +801,43 @@ protocol change.
   - The "install the instructions block" Settings action stayed
     unbuilt; docs/cli-agent-instructions.md remains paste-your-own.
 - **Phase 3**: windowless daemon mode (activation policy + run without a
-  window), Homebrew formula, `termic events --json` (standing subscription:
+  window), `termic quit`, tab management inside a running task (GH #138, see
+  "Tabs inside a running task"), `termic events --json` (standing
+  subscription:
   one JSON line per task event - done, waiting, created - fed by the same
   settle signal as `--wait`). The event stream is also what would make
   app-side hooks ("on task done, run this command" in settings) trivial
   later; hooks themselves are a separate future feature, not part of this
   plan.
+
+  `termic quit` (protocol v4): the only shell-side teardown for a
+  windowless instance, since the menu-bar Quit is otherwise the sole
+  affordance and a user who picked "Keep in Menu Bar" plus don't-ask-again
+  needs one that does not involve the mouse. Notes:
+  - Authenticated, like every destructive verb. Caged agents cannot reach
+    it at all (seatbelt denies the socket), same as `archive`.
+  - Two-step: `preview` reports what WOULD die so the confirmation can
+    name it, then the commit. The preview must never tear anything down.
+  - Confirms on a TTY unless `--yes`, with the reconnect-after-confirm
+    `archive` uses (a human outlasts the 30s idle timeout).
+  - The server replies BEFORE exiting, and the teardown is triggered by
+    the connection thread AFTER its write returns, not by a fixed grace.
+    A timer cannot be sized: the serving thread can be descheduled past
+    any constant on a machine busy running agents, and a successful quit
+    would then be reported as CONNECTION_LOST. The flag is thread-local,
+    since one thread per connection means a global would let a concurrent
+    request consume it and quit before the quitting client's reply lands.
+  - Never auto-launches, and exits 0 when Termic is not running ON THE
+    DEFAULT SOCKET: starting the app to stop it is absurd, and a teardown
+    script should not need `|| true`. With TERMIC_SOCKET set explicitly a
+    missing socket is a misconfiguration and still exits 4 - reporting
+    success there would tell a script it had stopped agents that are in
+    fact still running.
+  - Live-agent counts come from the PTY map (ground truth for what gets
+    SIGKILLed), filtered to agent-kind roles so the aux shell and
+    setup/run script tabs are not counted as agents. The working count is
+    per TASK (the work-state cache aggregates that way), reports 0 when
+    stale, and is clamped to the task count.
 
   Windowless mode implemented, where measurement refined the sketch:
   - The trap's "keep the webview alive hidden" branch WON on evidence, so

--- a/src-tauri/src/cli_server.rs
+++ b/src-tauri/src/cli_server.rs
@@ -61,6 +61,23 @@ const ARCHIVE_TIMEOUT: Duration = Duration::from_secs(300);
 /// or a respawn (PTY spawn deadline 15s + margin); the injection into a
 /// respawned agent continues app-side after the RPC returns.
 const SEND_TIMEOUT: Duration = Duration::from_secs(60);
+thread_local! {
+    /// Set by the `quit` handler, consumed by `serve_conn` once the reply has
+    /// been written: a flag rather than a direct call so teardown cannot race
+    /// the reply it is supposed to follow.
+    ///
+    /// THREAD-LOCAL, not a global. `serve_listener` spawns one thread per
+    /// connection and `handle_request` runs synchronously on it, so a global
+    /// would let ANY concurrent connection consume the flag - a sibling
+    /// `termic list` finishing its own write first would tear the app down
+    /// before the quitting client's reply was flushed, which is the exact
+    /// failure this mechanism exists to prevent, just moved from a timer race
+    /// to a thread race. Thread-local also means a future caller of
+    /// handle_request outside serve_conn cannot leave the flag armed for an
+    /// unrelated request to trip over.
+    static QUIT_AFTER_REPLY: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 /// Keepalive cadence on streamed replies (10s in production). Must stay
 /// well under the CLI's 30s socket read timeout. Tests shrink every
 /// watch-loop constant so the timing paths run in milliseconds.
@@ -281,7 +298,22 @@ fn serve_conn(stream: UnixStream, host: Arc<dyn CliHost>) {
             let mut sink = SocketSink { writer: &mut writer };
             handle_request(&req, &*host, &mut sink)
         };
-        if proto::write_msg(&mut writer, &reply).is_err() {
+        let wrote = proto::write_msg(&mut writer, &reply).is_ok();
+        // `quit` defers teardown to HERE, once the reply is actually on the
+        // wire. Exiting from inside handle_request raced the write: on a busy
+        // machine (this app exists to run many agents) the serving thread can
+        // be descheduled past any fixed grace, the socket closes first, and a
+        // SUCCESSFUL quit is reported to the client as CONNECTION_LOST. Once
+        // write_msg returns the bytes are buffered in the kernel and survive
+        // our exit.
+        // Deliberately NOT gated on `wrote`: the commit was received and
+        // processed, so a client that died before reading its reply does not
+        // cancel a quit the user asked for. Only the ORDER is guaranteed here,
+        // not delivery.
+        if QUIT_AFTER_REPLY.with(|f| f.replace(false)) {
+            host.quit_app();
+        }
+        if !wrote {
             return;
         }
     }
@@ -454,6 +486,11 @@ pub(crate) trait CliHost: Send + Sync {
     fn work_states(&self, ids: &[String]) -> Option<HashMap<String, WorkStateInfo>>;
     fn open_task_in_ui(&self, task_id: &str) -> Result<(), String>;
     fn raise_window(&self);
+    /// (tasks with live agents, live agent PTYs). Ground truth from the
+    /// PTY map, not the webview cache.
+    fn live_agent_counts(&self) -> (u32, u32);
+    /// Tear the app down. Everything the app owns dies with it.
+    fn quit_app(&self);
     fn diff_stat(&self, task: &Task) -> Option<proto::DiffStat>;
     /// Registered agent CLIs (Settings registry).
     fn agents(&self) -> Vec<AgentMeta>;
@@ -571,6 +608,40 @@ pub(crate) fn handle_request(req: &Request, host: &dyn CliHost, sink: &mut dyn E
         Command::New { .. } => handle_new(req, host, sink),
         Command::Wait { task, project, timeout_ms, cwd } => {
             handle_wait(&req.id, host, task.as_deref(), project.as_deref(), cwd.as_deref(), *timeout_ms, sink)
+        }
+        Command::Quit { commit } => {
+            let (tasks_with_agents, live_agents) = host.live_agent_counts();
+            // Working count comes from the webview cache - only it knows
+            // work state. A stale cache reports 0 rather than guessing, so
+            // the number is a floor: it never overstates what the user is
+            // about to lose, and the PTY counts above still tell the truth
+            // about what dies.
+            let snap = host.agent_cache().snapshot();
+            // Per TASK, not per agent: the cache aggregates a single state
+            // per task. Clamped, because a cache inside the staleness window
+            // can still lag a PTY that just died, which would otherwise read
+            // as "kills 1 agent across 1 task, 2 of them still working".
+            let working_tasks = snap
+                .age
+                .filter(|a| *a <= CACHE_STALE_AFTER)
+                .map(|_| snap.states.values().filter(|s| s.state == "working").count() as u32)
+                .unwrap_or(0)
+                .min(tasks_with_agents);
+            if *commit {
+                // Armed, not fired: serve_conn tears down after this reply is
+                // written. See the note there.
+                QUIT_AFTER_REPLY.with(|f| f.set(true));
+            }
+            Reply::ok(
+                &req.id,
+                ReplyData::Quit(proto::QuitData {
+                    running: true,
+                    tasks_with_agents,
+                    live_agents,
+                    working_tasks,
+                    quitting: *commit,
+                }),
+            )
         }
         Command::Archive { task, project } => {
             handle_archive(&req.id, host, task, project.as_deref())
@@ -2317,6 +2388,17 @@ impl CliHost for TauriHost {
     ) -> Result<serde_json::Value, String> {
         webview_rpc_stream(&self.app, method, params, timeout, on_progress)
     }
+    fn live_agent_counts(&self) -> (u32, u32) {
+        let manager = self.app.state::<crate::PtyManager>();
+        crate::live_agent_pty_counts(&manager)
+    }
+    fn quit_app(&self) {
+        // Called by serve_conn AFTER the reply is written, so this can exit
+        // immediately. app.exit drives RunEvent::Exit -> cleanup_children,
+        // which reaps PTYs, script process groups, greps and spotlight
+        // sessions - the same teardown Cmd-Q performs.
+        self.app.exit(0);
+    }
     fn agent_cache(&self) -> &AgentCache {
         global_agent_cache()
     }
@@ -3029,6 +3111,11 @@ mod tests {
         /// `tasks` on the reload handle_new performs).
         extra_tasks: Mutex<Vec<Task>>,
         killed: Mutex<Vec<String>>,
+        /// (tasks with agents, live agents) the stub reports for `quit`.
+        live_agents: (u32, u32),
+        /// Bumped by quit_app, so a test can assert teardown happened
+        /// exactly once and NOT at all under `--preview`.
+        quit_calls: Mutex<u32>,
         /// Flat side-effect log ("kill:<id>", "rpc:<method>",
         /// "detach:<id>:<reason>") so tests can assert ORDER across
         /// kinds (archive must notify, then kill, then rpc).
@@ -3071,6 +3158,8 @@ mod tests {
                 states: None,
                 opened: Mutex::new(Vec::new()),
                 raised: Mutex::new(0),
+                live_agents: (0, 0),
+                quit_calls: Mutex::new(0),
                 agents: vec![
                     agent_meta("claude", true),
                     agent_meta("codex", true),
@@ -3109,6 +3198,13 @@ mod tests {
     }
 
     impl CliHost for StubHost {
+        fn live_agent_counts(&self) -> (u32, u32) {
+            self.live_agents
+        }
+        fn quit_app(&self) {
+            *self.quit_calls.lock().unwrap() += 1;
+            self.ops.lock().unwrap().push("quit".into());
+        }
         fn cli_enabled(&self) -> bool {
             self.enabled
         }
@@ -3299,6 +3395,106 @@ mod tests {
             Some(ReplyData::Hello(h)) => assert_eq!(h.protocol, proto::PROTOCOL_VERSION),
             other => panic!("expected hello, got {other:?}"),
         }
+    }
+
+    // The protocol tolerates unknown fields by design, so a misspelled or
+    // renamed flag silently takes serde's default. For this verb that default
+    // must be "preview", never "tear the app down".
+    #[test]
+    fn quit_without_the_commit_field_previews_rather_than_quitting() {
+        let host = StubHost { live_agents: (1, 1), ..Default::default() };
+        let raw = r#"{"id":"x","token":"tok","cmd":"quit","previw":true}"#;
+        let req: Request = serde_json::from_str(raw).expect("unknown fields are tolerated");
+        let reply = handle(&req, &host);
+        assert!(reply.ok, "{reply:?}");
+        let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit") };
+        assert!(!q.quitting, "a missing commit field must not quit");
+        assert_eq!(*host.quit_calls.lock().unwrap(), 0, "typo'd field tore the app down");
+    }
+
+    // The cache can name more working tasks than there are tasks with live
+    // agents: it is a webview push, and a state inside the 120s staleness
+    // window can still lag a PTY that just died. Without the clamp the
+    // confirmation reads "kills 1 agent across 1 task. 2 tasks still
+    // working", which is nonsense the user is being asked to approve.
+    #[test]
+    fn quit_clamps_working_tasks_to_tasks_with_live_agents() {
+        let host = StubHost { live_agents: (1, 1), ..Default::default() };
+        host.push_states(&[
+            ("w1", TaskAgentState { state: "working".into(), tabs: 1, queued: 0, capable: true }),
+            // Still cached as working, but its agent PTY is already gone.
+            ("w3", TaskAgentState { state: "working".into(), tabs: 1, queued: 0, capable: true }),
+        ]);
+        let reply = handle(&req(Command::Quit { commit: false }, Some("tok")), &host);
+        let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit") };
+        assert_eq!(q.tasks_with_agents, 1);
+        assert_eq!(q.working_tasks, 1, "working must never exceed the task count");
+    }
+
+    // `quit` is the most destructive verb on the socket, so the preview /
+    // commit split is load-bearing: the CLI asks what would die to build its
+    // confirmation question, and that ask must not itself kill anything.
+    #[test]
+    fn quit_preview_reports_without_tearing_down() {
+        let host = StubHost { live_agents: (2, 3), ..Default::default() };
+        host.push_states(&[
+            ("w1", TaskAgentState { state: "working".into(), tabs: 1, queued: 0, capable: true }),
+            ("w3", TaskAgentState { state: "idle".into(), tabs: 1, queued: 0, capable: true }),
+        ]);
+        let reply = handle(&req(Command::Quit { commit: false }, Some("tok")), &host);
+        assert!(reply.ok, "{reply:?}");
+        let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit, got {reply:?}") };
+        assert_eq!((q.tasks_with_agents, q.live_agents), (2, 3));
+        assert_eq!(q.working_tasks, 1);
+        assert!(!q.quitting, "preview must not claim to be quitting");
+        assert_eq!(*host.quit_calls.lock().unwrap(), 0, "preview tore the app down");
+    }
+
+    #[test]
+    fn quit_commits_and_reports_what_died() {
+        let host = StubHost { live_agents: (2, 3), ..Default::default() };
+        let reply = handle(&req(Command::Quit { commit: true }, Some("tok")), &host);
+        assert!(reply.ok, "{reply:?}");
+        let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit, got {reply:?}") };
+        assert!(q.quitting);
+        assert_eq!(q.live_agents, 3);
+        // handle_request only ARMS teardown; serve_conn fires it after the
+        // reply is written. See quit_replies_before_it_tears_the_app_down.
+        assert_eq!(*host.quit_calls.lock().unwrap(), 0);
+        assert!(
+            QUIT_AFTER_REPLY.with(|f| f.replace(false)),
+            "commit did not arm teardown on this thread",
+        );
+    }
+
+    // Quitting kills every agent, so it sits behind the same gate as the
+    // rest: NOT part of the unauthenticated hello/raise surface.
+    #[test]
+    fn quit_requires_a_token() {
+        let host = StubHost::default();
+        let reply = handle(&req(Command::Quit { commit: true }, None), &host);
+        assert!(!reply.ok);
+        assert_eq!(reply.error.as_ref().unwrap().code, ErrorCode::Auth);
+        assert_eq!(*host.quit_calls.lock().unwrap(), 0, "unauthenticated quit tore the app down");
+    }
+
+    // A stale work-state cache must report 0 working rather than guessing:
+    // the question would otherwise overstate what the user is about to lose.
+    // The PTY counts are unaffected - they come from the PTY map, not here.
+    #[test]
+    fn quit_reports_no_working_tasks_when_the_cache_is_stale() {
+        let host = StubHost { live_agents: (1, 1), ..Default::default() };
+        host.push_states(&[(
+            "w1",
+            TaskAgentState { state: "working".into(), tabs: 1, queued: 0, capable: true },
+        )]);
+        // CACHE_STALE_AFTER is 800ms under cfg(test); let it actually go stale
+        // rather than reaching into the cache's internals.
+        std::thread::sleep(CACHE_STALE_AFTER + Duration::from_millis(100));
+        let reply = handle(&req(Command::Quit { commit: false }, Some("tok")), &host);
+        let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit") };
+        assert_eq!(q.working_tasks, 0, "a stale cache must not be reported as fact");
+        assert_eq!(q.live_agents, 1, "PTY counts do not depend on the cache");
     }
 
     #[test]
@@ -4489,6 +4685,34 @@ mod tests {
         let dynamic: Arc<dyn CliHost> = arc.clone();
         std::thread::spawn(move || serve_listener(listener, dynamic));
         (sock, dir, arc)
+    }
+
+    // The ordering `quit` depends on: the client must GET its reply, and only
+    // then may the app tear down. Get this backwards and a successful quit is
+    // reported as CONNECTION_LOST (exit 8). Exercised over a real socket
+    // because the bug lives in serve_conn, not in handle_request.
+    #[test]
+    fn quit_replies_before_it_tears_the_app_down() {
+        let (sock, _guard, host) = spawn_server_arc(StubHost {
+            live_agents: (1, 2),
+            ..Default::default()
+        });
+        let reply = roundtrip_on(&sock, &req(Command::Quit { commit: true }, Some("tok")));
+        // The reply arrived at all: that is the property under test.
+        assert!(reply.ok, "{reply:?}");
+        let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit, got {reply:?}") };
+        assert!(q.quitting);
+        assert_eq!(q.live_agents, 2);
+        // ...and teardown followed it.
+        let mut fired = false;
+        for _ in 0..100 {
+            if *host.quit_calls.lock().unwrap() == 1 {
+                fired = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(fired, "reply was delivered but the app never tore down");
     }
 
     #[test]

--- a/src-tauri/src/cli_server.rs
+++ b/src-tauri/src/cli_server.rs
@@ -621,12 +621,18 @@ pub(crate) fn handle_request(req: &Request, host: &dyn CliHost, sink: &mut dyn E
             // per task. Clamped, because a cache inside the staleness window
             // can still lag a PTY that just died, which would otherwise read
             // as "kills 1 agent across 1 task, 2 of them still working".
+            //
+            // None when the cache is stale: the webview stopped reporting, so
+            // this is UNKNOWN rather than zero. The prompt says so instead of
+            // quietly dropping the note, which would read the same as "nothing
+            // is working" on a question about killing agents.
             let working_tasks = snap
                 .age
                 .filter(|a| *a <= CACHE_STALE_AFTER)
-                .map(|_| snap.states.values().filter(|s| s.state == "working").count() as u32)
-                .unwrap_or(0)
-                .min(tasks_with_agents);
+                .map(|_| {
+                    (snap.states.values().filter(|s| s.state == "working").count() as u32)
+                        .min(tasks_with_agents)
+                });
             if *commit {
                 // Armed, not fired: serve_conn tears down after this reply is
                 // written. See the note there.
@@ -3428,7 +3434,7 @@ mod tests {
         let reply = handle(&req(Command::Quit { commit: false }, Some("tok")), &host);
         let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit") };
         assert_eq!(q.tasks_with_agents, 1);
-        assert_eq!(q.working_tasks, 1, "working must never exceed the task count");
+        assert_eq!(q.working_tasks, Some(1), "working must never exceed the task count");
     }
 
     // `quit` is the most destructive verb on the socket, so the preview /
@@ -3445,7 +3451,7 @@ mod tests {
         assert!(reply.ok, "{reply:?}");
         let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit, got {reply:?}") };
         assert_eq!((q.tasks_with_agents, q.live_agents), (2, 3));
-        assert_eq!(q.working_tasks, 1);
+        assert_eq!(q.working_tasks, Some(1));
         assert!(!q.quitting, "preview must not claim to be quitting");
         assert_eq!(*host.quit_calls.lock().unwrap(), 0, "preview tore the app down");
     }
@@ -3482,7 +3488,7 @@ mod tests {
     // the question would otherwise overstate what the user is about to lose.
     // The PTY counts are unaffected - they come from the PTY map, not here.
     #[test]
-    fn quit_reports_no_working_tasks_when_the_cache_is_stale() {
+    fn quit_reports_unknown_work_state_when_the_cache_is_stale() {
         let host = StubHost { live_agents: (1, 1), ..Default::default() };
         host.push_states(&[(
             "w1",
@@ -3493,7 +3499,7 @@ mod tests {
         std::thread::sleep(CACHE_STALE_AFTER + Duration::from_millis(100));
         let reply = handle(&req(Command::Quit { commit: false }, Some("tok")), &host);
         let Some(ReplyData::Quit(q)) = reply.data else { panic!("expected quit") };
-        assert_eq!(q.working_tasks, 0, "a stale cache must not be reported as fact");
+        assert_eq!(q.working_tasks, None, "a stale cache is UNKNOWN, not zero");
         assert_eq!(q.live_agents, 1, "PTY counts do not depend on the cache");
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4472,6 +4472,44 @@ fn task_set_sandbox(
     Ok(kill_task_ptys(&state, &id))
 }
 
+/// (tasks with a live agent, live AGENT PTYs). Ground truth for what
+/// `termic quit` is about to SIGKILL, counted off the PTY map rather than
+/// the webview's cache: the cache can be stale and this is the number the
+/// user is being asked to approve.
+///
+/// Only `kind == "agent"` counts. The map also holds the aux shell, plain
+/// shell tabs and setup/run script tabs; every one of those dies with the
+/// app too, but calling them "agents" in the confirmation would inflate
+/// the number the user is deciding on. Attribution comes from
+/// `role.task_id`, NOT `slot.task_id` - an agent tab carries the role
+/// while `slot.task_id` is the sandbox trigger and is unset on some tabs,
+/// which would otherwise report "1 agent across 0 tasks".
+pub(crate) fn live_agent_pty_counts(manager: &PtyManager) -> (u32, u32) {
+    let map = manager.inner.lock();
+    count_live_agents(map.values().map(|s| (s.child_pid.is_some(), s.role.as_ref())))
+}
+
+/// The rule behind `live_agent_pty_counts`, over plain data so it can be
+/// unit-tested: a real `PtySlot` owns a live `MasterPty` and cannot be
+/// constructed in a test.
+fn count_live_agents<'a>(
+    slots: impl Iterator<Item = (bool, Option<&'a PtyRole>)>,
+) -> (u32, u32) {
+    let mut tasks: HashSet<&str> = HashSet::new();
+    let mut total = 0u32;
+    for (alive, role) in slots {
+        if !alive {
+            continue; // already exited; nothing left to kill
+        }
+        let Some(role) = role.filter(|r| r.kind == "agent") else {
+            continue;
+        };
+        total += 1;
+        tasks.insert(role.task_id.as_str());
+    }
+    (tasks.len() as u32, total)
+}
+
 /// Find + SIGKILL every live PTY belonging to a task. Shared by
 /// `task_set_sandbox` (profile change requires a respawn) and the CLI's
 /// `archive` (removing a worktree under a live agent is undefined). The
@@ -10773,6 +10811,42 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+
+    fn role(kind: &str, task: &str) -> PtyRole {
+        PtyRole { task_id: task.into(), kind: kind.into(), is_default: false }
+    }
+
+    // `termic quit`'s confirmation says "kills N agents across M tasks", and
+    // that number is the only thing between a teardown script and every
+    // running agent. The PTY map also holds the aux shell, plain shell tabs
+    // and setup/run script tabs; counting those as "agents" would inflate the
+    // number the user is deciding on.
+    #[test]
+    fn live_agent_count_counts_agents_only() {
+        let a1 = role("agent", "t1");
+        let a2 = role("agent", "t1"); // second agent tab, SAME task
+        let a3 = role("agent", "t2");
+        let aux = role("aux", "t1");
+        let slots = vec![
+            (true, Some(&a1)),
+            (true, Some(&a2)),
+            (true, Some(&a3)),
+            (true, Some(&aux)),  // aux shell: dies too, but is not an agent
+            (true, None),        // setup/run script or plain shell tab
+            (false, Some(&a3)),  // already exited: nothing left to kill
+        ];
+        // 3 live agent tabs across 2 distinct tasks.
+        assert_eq!(count_live_agents(slots.into_iter()), (2, 3));
+    }
+
+    #[test]
+    fn live_agent_count_is_zero_when_only_shells_are_open() {
+        let aux = role("aux", "t1");
+        let slots = vec![(true, Some(&aux)), (true, None)];
+        // Must not report "1 agent across 0 tasks" - the shape the old
+        // slot.task_id attribution produced.
+        assert_eq!(count_live_agents(slots.into_iter()), (0, 0));
+    }
 
     // The close button routes on a STRING from settings.json. Anything the
     // app does not recognise must fall back to ASKING: quitting kills every

--- a/termic-cli/src/client.rs
+++ b/termic-cli/src/client.rs
@@ -346,7 +346,6 @@ mod tests {
         assert!(!err.message.contains("TERMIC_SOCKET"), "got: {}", err.message);
     }
 
-    
     use termic_proto::{ErrorCode, Reply, ReplyData};
 
     #[test]

--- a/termic-cli/src/client.rs
+++ b/termic-cli/src/client.rs
@@ -123,16 +123,21 @@ fn try_connect(paths: &SocketPaths) -> std::io::Result<Conn> {
 pub fn connect_or_launch(paths: &SocketPaths, no_launch: bool) -> Result<Conn, CliError> {
     match try_connect(paths) {
         Ok(c) => return Ok(c),
-        Err(_) if no_launch => {
-            return Err(CliError::new(
-                exit_code::APP_NOT_RUNNING,
-                "Termic must be open (--no-launch given)",
-            ));
-        }
+        // An EXPLICIT socket path outranks the no-launch message: the user
+        // pointed us somewhere, and "Termic must be open" would hide the fact
+        // that we were looking at their path and did not find it. `quit`
+        // passes no_launch internally, so without this ordering its
+        // misconfiguration error would blame a flag the user never typed.
         Err(_) if paths.custom => {
             return Err(CliError::new(
                 exit_code::APP_NOT_RUNNING,
                 format!("Termic is not listening on TERMIC_SOCKET ({})", paths.socket.display()),
+            ));
+        }
+        Err(_) if no_launch => {
+            return Err(CliError::new(
+                exit_code::APP_NOT_RUNNING,
+                "Termic must be open (--no-launch given)",
             ));
         }
         Err(_) => {}
@@ -295,6 +300,53 @@ pub fn reply_to_result(reply: proto::Reply) -> Result<proto::ReplyData, CliError
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // `quit` passes no_launch internally and swallows APP_NOT_RUNNING into a
+    // success, but ONLY on the default socket. These two pin the arm ordering
+    // that makes that safe: an EXPLICIT TERMIC_SOCKET must produce the
+    // path-naming error, not the no-launch one, so the swallow (which keys on
+    // `custom`) cannot report "nothing to quit" for a socket the user pointed
+    // us at while agents are still running elsewhere.
+    #[test]
+    fn an_explicit_socket_that_is_missing_names_the_path() {
+        let paths = SocketPaths {
+            socket: PathBuf::from("/nonexistent/termic-explicit.sock"),
+            token_file: PathBuf::from("/nonexistent/termic-explicit.token"),
+            custom: true,
+        };
+        let err = match connect_or_launch(&paths, true) {
+            Ok(_) => panic!("nothing should be listening on this path"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code, exit_code::APP_NOT_RUNNING);
+        assert!(
+            err.message.contains("TERMIC_SOCKET"),
+            "an explicit socket must name itself, got: {}",
+            err.message,
+        );
+        assert!(
+            !err.message.contains("--no-launch"),
+            "must not blame a flag the user never typed: {}",
+            err.message,
+        );
+    }
+
+    #[test]
+    fn the_default_socket_falls_back_to_the_no_launch_message() {
+        let paths = SocketPaths {
+            socket: PathBuf::from("/nonexistent/termic-default.sock"),
+            token_file: PathBuf::from("/nonexistent/termic-default.token"),
+            custom: false,
+        };
+        let err = match connect_or_launch(&paths, true) {
+            Ok(_) => panic!("nothing should be listening on this path"),
+            Err(e) => e,
+        };
+        assert_eq!(err.code, exit_code::APP_NOT_RUNNING);
+        assert!(!err.message.contains("TERMIC_SOCKET"), "got: {}", err.message);
+    }
+
+    
     use termic_proto::{ErrorCode, Reply, ReplyData};
 
     #[test]

--- a/termic-cli/src/lib.rs
+++ b/termic-cli/src/lib.rs
@@ -527,6 +527,39 @@ Exit codes: 0 success, 1 unknown or ambiguous task, 4 app not running, \
         project: Option<String>,
     },
 
+    /// Quit Termic: every running agent dies with it. For the human at the keyboard, not for agents driving Termic.
+    ///
+    /// The only shell-side teardown for a windowless instance. Asks for
+    /// confirmation on a TTY unless --yes, naming how many agents it is
+    /// about to kill. Never launches Termic; if it is not running this
+    /// succeeds silently, so teardown scripts do not need `|| true`.
+    #[command(
+        after_help = "Every live agent PTY, script process group and in-flight grep dies \
+with the app, the same teardown Cmd-Q does. Any ACTIVE SPOTLIGHT SESSION is \
+also reverted, which force-checks-out the project's main checkout. The \
+confirmation names how many agents it is about to kill; non-interactive runs \
+REQUIRE --yes.
+
+Never launches Termic. On the default socket, a Termic that is not running \
+prints a note and exits 0, so teardown scripts do not need `|| true`. With \
+TERMIC_SOCKET set explicitly, a missing socket is a misconfiguration and \
+still exits 4.
+
+Prints what happened on stdout. With --output-format json, one object, \
+always carrying `running` and `quitting`: \
+{\"running\", \"quitting\", \"tasks_with_agents\", \"live_agents\", \
+\"working_tasks\"} when Termic was running, or {\"running\": false, \
+\"quitting\": false} when it was not.
+
+Exit codes: 0 quit (or nothing was running), 1 error (declined, no TTY \
+without --yes), 4 the app went away before the command committed, 5 CLI \
+disabled, 6 refused, 8 the app exited mid-command."
+    )]
+    Quit {
+        /// Skip the confirmation prompt (required non-interactively).
+        #[arg(short, long)]
+        yes: bool,
+    },
     /// Archive a task: SIGKILL its live agents, remove its worktree.
     #[command(
         after_help = "Kills the task's live agent PTYs FIRST, then archives: the worktree \
@@ -684,7 +717,25 @@ fn execute(cli: &Cli) -> Result<Output, CliError> {
     };
 
     let paths = client::socket_paths();
-    let mut conn = client::connect_or_launch(&paths, cli.no_launch)?;
+    // `quit` never launches: starting Termic in order to stop it is absurd,
+    // and a teardown script wants "already gone" to be SUCCESS, not an error
+    // it has to `|| true` away. Every other verb keeps auto-launch.
+    let quitting = matches!(cli.cmd, Cmd::Quit { .. });
+    let mut conn = match client::connect_or_launch(&paths, cli.no_launch || quitting) {
+        // "Nothing to quit" is success, so a teardown script does not need
+        // `|| true`. But ONLY on the default socket: if the user pointed
+        // TERMIC_SOCKET somewhere explicit, a socket that is not there is a
+        // misconfiguration, and reporting exit 0 would tell a script it had
+        // stopped agents that are in fact still running.
+        Err(e) if quitting && !paths.custom && e.code == exit_code::APP_NOT_RUNNING => {
+            return Ok(Output::ok(final_stdout(
+                format,
+                "Termic is not running.",
+                &serde_json::json!({ "running": false, "quitting": false }),
+            )));
+        }
+        other => other?,
+    };
     client::hello(&mut conn)?;
     let token = client::read_token(&paths)?;
 
@@ -791,6 +842,7 @@ fn execute(cli: &Cli) -> Result<Output, CliError> {
             let code = w.result.outcome.exit_code();
             Ok(Output { stdout: final_stdout(format, &output::wait_text(&w), &w), code })
         }
+        Cmd::Quit { yes } => execute_quit(&mut conn, &token, format, *yes, &paths),
         Cmd::Archive { task, project, yes } => {
             execute_archive(&mut conn, &token, format, task, project.as_deref(), *yes, &paths)
         }
@@ -1149,6 +1201,38 @@ fn execute_archive(
     Ok(Output::ok(final_stdout(format, &output::archive_text(&a), &a)))
 }
 
+/// `termic quit`. Preview first so the confirmation can name what dies,
+/// then commit. Never auto-launches: launching Termic in order to quit it
+/// is absurd, and a teardown script wants "already gone" to be success.
+fn execute_quit(
+    conn: &mut client::Conn,
+    token: &str,
+    format: OutputFormat,
+    yes: bool,
+    paths: &client::SocketPaths,
+) -> Result<Output, CliError> {
+    let data = client::request(conn, proto::Command::Quit { commit: false }, token)?;
+    let proto::ReplyData::Quit(p) = data else {
+        return Err(CliError::new(exit_code::ERROR, "unexpected reply to quit"));
+    };
+
+    let mut fresh = None;
+    if !yes {
+        if !confirm_tty(&output::quit_question(&p))? {
+            return Err(CliError::new(exit_code::ERROR, "quit declined"));
+        }
+        // A human can sit on the prompt longer than the server's 30s idle
+        // timeout, so reconnect before committing (same as archive).
+        fresh = Some(reconnect(paths)?);
+    }
+    let conn = fresh.as_mut().unwrap_or(conn);
+    let data = client::request(conn, proto::Command::Quit { commit: true }, token)?;
+    let proto::ReplyData::Quit(q) = data else {
+        return Err(CliError::new(exit_code::ERROR, "unexpected reply to quit"));
+    };
+    Ok(Output::ok(final_stdout(format, &output::quit_text(&q), &q)))
+}
+
 fn execute_project(
     conn: &mut client::Conn,
     token: &str,
@@ -1445,6 +1529,11 @@ fn verb_exit_codes(name: &str) -> Vec<i32> {
         // Fully local (no socket): only success, an unknown command
         // name, and the in-cage refusal that precedes it are reachable.
         "help" => vec![0, 1, 6],
+        // COMMON, and every code in it is genuinely reachable: 4 and 8 when
+        // the app exits underneath us (a second `quit`, or Cmd-Q while a
+        // human sits on the confirmation), which is why `after_help` lists
+        // them rather than pretending quit always succeeds.
+        "quit" => COMMON.to_vec(),
         _ => COMMON.to_vec(),
     }
 }
@@ -1756,7 +1845,7 @@ mod tests {
             v["commands"].as_array().unwrap().iter().map(|c| c["name"].as_str().unwrap()).collect();
         for expected in [
             "list", "status", "open", "new", "send", "attach", "logs", "result", "diff",
-            "apply", "path", "wait", "archive", "project add", "project list",
+            "apply", "path", "wait", "archive", "quit", "project add", "project list",
             "project remove", "help",
         ] {
             assert!(names.contains(&expected), "missing {expected} in {names:?}");

--- a/termic-cli/src/lib.rs
+++ b/termic-cli/src/lib.rs
@@ -548,7 +548,7 @@ still exits 4.
 Prints what happened on stdout. With --output-format json, one object, \
 always carrying `running` and `quitting`: \
 {\"running\", \"quitting\", \"tasks_with_agents\", \"live_agents\", \
-\"working_tasks\"} when Termic was running, or {\"running\": false, \
+\"working_tasks\" (null when the work-state cache is stale)} when Termic was running, or {\"running\": false, \
 \"quitting\": false} when it was not.
 
 Exit codes: 0 quit (or nothing was running), 1 error (declined, no TTY \

--- a/termic-cli/src/output.rs
+++ b/termic-cli/src/output.rs
@@ -344,10 +344,13 @@ pub fn quit_question(p: &QuitData) -> String {
     // and naming it here would bury the number that matters.
     let agents = plural(p.live_agents, "agent", "agents");
     let tasks = plural(p.tasks_with_agents, "task", "tasks");
-    let working = if p.working_tasks > 0 {
-        format!(" {} still working.", plural(p.working_tasks, "task", "tasks"))
-    } else {
-        String::new()
+    // Three states, not two. `None` is UNKNOWN (the work-state cache went
+    // stale), and saying so beats rendering it the same as "nothing is
+    // working" on a question about killing agents.
+    let working = match p.working_tasks {
+        Some(0) => String::new(),
+        Some(n) => format!(" {} still working.", plural(n, "task", "tasks")),
+        None => " Work state unknown.".to_string(),
     };
     format!(
         "termic: quit Termic? This kills {agents} across {tasks}.{working}",
@@ -358,10 +361,10 @@ pub fn quit_text(q: &QuitData) -> String {
     if q.live_agents == 0 {
         return "Termic is quitting.".into();
     }
-    format!(
-        "Termic is quitting; {} killed.",
-        plural(q.live_agents, "agent", "agents"),
-    )
+    // Present tense on purpose: this reply is built and written BEFORE
+    // serve_conn fires the teardown, so "killed" would claim something that
+    // has not happened yet (guaranteed to follow, but not yet true).
+    format!("Termic is quitting; {}.", plural(q.live_agents, "agent", "agents"))
 }
 
 fn plural(n: u32, one: &str, many: &str) -> String {
@@ -372,7 +375,7 @@ fn plural(n: u32, one: &str, many: &str) -> String {
 mod tests {
     use super::*;
 
-    fn d(tasks: u32, agents: u32, working: u32) -> QuitData {
+    fn d(tasks: u32, agents: u32, working: Option<u32>) -> QuitData {
         QuitData { running: true, tasks_with_agents: tasks, live_agents: agents, working_tasks: working, quitting: false }
     }
 
@@ -380,7 +383,7 @@ mod tests {
     // thing standing between a teardown script and every running agent.
     #[test]
     fn question_names_what_dies() {
-        let q = quit_question(&d(2, 3, 1));
+        let q = quit_question(&d(2, 3, Some(1)));
         assert!(q.contains("3 agents"), "{q}");
         assert!(q.contains("2 tasks"), "{q}");
         assert!(q.contains("1 task still working"), "{q}");
@@ -388,7 +391,7 @@ mod tests {
 
     #[test]
     fn question_singularises() {
-        let q = quit_question(&d(1, 1, 0));
+        let q = quit_question(&d(1, 1, Some(0)));
         assert!(q.contains("1 agent across 1 task"), "{q}");
         assert!(!q.contains("still working"), "nothing working, so do not mention it: {q}");
     }
@@ -398,29 +401,40 @@ mod tests {
     // still working", not "2 agents".
     #[test]
     fn question_says_tasks_not_agents_for_the_working_count() {
-        let q = quit_question(&d(2, 5, 2));
+        let q = quit_question(&d(2, 5, Some(2)));
         assert!(q.contains("5 agents"), "{q}");
         assert!(q.contains("2 tasks still working"), "{q}");
+    }
+
+    // A stale work-state cache is UNKNOWN, not idle. Rendering it as silence
+    // would make "nothing is working" and "I cannot tell" identical on a
+    // prompt about killing agents, which understates what is about to die.
+    #[test]
+    fn question_says_unknown_rather_than_dropping_the_note() {
+        let q = quit_question(&d(2, 3, None));
+        assert!(q.contains("3 agents"), "{q}");
+        assert!(q.contains("Work state unknown"), "{q}");
+        assert!(!q.contains("still working"), "{q}");
     }
 
     // Nothing running: do not invent a scary question.
     #[test]
     fn question_is_plain_when_nothing_is_running() {
-        assert_eq!(quit_question(&d(0, 0, 0)), "termic: quit Termic?");
+        assert_eq!(quit_question(&d(0, 0, Some(0))), "termic: quit Termic?");
     }
 
     #[test]
     fn text_reports_the_kill_count() {
-        let mut q = d(1, 2, 0);
+        let mut q = d(1, 2, Some(0));
         q.quitting = true;
-        assert!(quit_text(&q).contains("2 agents killed"), "{}", quit_text(&q));
-        assert_eq!(quit_text(&d(0, 0, 0)), "Termic is quitting.");
+        assert!(quit_text(&q).contains("2 agents"), "{}", quit_text(&q));
+        assert_eq!(quit_text(&d(0, 0, Some(0))), "Termic is quitting.");
     }
 
     // Copy rule: no em dashes anywhere in CLI output.
     #[test]
     fn no_em_dashes() {
-        for s in [quit_question(&d(2, 3, 1)), quit_text(&d(1, 2, 0))] {
+        for s in [quit_question(&d(2, 3, Some(1))), quit_text(&d(1, 2, Some(0)))] {
             assert!(!s.contains('\u{2014}'), "em dash in CLI output: {s}");
         }
     }

--- a/termic-cli/src/output.rs
+++ b/termic-cli/src/output.rs
@@ -5,7 +5,7 @@
 use serde::Serialize;
 use termic_proto::{
     send_mode, ApplyData, ArchiveData, DiffData, DiffStat, NewData, OpenData, ProjectInfo,
-    ProjectRemoveData, ResultData, SendData, StreamEvent, TaskStatus, TaskSummary, WaitData,
+    ProjectRemoveData, QuitData, ResultData, SendData, StreamEvent, TaskStatus, TaskSummary, WaitData,
     WaitOutcome, WaitResult,
 };
 
@@ -331,9 +331,99 @@ pub fn project_remove_text(r: &ProjectRemoveData) -> String {
     format!("removed project {} ({tasks})", r.name)
 }
 
+/// The confirmation question. Names what actually dies, because that is
+/// the whole reason quitting a windowless Termic is a decision at all.
+pub fn quit_question(p: &QuitData) -> String {
+    if p.live_agents == 0 {
+        return "termic: quit Termic?".into();
+    }
+    // NOTE: quitting also reverts any active spotlight session, which force-
+    // checks-out the project's MAIN checkout. That is the one effect reaching
+    // outside Termic's own state, so `quit --help` spells it out. It is left
+    // out of this one-line question deliberately: spotlight is off by default
+    // and naming it here would bury the number that matters.
+    let agents = plural(p.live_agents, "agent", "agents");
+    let tasks = plural(p.tasks_with_agents, "task", "tasks");
+    let working = if p.working_tasks > 0 {
+        format!(" {} still working.", plural(p.working_tasks, "task", "tasks"))
+    } else {
+        String::new()
+    };
+    format!(
+        "termic: quit Termic? This kills {agents} across {tasks}.{working}",
+    )
+}
+
+pub fn quit_text(q: &QuitData) -> String {
+    if q.live_agents == 0 {
+        return "Termic is quitting.".into();
+    }
+    format!(
+        "Termic is quitting; {} killed.",
+        plural(q.live_agents, "agent", "agents"),
+    )
+}
+
+fn plural(n: u32, one: &str, many: &str) -> String {
+    format!("{n} {}", if n == 1 { one } else { many })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn d(tasks: u32, agents: u32, working: u32) -> QuitData {
+        QuitData { running: true, tasks_with_agents: tasks, live_agents: agents, working_tasks: working, quitting: false }
+    }
+
+    // The question is the whole safety surface of `quit`: it is the only
+    // thing standing between a teardown script and every running agent.
+    #[test]
+    fn question_names_what_dies() {
+        let q = quit_question(&d(2, 3, 1));
+        assert!(q.contains("3 agents"), "{q}");
+        assert!(q.contains("2 tasks"), "{q}");
+        assert!(q.contains("1 task still working"), "{q}");
+    }
+
+    #[test]
+    fn question_singularises() {
+        let q = quit_question(&d(1, 1, 0));
+        assert!(q.contains("1 agent across 1 task"), "{q}");
+        assert!(!q.contains("still working"), "nothing working, so do not mention it: {q}");
+    }
+
+    // The count is per TASK (the work-state cache aggregates that way), so
+    // the wording must not imply agents. Two busy tabs in one task is "1 task
+    // still working", not "2 agents".
+    #[test]
+    fn question_says_tasks_not_agents_for_the_working_count() {
+        let q = quit_question(&d(2, 5, 2));
+        assert!(q.contains("5 agents"), "{q}");
+        assert!(q.contains("2 tasks still working"), "{q}");
+    }
+
+    // Nothing running: do not invent a scary question.
+    #[test]
+    fn question_is_plain_when_nothing_is_running() {
+        assert_eq!(quit_question(&d(0, 0, 0)), "termic: quit Termic?");
+    }
+
+    #[test]
+    fn text_reports_the_kill_count() {
+        let mut q = d(1, 2, 0);
+        q.quitting = true;
+        assert!(quit_text(&q).contains("2 agents killed"), "{}", quit_text(&q));
+        assert_eq!(quit_text(&d(0, 0, 0)), "Termic is quitting.");
+    }
+
+    // Copy rule: no em dashes anywhere in CLI output.
+    #[test]
+    fn no_em_dashes() {
+        for s in [quit_question(&d(2, 3, 1)), quit_text(&d(1, 2, 0))] {
+            assert!(!s.contains('\u{2014}'), "em dash in CLI output: {s}");
+        }
+    }
 
     fn summary() -> TaskSummary {
         TaskSummary {

--- a/termic-proto/src/lib.rs
+++ b/termic-proto/src/lib.rs
@@ -503,11 +503,17 @@ pub struct QuitData {
     /// TASKS the webview reports as working, not agents: the work-state
     /// cache aggregates per task, so two busy tabs in one task count once.
     /// Named for what it counts rather than what a caller might hope.
-    /// Best-effort - a stale cache reports 0 rather than guessing - and
-    /// clamped to `tasks_with_agents`, because a lagging cache can otherwise
+    /// Clamped to `tasks_with_agents`, because a lagging cache can otherwise
     /// name a task whose agent PTY is already gone.
+    ///
+    /// `None` means UNKNOWN, not zero: the cache went stale, so the webview
+    /// stopped reporting. The distinction is load-bearing for a confirmation
+    /// prompt - collapsing it into 0 would render "nothing is working" and
+    /// "I cannot tell" identically, and understating what is about to die is
+    /// the wrong direction for a safety question. `live_agents` is ground
+    /// truth either way; only this field can go dark.
     #[serde(default)]
-    pub working_tasks: u32,
+    pub working_tasks: Option<u32>,
     /// False for `preview`, true when the app is on its way out.
     pub quitting: bool,
 }
@@ -1262,7 +1268,7 @@ mod tests {
                 running: true,
                 tasks_with_agents: 2,
                 live_agents: 3,
-                working_tasks: 1,
+                working_tasks: Some(1),
                 quitting: true,
             }),
             ReplyData::Archive(ArchiveData {

--- a/termic-proto/src/lib.rs
+++ b/termic-proto/src/lib.rs
@@ -31,7 +31,10 @@ use std::io::{self, BufRead, Read, Write};
 /// the bidirectional `attach` session (AttachFrame lines after the
 /// accepted request). Exit codes 10 (apply conflict) and 11 (attach
 /// target closed) become live.
-pub const PROTOCOL_VERSION: u32 = 3;
+pub const PROTOCOL_VERSION: u32 = 4;
+
+/// serde default for `QuitData::running`.
+pub(crate) fn default_true() -> bool { true }
 
 /// Socket + token file names inside the app's data dir.
 pub const SOCKET_FILE: &str = "termic.sock";
@@ -224,6 +227,22 @@ pub enum Command {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cwd: Option<String>,
     },
+    /// Shut the app down: every PTY, script process group, in-flight grep
+    /// and spotlight session goes with it (the same teardown Cmd-Q does).
+    /// Authenticated, because it is the most destructive thing the socket
+    /// can do. The confirmation prompt is the CLI's job (`--yes` skips it);
+    /// the server never asks.
+    Quit {
+        /// Actually quit. Defaults to FALSE, i.e. preview only.
+        ///
+        /// Deliberately phrased so the fail-open direction is the safe one.
+        /// The protocol tolerates unknown fields by design, so `previw: true`
+        /// or any future rename would silently take the default - and for the
+        /// most destructive verb on the socket that default must not be
+        /// "tear the app down".
+        #[serde(default)]
+        commit: bool,
+    },
     /// Archive a task. Live agent PTYs are SIGKILLed first. The
     /// confirmation prompt is the CLI's job (`--yes` skips it); the
     /// server never asks.
@@ -399,6 +418,7 @@ pub enum ReplyData {
     Open(OpenData),
     New(NewData),
     Wait(WaitData),
+    Quit(QuitData),
     Archive(ArchiveData),
     ProjectList(ProjectListData),
     ProjectAdd(ProjectAddData),
@@ -465,6 +485,31 @@ pub struct WaitData {
     pub task_id: String,
     #[serde(flatten)]
     pub result: WaitResult,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QuitData {
+    /// Always true from the server (it answered, so it was running). The
+    /// not-running case is synthesised by the CLI with `running: false`, so
+    /// a script can branch on this one field either way.
+    #[serde(default = "crate::default_true")]
+    pub running: bool,
+    /// Tasks with at least one live agent PTY.
+    #[serde(default)]
+    pub tasks_with_agents: u32,
+    /// Live agent PTYs that will die (or died) with the app.
+    #[serde(default)]
+    pub live_agents: u32,
+    /// TASKS the webview reports as working, not agents: the work-state
+    /// cache aggregates per task, so two busy tabs in one task count once.
+    /// Named for what it counts rather than what a caller might hope.
+    /// Best-effort - a stale cache reports 0 rather than guessing - and
+    /// clamped to `tasks_with_agents`, because a lagging cache can otherwise
+    /// name a task whose agent PTY is already gone.
+    #[serde(default)]
+    pub working_tasks: u32,
+    /// False for `preview`, true when the app is on its way out.
+    pub quitting: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1095,6 +1140,8 @@ mod tests {
                 cwd: None,
             },
             Command::Wait { task: None, project: None, timeout_ms: None, cwd: Some("/t".into()) },
+            Command::Quit { commit: false },
+            Command::Quit { commit: true },
             Command::Archive { task: "fix-auth".into(), project: Some("web".into()) },
             Command::ProjectAdd { path: "/repo/web".into(), non_git: false },
             Command::ProjectAdd { path: "/notes/plain".into(), non_git: true },
@@ -1210,6 +1257,13 @@ mod tests {
             ReplyData::Wait(WaitData {
                 task_id: "w1".into(),
                 result: WaitResult { outcome: WaitOutcome::Timeout, state: None, detail: Some("x".into()) },
+            }),
+            ReplyData::Quit(QuitData {
+                running: true,
+                tasks_with_agents: 2,
+                live_agents: 3,
+                working_tasks: 1,
+                quitting: true,
             }),
             ReplyData::Archive(ArchiveData {
                 task_id: "w1".into(),


### PR DESCRIPTION
Two commits: `termic quit` (implementation) and the GH #138 tab spec (plan only).

## Why

Windowless mode left the menu-bar Quit as the only way to stop Termic. For a CLI feature that is backwards: pick "Keep in Menu Bar", tick don't-ask-again, and stopping your agents needs the mouse.

```
termic quit          confirm on a TTY, naming what dies
termic quit --yes    for scripts
```

## Decisions

| Decision | Why |
|---|---|
| `commit: bool`, not `preview: bool` | Unknown fields are tolerated by design, so `previw: true` takes serde's default. For this verb that default must not be "tear down". A test sends the typo. |
| Teardown fires *after* the reply is written | A fixed grace cannot be sized: a descheduled thread closes the socket first and a **successful** quit reports `CONNECTION_LOST`. The flag is thread-local, since it is one thread per connection. |
| Counts filtered to `role.kind == "agent"` | The PTY map also holds the aux shell and setup/run script tabs. Otherwise: "kills 3 agents" for one agent plus a shell and a run tab. |
| `working_tasks`, clamped to the task count | The work-state cache aggregates per task, so it counts tasks, not agents. The clamp stops "1 agent across 1 task, 2 tasks still working" when the cache lags a dead PTY. |
| Exit 0 vs 4 when nothing is running | Default socket → 0, so teardown scripts skip `\|\| true`. Explicit `TERMIC_SOCKET` → 4; success there would claim it stopped agents that are still running. |

Authenticated like every destructive verb; caged agents cannot reach the socket at all. `--help` and the agent-facing `about` both disclose that quitting reverts active spotlight sessions, which force-checks-out the project's **main** checkout. Protocol v4.

## Tests

- **7 server cases**: preview tears nothing down · commit reports what died · missing `commit` previews · unauthenticated refused · stale cache reports 0 · the clamp holds · socket-level reply-before-teardown
- **Counting rule**: agents only; shells alone report 0, never "1 agent across 0 tasks"
- **Exit 0/4 asymmetry**, proto round-trips both directions, output goldens on the confirmation wording

Live: windowless + fakeagent → `live_agents 1 / working_tasks 0`, app exited, agent reaped. Nothing running → 0. Bad explicit socket → 4.

Green: 277 cargo · 53 cli · 16 proto · 487 vitest · clippy at main's baseline.

## Plan updates (commit 2, docs only)

### GH #138 tab spec

Today the whole tab surface is one boolean. `attach --shell` picks the aux terminal, everything else silently means "the default agent tab", and `status` reports a session *count*. A second claude tab is unreachable, not just awkward.

**Picking what to open is not a binary.** The "+" menu already offers three kinds and gates them, so the verb mirrors that rather than inventing a simpler model:

| Flag | Opens | Gating |
|---|---|---|
| `--agent <id>` | `kind: "agent"` registry entry | must be enabled **and** detected on PATH; fails listing valid ids |
| `--terminal <id>` | `kind: "terminal"` custom entry (#27) | never resumes, no YOLO args |
| `--shell` | the task's aux terminal | matches `attach --shell` |
| *omitted* | the task's own `cli` | what the `+` button does before you pick |

Separate flags, not one `--kind <string>`: sandbox follows kind (agent tabs inherit the task's pin, terminal/shell are uncaged), so a typo must not silently downgrade a caged agent.

Plus the targeting half: `--tab <n|title>` on send/wait/attach/logs (absent = the default agent tab, so nothing existing changes meaning) and tabs listed in `status`.

Open questions written down rather than guessed: selector stability (`PtyRole` carries neither id nor title, so exposing one is an IPC change on top of the protocol change), ambiguity as an error, the now-redundant `attach --shell`, resuming a closed tab (the `+` menu offers it; the CLI has no equivalent), and whether `tab -p` needs Phase 1's delivery contract.

### Homebrew: settled, not pending

Drops off Phase 3.

- **Cask: done.** Ships the app; `release.yml` bumps version + sha256 in the tap each release.
- **CLI-only formula: not doing it.** `brew install termic` hands you a client with no server, since the app *is* the daemon.
- **Not a cask `binary` stanza either.** It would put `termic` on PATH for everyone, which Landing rules out.
