### PR TITLE
feat(diff): render images in the git diff instead of binary garbage

### DIFF
--- a/e2e/specs/files.e2e.ts
+++ b/e2e/specs/files.e2e.ts
@@ -383,5 +383,50 @@ describe("file tree", () => {
     // The original child is still there too (a refresh, not a replace).
     expect(await rowExists("e2e-refresh/one.txt")).toBe(true);
   });
+
+  // Clicking an image in the tree must render the picture, not an empty pane:
+  // the tab routes to PreviewPane (previewKindForPath) and the bytes arrive as
+  // base64 over taskFileReadBase64. The fixture's committed shot.png is the
+  // subject (scripts/e2e-seed.mjs).
+  it("previews an image clicked in the tree", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+    taskId = taskId ?? (await openTask("e2e-tree"));
+    await ensureActiveTask(taskId);
+
+    await browser.waitUntil(() => rowExists("shot.png"), {
+      timeout: 10_000,
+      timeoutMsg: "shot.png never appeared in the tree",
+    });
+    await clickRow("shot.png");
+
+    // The tab opened as an edit tab...
+    await browser.waitUntil(
+      () =>
+        browser.execute(
+          (id) =>
+            (window.__termic!.useApp.getState().tabs[id] ?? []).some(
+              (t: any) => t.type === "edit" && t.path === "shot.png",
+            ),
+          taskId,
+        ),
+      { timeout: 8_000, timeoutMsg: "clicking the image never opened a tab" },
+    );
+
+    // ...and it renders a real, decoded image rather than an empty pane.
+    await browser.waitUntil(
+      async () => {
+        const r = await browser.execute((id) => {
+          const pane = document.querySelector(`[data-task-id="${id}"]`);
+          const img = pane?.querySelector('img[src^="data:image/"]') as HTMLImageElement | null;
+          if (!img) return { found: false, w: 0, h: 0 };
+          return { found: true, w: img.naturalWidth, h: img.naturalHeight };
+        }, taskId);
+        return r.found && r.w > 0 && r.h > 0;
+      },
+      { timeout: 10_000, timeoutMsg: "the image preview never rendered decoded pixels" },
+    );
+    await snap("image-preview.png");
+  });
 });
 

--- a/e2e/specs/git.e2e.ts
+++ b/e2e/specs/git.e2e.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { archiveTask, clickByText, openTask, requireTermicApi, snap, waitForAppShell, waitForText, waitForTextGone } from "../helpers";
@@ -107,11 +107,127 @@ describe("git dirty tree", () => {
   });
 });
 
+// Tasks here open the repo ROOT, so every case below edits this one working
+// tree and has to put it back.
+const fixture = process.env.E2E_FIXTURE ?? path.join(process.cwd(), ".e2e", "fixture-repo");
+
+// P1: a diff on a PNG renders pictures, not the screenful of U+FFFD that a
+// lossy decode of `git show HEAD:shot.png` used to produce. The fixture repo
+// carries a committed 1x1 PNG (scripts/e2e-seed.mjs), so both sides exist.
+describe("image diff", () => {
+  let taskId: string | undefined;
+  // Different bytes, still a valid PNG (2x1 instead of 1x1) so the After side
+  // decodes and reports its own dimensions.
+  const EDITED_PNG_B64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAABCAYAAAD0In+KAAAADklEQVR4nGO4WR7+H4QBF40FTdFBOmcAAAAASUVORK5CYII=";
+
+  after(async () => {
+    if (taskId) await archiveTask(taskId);
+    // Tasks open the repo ROOT (taskOpenRepo), so these cases dirty the shared
+    // fixture in place — restore both files or the commit spec below sees a
+    // tree that never goes clean.
+    execSync(`git -C "${fixture}" checkout -- shot.png README.md`);
+  });
+
+  const diffPaneText = () =>
+    browser.execute((id) => {
+      const pane = document.querySelector(`[data-task-id="${id}"]`) ?? document.body;
+      return (pane as HTMLElement).innerText;
+    }, taskId);
+
+  it("renders both sides of a changed PNG as images", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+    taskId = await openTask("e2e-image-diff");
+
+    // Write the new bytes straight into the task worktree: taskFileWrite is
+    // String-only, and this file is binary by design.
+    const taskPath = await browser.execute(
+      (id) => window.__termic!.useApp.getState().tasks.find((t: any) => t.id === id)?.path,
+      taskId,
+    );
+    writeFileSync(path.join(taskPath as string, "shot.png"), Buffer.from(EDITED_PNG_B64, "base64"));
+
+    await browser.execute((id) => {
+      window.__termic!.useApp.getState().bumpGitRevision(id);
+      window.__termic!.useApp.getState().openPreviewTab(id, {
+        type: "diff",
+        path: "shot.png",
+        title: "Δ shot.png",
+        scope: "unstaged",
+      });
+    }, taskId);
+
+    // Two <img>, one per side, both fed by the base64 diff channel.
+    await browser.waitUntil(
+      async () => {
+        const n = await browser.execute(() =>
+          document.querySelectorAll('img[src^="data:image/png;base64,"]').length);
+        return n === 2;
+      },
+      { timeout: 10_000, timeoutMsg: "the image diff never rendered two <img> sides" },
+    );
+
+    // Dimensions are read off the decoded images, so this also proves the
+    // bytes survived the round trip rather than arriving corrupted.
+    await browser.waitUntil(
+      async () => {
+        const txt = await diffPaneText();
+        return txt.includes("1×1") && txt.includes("2×1");
+      },
+      { timeout: 10_000, timeoutMsg: "per-side dimensions never appeared" },
+    );
+
+    // Case-insensitive: the labels are CSS-uppercased, and innerText only
+    // reflects that while the window is actually rendering — occluded, it
+    // falls back to the raw "Before"/"After".
+    const txt = (await diffPaneText()).toUpperCase();
+    expect(txt).toContain("BEFORE");
+    expect(txt).toContain("AFTER");
+    // The bug this replaces: a wall of replacement characters.
+    expect(txt).not.toContain("�");
+
+    await snap("image-diff.png");
+  });
+
+  it("does not mount a CodeMirror editor for the image diff", async () => {
+    const editors = await browser.execute((id) => {
+      const pane = document.querySelector(`[data-task-id="${id}"]`);
+      return pane ? pane.querySelectorAll(".cm-editor").length : -1;
+    }, taskId);
+    expect(editors).toBe(0);
+  });
+
+  it("still renders a text diff as CodeMirror in the same task", async () => {
+    // Negative control: the kind branch must not swallow ordinary files.
+    await browser.execute(async (id) => {
+      const orig = await window.__termic!.ipc.taskFileRead(id, "README.md");
+      await window.__termic!.ipc.taskFileWrite(id, "README.md", orig + "\nimage-diff control\n");
+      window.__termic!.useApp.getState().bumpGitRevision(id);
+      window.__termic!.useApp.getState().openPreviewTab(id, {
+        type: "diff",
+        path: "README.md",
+        title: "Δ README.md",
+        scope: "unstaged",
+      });
+    }, taskId);
+
+    await browser.waitUntil(
+      async () => {
+        const n = await browser.execute((id) => {
+          const pane = document.querySelector(`[data-task-id="${id}"]`);
+          return pane ? pane.querySelectorAll(".cm-editor").length : 0;
+        }, taskId);
+        return n > 0;
+      },
+      { timeout: 10_000, timeoutMsg: "the text diff never mounted CodeMirror" },
+    );
+  });
+});
+
 // P1: the staging + commit backend (Fork-style). Cases: a changed file can be
 // staged (moves to the staged list), and committing it leaves the tree clean.
 // Teardown hard-resets the fixture repo so its HEAD/tree are exactly restored.
-const fixture = process.env.E2E_FIXTURE ?? path.join(process.cwd(), ".e2e", "fixture-repo");
-
 describe("git stage & commit", () => {
   let taskId: string | undefined;
   let headSha = "";

--- a/scripts/e2e-seed.mjs
+++ b/scripts/e2e-seed.mjs
@@ -13,6 +13,10 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
 const seedDir = path.join(scriptDir, "e2e-seed");
 
+/** 1x1 transparent PNG — the committed side of the image-diff spec's fixture. */
+const TINY_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
 const sh = (cmd, cwd) => execSync(cmd, { cwd, stdio: "ignore" });
 const shOut = (cmd, cwd) =>
   execSync(cmd, { cwd, stdio: ["ignore", "pipe", "ignore"] }).toString();
@@ -43,6 +47,19 @@ export function seed(o = {}) {
     sh("git add .", fixture);
     sh(
       'git -c user.email=e2e@termic.dev -c user.name=e2e commit -q -m "init fixture"',
+      fixture,
+    );
+  }
+
+  // 1a. A committed 1x1 PNG, so the image-diff spec has a HEAD side to compare
+  // against. Separate from the block above (which only runs for a brand-new
+  // fixture) so an already-seeded checkout picks it up too.
+  const shot = path.join(fixture, "shot.png");
+  if (!existsSync(shot)) {
+    writeFileSync(shot, Buffer.from(TINY_PNG_B64, "base64"));
+    sh("git add shot.png", fixture);
+    sh(
+      'git -c user.email=e2e@termic.dev -c user.name=e2e commit -q -m "fixture image"',
       fixture,
     );
   }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1076,7 +1076,9 @@ fn migrate_workspaces_to_tasks() {
 
 // ───────────────────────────── git ─────────────────────────────
 
-fn git(args: &[&str], cwd: &Path) -> Result<String> {
+/// Raw stdout, for callers that read blobs (`git show HEAD:some.png`) where
+/// a lossy UTF-8 decode would destroy the bytes.
+fn git_bytes(args: &[&str], cwd: &Path) -> Result<Vec<u8>> {
     let mut cmd = Command::new("git");
     cmd.args(args).current_dir(cwd);
     // Run with the user's login-shell environment, same as the PTY (see
@@ -1093,7 +1095,11 @@ fn git(args: &[&str], cwd: &Path) -> Result<String> {
     if !out.status.success() {
         return Err(anyhow!("git {:?} failed: {}", args, String::from_utf8_lossy(&out.stderr)));
     }
-    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+    Ok(out.stdout)
+}
+
+fn git(args: &[&str], cwd: &Path) -> Result<String> {
+    Ok(String::from_utf8_lossy(&git_bytes(args, cwd)?).into_owned())
 }
 
 /// Time-bounded fetch of a single ref. `remote_ref` is like "origin/develop":
@@ -6242,6 +6248,9 @@ fn task_path_stat(id: String, path: String) -> Result<PathStat, String> {
     check_task_path_existence(&cwd, &rel)
 }
 
+/// Ceiling on bytes shipped to the webview for a preview or an image diff.
+const PREVIEW_CAP: u64 = 20_000_000;
+
 /// Read `abs` capped at `cap` bytes, TOCTOU-safe: the size/type check runs
 /// against an `fstat` on the already-OPEN handle (not a separate path-based
 /// `metadata()` call), so a swap between the check and the read (symlink
@@ -6343,7 +6352,7 @@ fn task_file_read_base64_for_task(w: &Task, path: &str, known_fp: Option<&str>) 
             return Ok(Base64Read { unchanged: true, mime: None, data: None, fp: current_fp });
         }
     }
-    let bytes = read_capped_file(&abs, 20_000_000)?;
+    let bytes = read_capped_file(&abs, PREVIEW_CAP)?;
     // Re-stat AFTER the read so `fp` is correlated with the bytes just
     // returned (not the pre-read snapshot, which a concurrent write
     // could have already invalidated).
@@ -6381,7 +6390,7 @@ fn read_preview_file_for_task(w: &Task, path: &str) -> Result<(Vec<u8>, &'static
     let (cwd, rel) = resolve_task_git_path(w, path)?;
     let abs = safe_task_path(&cwd, &rel)?;
     let mime = preview_mime_for_ext(&abs).ok_or_else(|| format!("not previewable: {path}"))?;
-    let bytes = read_capped_file(&abs, 20_000_000)?;
+    let bytes = read_capped_file(&abs, PREVIEW_CAP)?;
     Ok((bytes, mime))
 }
 
@@ -6524,12 +6533,14 @@ fn reveal_command(os: &str, target: &str) -> (&'static str, Vec<String>) {
 /// deleted in the worktree).
 #[derive(Serialize)]
 struct FileDiffSides {
+    /// Decoded contents, `kind == "text"` only — "" for image/binary, whose
+    /// bytes travel in `original_data`/`modified_data` (or not at all).
     original: String,
     modified: String,
-    /// Whether each side actually exists (and is readable as UTF-8): the
-    /// content strings are "" both for a MISSING side and for an EMPTY
-    /// file, so the frontend's one-sided detection needs these to avoid
-    /// misclassifying a truncated-to-empty file as "new or deleted".
+    /// Whether each side actually exists: the content strings are "" both for
+    /// a MISSING side and for an EMPTY file, so the frontend's one-sided
+    /// detection needs these to avoid misclassifying a truncated-to-empty
+    /// file as "new or deleted".
     original_exists: bool,
     modified_exists: bool,
     /// Working-tree fingerprint (`mtime_nanos:len`) of the modified file,
@@ -6537,6 +6548,19 @@ struct FileDiffSides {
     /// the same fingerprint the Git panel rows use (store/fileViewed.ts).
     #[serde(default)]
     fp: String,
+    /// "text" | "image" | "binary" — which body the diff pane renders. A PNG
+    /// used to decode into a screenful of U+FFFD on the deleted-line wash;
+    /// see `diff_sides_kind`.
+    kind: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mime: Option<String>,
+    /// Base64 of each side, `kind == "image"` only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    original_data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modified_data: Option<String>,
+    original_bytes: u64,
+    modified_bytes: u64,
 }
 
 /// Resolve a task-relative path to (member cwd, path relative to that
@@ -6568,7 +6592,28 @@ fn resolve_task_git_path(w: &Task, path: &str) -> Result<(PathBuf, String), Stri
     resolve_task_git_path_ex(w, path, false)
 }
 
+/// Which body the diff pane renders for these two sides. Text wins whenever
+/// every present side decodes as UTF-8, so an `.svg` (or any other textual
+/// format with an image-ish extension) keeps its line-by-line diff. Images
+/// are shipped as base64 only under the same 20 MB ceiling the preview
+/// channel uses — a bigger one would jank the webview, so it degrades to the
+/// "binary" summary rather than being sent.
+fn diff_sides_kind(abs: Option<&Path>, sides: [Option<&Vec<u8>>; 2]) -> &'static str {
+    let present = || sides.into_iter().flatten();
+    if present().all(|b| std::str::from_utf8(b).is_ok()) {
+        return "text";
+    }
+    let is_image = abs
+        .and_then(preview_mime_for_ext)
+        .is_some_and(|m| m.starts_with("image/"));
+    if is_image && present().all(|b| b.len() as u64 <= PREVIEW_CAP) {
+        return "image";
+    }
+    "binary"
+}
+
 fn task_file_diff_sides_for_task(w: &Task, path: &str, scope: Option<&str>) -> Result<FileDiffSides, String> {
+    use base64::Engine as _;
     let (cwd, rel_path) = resolve_task_git_path(w, path)?;
     // Which two sides to compare depends on where the click came from
     // (GH #122):
@@ -6581,26 +6626,46 @@ fn task_file_diff_sides_for_task(w: &Task, path: &str, scope: Option<&str>) -> R
     //
     // `git show :0:path` reads the index (stage 0); it fails for an
     // untracked path just like `show HEAD:path` fails for a new file.
-    // read_to_string fails for non-UTF8. Either way the side is
-    // unrenderable → exists=false, content "".
+    // Either way the side doesn't exist → exists=false, content "".
+    //
+    // Both sides are read as BYTES: `git()` lossily decodes, which turned a
+    // PNG blob into a screenful of replacement characters.
     let modified_path = safe_task_path(&cwd, &rel_path).ok();
+    // Uncapped, like the `git show` sides: a cap here would report an
+    // oversized file as MISSING, i.e. as a deletion. Size only decides what
+    // gets shipped to the webview (`diff_sides_kind`), not what exists.
     let read_worktree = || match &modified_path {
-        Some(p) if p.exists() => fs::read_to_string(p).ok(),
+        Some(p) if p.exists() => fs::read(p).ok(),
         _ => None,
     };
-    let show_head = || git(&["--no-pager", "show", &format!("HEAD:{rel_path}")], &cwd).ok();
-    let show_index = || git(&["--no-pager", "show", &format!(":0:{rel_path}")], &cwd).ok();
+    let show_head = || git_bytes(&["--no-pager", "show", &format!("HEAD:{rel_path}")], &cwd).ok();
+    let show_index = || git_bytes(&["--no-pager", "show", &format!(":0:{rel_path}")], &cwd).ok();
     let (original, modified) = match scope {
         Some("staged") => (show_head(), show_index()),
         Some("unstaged") => (show_index(), read_worktree()),
         _ => (show_head(), read_worktree()),
     };
     let fp = modified_path.as_deref().map(file_fp).unwrap_or_default();
+    let kind = diff_sides_kind(modified_path.as_deref(), [original.as_ref(), modified.as_ref()]);
+    let b64 = |side: &Option<Vec<u8>>| {
+        side.as_ref().map(|b| base64::engine::general_purpose::STANDARD.encode(b))
+    };
+    let text = |side: &Option<Vec<u8>>| {
+        side.as_ref().map(|b| String::from_utf8_lossy(b).into_owned()).unwrap_or_default()
+    };
     Ok(FileDiffSides {
         original_exists: original.is_some(),
         modified_exists: modified.is_some(),
-        original: original.unwrap_or_default(),
-        modified: modified.unwrap_or_default(),
+        original_bytes: original.as_ref().map(|b| b.len() as u64).unwrap_or_default(),
+        modified_bytes: modified.as_ref().map(|b| b.len() as u64).unwrap_or_default(),
+        original: if kind == "text" { text(&original) } else { String::new() },
+        modified: if kind == "text" { text(&modified) } else { String::new() },
+        mime: (kind == "image")
+            .then(|| modified_path.as_deref().and_then(preview_mime_for_ext).map(str::to_string))
+            .flatten(),
+        original_data: if kind == "image" { b64(&original) } else { None },
+        modified_data: if kind == "image" { b64(&modified) } else { None },
+        kind,
         fp,
     })
 }
@@ -11551,6 +11616,105 @@ mod tests {
         let unstaged = task_file_diff_sides_for_task(&task, "base.txt", Some("unstaged")).unwrap();
         assert_eq!(unstaged.original, "staged content\n");
         assert_eq!(unstaged.modified, "worktree content\n");
+
+        assert_eq!(full.kind, "text");
+        assert_eq!(full.original_bytes, "base content\n".len() as u64);
+    }
+
+    /// A 1×1 transparent PNG — real enough that an <img> renders it.
+    const TINY_PNG: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+        0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+        0x42, 0x60, 0x82,
+    ];
+
+    /// `git_commit_file` takes a &str, so binary fixtures commit their bytes
+    /// here instead.
+    fn git_commit_bytes(repo: &Path, name: &str, bytes: &[u8]) {
+        fs::write(repo.join(name), bytes).unwrap();
+        git_run(repo, &["add", "."]);
+        git_run(repo, &["-c", "user.name=Test", "-c", "user.email=t@t", "commit", "-m", name]);
+    }
+
+    fn task_at(dir: &Path) -> Task {
+        Task { path: dir.to_string_lossy().into_owned(), ..Default::default() }
+    }
+
+    #[test]
+    fn diff_sides_ships_both_png_sides_as_base64() {
+        use base64::Engine as _;
+        let dir = tempdir().unwrap();
+        git_init_with_commit(dir.path());
+        git_commit_bytes(dir.path(), "shot.png", TINY_PNG);
+        // Any different bytes; the modified side just has to not equal HEAD.
+        let edited: Vec<u8> = TINY_PNG.iter().copied().chain([0u8, 1, 2]).collect();
+        fs::write(dir.path().join("shot.png"), &edited).unwrap();
+
+        let sides = task_file_diff_sides_for_task(&task_at(dir.path()), "shot.png", None).unwrap();
+        assert_eq!(sides.kind, "image");
+        assert_eq!(sides.mime.as_deref(), Some("image/png"));
+        assert!(sides.original_exists && sides.modified_exists);
+        // The whole point: bytes survive the round trip instead of being
+        // lossily decoded into U+FFFD.
+        let dec = |s: &Option<String>| {
+            base64::engine::general_purpose::STANDARD.decode(s.as_ref().unwrap()).unwrap()
+        };
+        assert_eq!(dec(&sides.original_data), TINY_PNG);
+        assert_eq!(dec(&sides.modified_data), edited);
+        assert_eq!(sides.original_bytes, TINY_PNG.len() as u64);
+        assert_eq!(sides.modified_bytes, edited.len() as u64);
+        // Text fields stay empty for a non-text diff.
+        assert!(sides.original.is_empty() && sides.modified.is_empty());
+        assert!(!sides.fp.is_empty());
+    }
+
+    #[test]
+    fn diff_sides_reports_an_untracked_png_as_a_one_sided_image() {
+        let dir = tempdir().unwrap();
+        git_init_with_commit(dir.path());
+        fs::write(dir.path().join("new.png"), TINY_PNG).unwrap();
+
+        let sides = task_file_diff_sides_for_task(&task_at(dir.path()), "new.png", None).unwrap();
+        assert_eq!(sides.kind, "image");
+        assert!(!sides.original_exists);
+        assert!(sides.modified_exists);
+        assert!(sides.original_data.is_none());
+        assert!(sides.modified_data.is_some());
+        assert_eq!(sides.original_bytes, 0);
+        assert_eq!(sides.modified_bytes, TINY_PNG.len() as u64);
+    }
+
+    #[test]
+    fn diff_sides_summarizes_a_non_image_binary_without_shipping_bytes() {
+        let dir = tempdir().unwrap();
+        git_init_with_commit(dir.path());
+        git_commit_bytes(dir.path(), "blob.bin", &[0u8, 159, 146, 150]);
+        fs::write(dir.path().join("blob.bin"), [0u8, 1, 2, 3, 4, 5]).unwrap();
+
+        let sides = task_file_diff_sides_for_task(&task_at(dir.path()), "blob.bin", None).unwrap();
+        assert_eq!(sides.kind, "binary");
+        assert!(sides.mime.is_none());
+        assert!(sides.original_data.is_none() && sides.modified_data.is_none());
+        assert_eq!(sides.original_bytes, 4);
+        assert_eq!(sides.modified_bytes, 6);
+    }
+
+    #[test]
+    fn diff_sides_keeps_svg_as_a_text_diff() {
+        // SVG is in the image extension whitelist but is valid UTF-8, and a
+        // line diff of the changed attribute beats two pictures.
+        let dir = tempdir().unwrap();
+        git_init_with_commit(dir.path());
+        git_commit_bytes(dir.path(), "icon.svg", b"<svg width=\"1\"/>\n");
+        fs::write(dir.path().join("icon.svg"), "<svg width=\"2\"/>\n").unwrap();
+
+        let sides = task_file_diff_sides_for_task(&task_at(dir.path()), "icon.svg", None).unwrap();
+        assert_eq!(sides.kind, "text");
+        assert_eq!(sides.original, "<svg width=\"1\"/>\n");
+        assert_eq!(sides.modified, "<svg width=\"2\"/>\n");
+        assert!(sides.original_data.is_none() && sides.modified_data.is_none());
     }
 
     // ──────────────── spotlight git mechanics ────────────────

--- a/src/components/task/BinaryDiffBody.tsx
+++ b/src/components/task/BinaryDiffBody.tsx
@@ -1,0 +1,100 @@
+// Diff body for files CodeMirror can't render: images show Before/After
+// pictures side by side, every other binary shows a one-line summary. Before
+// this, `git show HEAD:shot.png` was decoded lossily and painted a screenful
+// of U+FFFD on the deleted-line wash. Fed by the same taskFileDiffSides call
+// the text diff uses (kind !== "text"); images arrive as base64 and render
+// through a data: URL, same channel as PreviewPane.
+
+import { useState } from "react";
+import type { DiffSides } from "@/lib/ipc";
+import { cn, formatBytes } from "@/lib/utils";
+
+// The per-line washes DiffPane paints on removed/added lines, reused here so
+// an image diff reads with the same red/green vocabulary as a text one.
+const REMOVED = "rgba(239,83,80,0.12)";
+const ADDED = "rgba(64,160,90,0.13)";
+
+// Transparent PNGs are invisible on a flat dark surface; a checkerboard is the
+// convention for "nothing here" in image tools.
+const CHECKER = {
+  backgroundImage:
+    "repeating-conic-gradient(var(--color-bg-2) 0% 25%, transparent 0% 50%)",
+  backgroundSize: "16px 16px",
+};
+
+function ImageSide({ label, data, mime, bytes, wash, className }: {
+  label: string;
+  data: string;
+  mime: string;
+  bytes: number;
+  wash: string;
+  className?: string;
+}) {
+  const [dims, setDims] = useState<string | null>(null);
+  return (
+    <div
+      className={cn("flex min-w-0 flex-1 flex-col items-center gap-2 p-4", className)}
+      style={{ background: wash }}
+    >
+      <div className="text-[11.5px] uppercase tracking-wide text-[var(--color-fg-dim)]">{label}</div>
+      <div className="flex min-h-0 flex-1 items-center justify-center" style={CHECKER}>
+        <img
+          src={`data:${mime};base64,${data}`}
+          alt={label}
+          className="max-h-full max-w-full object-contain"
+          onLoad={e => setDims(`${e.currentTarget.naturalWidth}×${e.currentTarget.naturalHeight}`)}
+        />
+      </div>
+      <div className="font-mono text-[11.5px] text-[var(--color-fg-dim)]">
+        {dims ? `${dims} · ${formatBytes(bytes)}` : formatBytes(bytes)}
+      </div>
+    </div>
+  );
+}
+
+export function BinaryDiffBody({ sides }: { sides: DiffSides }) {
+  const both = sides.original_exists && sides.modified_exists;
+  // A one-sided diff is an add or a delete: label it as such rather than
+  // showing an empty "Before" panel next to the real one.
+  const beforeLabel = both ? "Before" : "Deleted";
+  const afterLabel = both ? "After" : "Added";
+
+  if (sides.kind !== "image" || !sides.mime) {
+    return (
+      <div className="flex h-full items-center justify-center p-4">
+        <div className="font-mono text-[12.5px] text-[var(--color-fg-dim)]">
+          {both
+            ? `Binary file · ${formatBytes(sides.original_bytes)} → ${formatBytes(sides.modified_bytes)}`
+            : sides.modified_exists
+              ? `Binary file · added · ${formatBytes(sides.modified_bytes)}`
+              : `Binary file · deleted · ${formatBytes(sides.original_bytes)}`}
+        </div>
+      </div>
+    );
+  }
+
+  const mime = sides.mime;
+  return (
+    <div className="flex h-full">
+      {sides.original_data !== undefined && (
+        <ImageSide
+          label={beforeLabel}
+          data={sides.original_data}
+          mime={mime}
+          bytes={sides.original_bytes}
+          wash={REMOVED}
+        />
+      )}
+      {sides.modified_data !== undefined && (
+        <ImageSide
+          label={afterLabel}
+          data={sides.modified_data}
+          mime={mime}
+          bytes={sides.modified_bytes}
+          wash={ADDED}
+          className={sides.original_data !== undefined ? "border-l border-[var(--color-border-soft)]" : undefined}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/task/DiffPane.tsx
+++ b/src/components/task/DiffPane.tsx
@@ -5,7 +5,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import type { DiffTab, Task, GitFile } from "@/lib/types";
-import { taskFileDiffSides, taskGitStatus } from "@/lib/ipc";
+import { taskFileDiffSides, taskGitStatus, type DiffSides } from "@/lib/ipc";
+import { BinaryDiffBody } from "./BinaryDiffBody";
 import { orderedFiles, readView } from "./GitPanel";
 import { Button } from "@/components/ui/Button";
 import { FolderOpen, Columns2, AlignJustify, Eye } from "lucide-react";
@@ -60,6 +61,9 @@ export function DiffPane({ task, tab }: { task: Task; tab: DiffTab }) {
   // just show a blank pane (issue #26). We render unified instead and
   // disable the toggle, without touching the persisted preference.
   const [oneSided, setOneSided] = useState(false);
+  // Set for an image/binary file, where there are no lines to diff: the
+  // CodeMirror views are never built and BinaryDiffBody renders instead.
+  const [binary, setBinary] = useState<DiffSides | null>(null);
   // True once a comment-bearing editor is mounted (either mode). Gates the
   // header "Comment" button so it never fires into a not-yet-built view.
   const [commentable, setCommentable] = useState(false);
@@ -151,14 +155,27 @@ export function DiffPane({ task, tab }: { task: Task; tab: DiffTab }) {
     let alive = true;
     setErr(null);
     setCommentable(false);
+    setBinary(null);
     taskFileDiffSides(task.id, tab.path, tab.scope).then(sides => {
       if (!alive || !hostRef.current) return;
+      setFp(sides.fp);
+      if (sides.kind !== "text") {
+        // Tear down whatever the previous file left mounted — this pane has
+        // no editor at all, and a stale MergeView would keep rendering.
+        mergeRef.current?.destroy();
+        mergeRef.current = null;
+        editorRef.current?.destroy();
+        editorRef.current = null;
+        hostRef.current.innerHTML = "";
+        setOneSided(false);
+        setBinary(sides);
+        return;
+      }
       // Existence flags, not content emptiness — "" is what BOTH a missing
-      // side and an empty (or non-UTF8) file serialize to, and a file
-      // truncated to 0 bytes still has two real sides to compare.
+      // side and an empty file serialize to, and a file truncated to 0 bytes
+      // still has two real sides to compare.
       const degenerate = !sides.original_exists || !sides.modified_exists;
       setOneSided(degenerate);
-      setFp(sides.fp);
       // Tear any prior view down before mounting the new one.
       mergeRef.current?.destroy();
       mergeRef.current = null;
@@ -341,8 +358,12 @@ export function DiffPane({ task, tab }: { task: Task; tab: DiffTab }) {
         </ContextMenuRoot>
         <div className="flex items-center gap-1">
           {/* Side-by-side ⇄ Unified toggle. Persisted in localStorage
-              so the user's preference sticks across launches. */}
-          <div className="mr-1 inline-flex items-stretch rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-[2px]">
+              so the user's preference sticks across launches. Hidden for an
+              image/binary diff: both modes are line-based. */}
+          <div className={cn(
+            "mr-1 inline-flex items-stretch rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-[2px]",
+            binary && "hidden",
+          )}>
             <button
               type="button"
               title="Unified (inline)"
@@ -396,11 +417,15 @@ export function DiffPane({ task, tab }: { task: Task; tab: DiffTab }) {
         </div>
       </div>
       {err && <div className="p-4 font-mono text-[12.5px] text-[var(--color-err)]">Error: {err}</div>}
+      {!err && binary && <BinaryDiffBody sides={binary} />}
+      {/* Hidden rather than unmounted while `binary` renders: the effect bails
+          on a null hostRef, so unmounting the CodeMirror parent here would
+          leave the next TEXT file in this tab with nowhere to mount. */}
       {!err && (
         <div
           ref={hostRef}
           data-selectable
-          className="min-h-0 flex-1 overflow-auto"
+          className={cn("min-h-0 flex-1 overflow-auto", binary && "hidden")}
         />
       )}
     </div>

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -328,10 +328,25 @@ export const taskSpotlightStatus  = ()           => invoke<Record<string, string
 export const terminalStageFile = (taskId: string, src: string) =>
   invoke<string>("terminal_stage_file", { taskId, src });
 export const taskFileDiff = (id: string, path: string) => invoke<string>("task_file_diff", { id, path });
+/** Both sides of a file diff. `kind` picks the body the diff pane renders:
+ *  "text" carries `original`/`modified` for CodeMirror, "image" carries the
+ *  base64 of each side (+ `mime`) for an <img>, "binary" carries neither and
+ *  only the byte counts are shown. */
+export type DiffSides = {
+  original: string;
+  modified: string;
+  original_exists: boolean;
+  modified_exists: boolean;
+  fp: string;
+  kind: "text" | "image" | "binary";
+  mime?: string;
+  original_data?: string;
+  modified_data?: string;
+  original_bytes: number;
+  modified_bytes: number;
+};
 export const taskFileDiffSides = (id: string, path: string, scope?: "unstaged" | "staged") =>
-  invoke<{ original: string; modified: string; original_exists: boolean; modified_exists: boolean; fp: string }>(
-    "task_file_diff_sides", { id, path, scope: scope ?? null },
-  );
+  invoke<DiffSides>("task_file_diff_sides", { id, path, scope: scope ?? null });
 export const taskFileRead = (id: string, path: string) => invoke<string>("task_file_read", { id, path });
 /** Read a task image or PDF as base64, for the markdown preview's inline
  *  images or the file-tree preview pane (image/PDF extensions, 20 MB cap).

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { slugify, branchify, shortPath } from "@/lib/utils";
+import { slugify, branchify, shortPath, formatBytes } from "@/lib/utils";
 
 // ── slugify ───────────────────────────────────────────────────────────
 
@@ -91,5 +91,35 @@ describe("shortPath", () => {
 
   it("handles root-like single segment without truncation", () => {
     expect(shortPath("/foo")).toBe("/foo");
+  });
+});
+
+// ── formatBytes ───────────────────────────────────────────────────────
+
+describe("formatBytes", () => {
+  it("shows raw bytes below 1 KB", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(812)).toBe("812 B");
+    expect(formatBytes(999)).toBe("999 B");
+  });
+
+  it("switches to KB at 1000 bytes", () => {
+    expect(formatBytes(1000)).toBe("1.0 KB");
+    expect(formatBytes(2450)).toBe("2.5 KB");
+  });
+
+  it("drops the decimal at 10 units and above", () => {
+    expect(formatBytes(9950)).toBe("10 KB");
+    expect(formatBytes(245_000)).toBe("245 KB");
+  });
+
+  it("steps up through MB and GB", () => {
+    expect(formatBytes(1_400_000)).toBe("1.4 MB");
+    expect(formatBytes(20_000_000)).toBe("20 MB");
+    expect(formatBytes(3_200_000_000)).toBe("3.2 GB");
+  });
+
+  it("stays in GB beyond the largest unit", () => {
+    expect(formatBytes(5_000_000_000_000)).toBe("5000 GB");
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,6 +27,19 @@ export function cleanLines(input: string | string[]): string[] {
   return arr.map(l => l.trim()).filter(Boolean);
 }
 
+/** Byte count as "812 B" / "245 KB" / "1.4 MB" (decimal units, one decimal
+ *  place below 10 of a unit). */
+export function formatBytes(n: number) {
+  if (n < 1000) return `${n} B`;
+  const units = ["KB", "MB", "GB"];
+  let v = n / 1000;
+  let i = 0;
+  while (v >= 1000 && i < units.length - 1) { v /= 1000; i++; }
+  // 9.95, not 10: toFixed(1) would round it up to a "10.0" that contradicts
+  // the one-decimal-below-10 rule.
+  return v < 9.95 ? `${v.toFixed(1)} ${units[i]}` : `${Math.round(v)} ${units[i]}`;
+}
+
 /** Truncate path to "…/last/two/segments" when it gets long. */
 export function shortPath(p: string, segments = 2) {
   const parts = p.split("/").filter(Boolean);


### PR DESCRIPTION
## The problem

Opening a diff tab for a PNG (a visual-regression screenshot, an icon, anything binary) paints a full screen of U+FFFD replacement characters on the red deleted-line wash. There is no way to see what changed in the picture.

Root cause is one line: `git()` ends with `String::from_utf8_lossy(&out.stdout)`, so the `git show HEAD:<path>` side of `task_file_diff_sides_for_task` arrives as replacement characters. The worktree side used `fs::read_to_string`, which *fails* on binary, so `modified_exists` came back `false` and the pane treated a modified image as a deletion, rendering the garbage as one giant deleted block.

## What this does

**Backend**
- `git_bytes()` returns raw stdout; `git()` is now a thin lossy wrapper over it, so every existing caller is unchanged.
- Both diff sides are read as bytes and classified into `kind`: `text` when every present side is valid UTF-8, `image` for an `image/*` extension within the 20 MB preview ceiling, `binary` otherwise. `FileDiffSides` carries `kind`, `mime`, base64 sides, and byte counts.
- `.svg` keeps its line-by-line text diff. It is valid UTF-8, so it classifies as text naturally, with no extension special-case.
- The repeated `20_000_000` preview ceiling becomes `PREVIEW_CAP`. The worktree read stays uncapped like the git sides, so an oversized file is never mistaken for a deletion; size only decides what gets shipped to the webview.

**Frontend**
- New `BinaryDiffBody`: side-by-side Before/After pictures with per-side dimensions and file size, over a checkerboard so transparency reads. One-sided diffs render a single Added/Deleted panel. Non-image binaries get a one-line `Binary file - 245 KB -> 251 KB` summary instead of garbage.
- `DiffPane` branches on `kind` and constructs no CodeMirror view at all for those files. The header keeps the path, Open, and Mark as viewed (the review walk is unaffected); the unified/side-by-side toggle and Comment are hidden, since both are line-anchored.

No `tauri.conf.json`, capability, or dependency changes: the CSP already allows `img-src ... data:`, and this reuses the existing base64-over-IPC channel that `PreviewPane` uses.

## Screenshot

Before: a wall of replacement characters. After:

```
+-------------------+-------------------+
|      BEFORE       |       AFTER       |
|  +-------------+  |  +-------------+  |
|  |    <img>    |  |  |    <img>    |  |
|  +-------------+  |  +-------------+  |
| 1200x800 - 245 KB | 1200x800 - 251 KB |
+-------------------+-------------------+
```

<img width="1503" height="1000" alt="image" src="https://github.com/user-attachments/assets/b57435ab-ee02-4cb2-bd0c-2b04e572dc9a" />

<img width="1503" height="1009" alt="image" src="https://github.com/user-attachments/assets/f8200ef7-3ef2-438a-b998-cdf4e84ee536" />


## Tests

- **Rust** (`cargo test`, 281 passing): a modified PNG ships both sides as base64 that decode back to the exact committed and on-disk bytes; an untracked PNG is one-sided; a non-image binary reports sizes without shipping bytes; a modified `.svg` stays `kind == "text"` with intact contents.
- **Vitest** (`npm test`, 492 passing): `formatBytes` cases.
- **e2e** (`make e2e`): a new `image diff` describe in `git.e2e.ts` asserts two decoded `<img>` sides with their dimensions and no `.cm-editor`, plus a negative control that a text diff still mounts CodeMirror. The fixture repo now seeds a committed 1x1 PNG. `git.e2e.ts` passes 10/10.
- Also added the e2e case that was missing for `PreviewPane`: clicking an image in the file tree renders decoded pixels (`files.e2e.ts`, 10/10).

Per CONTRIBUTING/CLAUDE.md this touches no `CHANGELOG.md` entry and no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHvBcBWY3JiLy3zP1a8jPR