### PR TITLE
feat: show the git branch in the DEV/E2E pill

### DIFF
--- a/src/components/UpdaterBanner.tsx
+++ b/src/components/UpdaterBanner.tsx
@@ -45,30 +45,31 @@ export function UpdaterBanner() {
   // indistinguishable at a glance. Absent in release builds, where the
   // Beta pill already names what it was built from.
   const branch: string | undefined = import.meta.env.VITE_GIT_BRANCH;
+  // A detached HEAD reports the literal "HEAD", which is worth showing: it
+  // means the window is not on any branch, so it is probably not running
+  // what you think it is.
+  const branchLabel = branch ? (
+    <span className="max-w-[220px] truncate font-mono text-[10px] font-normal normal-case tracking-normal opacity-80">
+      {branch}
+    </span>
+  ) : null;
+  const branchTitle = branch ? ` Branch: ${branch}.` : "";
   if (import.meta.env.DEV && !update && !hideDevPill) {
     return isE2E ? (
       <span
-        title={`Driven by the e2e automation bridge (TERMIC_AUTOMATION=1).${branch ? ` Branch: ${branch}.` : ""}`}
+        title={`Driven by the e2e automation bridge (TERMIC_AUTOMATION=1).${branchTitle}`}
         className="flex select-none items-center gap-1.5 rounded-full border border-[var(--color-err)]/50 bg-[var(--color-err)]/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-err)]"
       >
         E2E
-        {branch && (
-          <span className="max-w-[220px] truncate font-mono text-[10px] font-normal normal-case tracking-normal opacity-80">
-            {branch}
-          </span>
-        )}
+        {branchLabel}
       </span>
     ) : (
       <span
-        title={`Development build, not a released version.${branch ? ` Branch: ${branch}.` : ""}`}
+        title={`Development build, not a released version.${branchTitle}`}
         className="flex select-none items-center gap-1.5 rounded-full border border-[var(--color-warn)]/40 bg-[var(--color-warn)]/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-warn)]"
       >
         DEV
-        {branch && (
-          <span className="max-w-[220px] truncate font-mono text-[10px] font-normal normal-case tracking-normal opacity-80">
-            {branch}
-          </span>
-        )}
+        {branchLabel}
       </span>
     );
   }

--- a/src/components/UpdaterBanner.tsx
+++ b/src/components/UpdaterBanner.tsx
@@ -40,20 +40,35 @@ export function UpdaterBanner() {
   const hideDevPill =
     import.meta.env.VITE_HIDE_DEV_PILL === "1" ||
     import.meta.env.VITE_HIDE_DEV_PILL === "true";
+  // Injected by vite.config.ts from `git rev-parse --abbrev-ref HEAD` at
+  // dev-server startup. One `tauri dev` window per worktree is otherwise
+  // indistinguishable at a glance. Absent in release builds, where the
+  // Beta pill already names what it was built from.
+  const branch: string | undefined = import.meta.env.VITE_GIT_BRANCH;
   if (import.meta.env.DEV && !update && !hideDevPill) {
     return isE2E ? (
       <span
-        title="Driven by the e2e automation bridge (TERMIC_AUTOMATION=1)."
-        className="flex select-none items-center rounded-full border border-[var(--color-err)]/50 bg-[var(--color-err)]/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-err)]"
+        title={`Driven by the e2e automation bridge (TERMIC_AUTOMATION=1).${branch ? ` Branch: ${branch}.` : ""}`}
+        className="flex select-none items-center gap-1.5 rounded-full border border-[var(--color-err)]/50 bg-[var(--color-err)]/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-err)]"
       >
         E2E
+        {branch && (
+          <span className="max-w-[220px] truncate font-mono text-[10px] font-normal normal-case tracking-normal opacity-80">
+            {branch}
+          </span>
+        )}
       </span>
     ) : (
       <span
-        title="Development build, not a released version."
-        className="flex select-none items-center rounded-full border border-[var(--color-warn)]/40 bg-[var(--color-warn)]/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-warn)]"
+        title={`Development build, not a released version.${branch ? ` Branch: ${branch}.` : ""}`}
+        className="flex select-none items-center gap-1.5 rounded-full border border-[var(--color-warn)]/40 bg-[var(--color-warn)]/15 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-warn)]"
       >
         DEV
+        {branch && (
+          <span className="max-w-[220px] truncate font-mono text-[10px] font-normal normal-case tracking-normal opacity-80">
+            {branch}
+          </span>
+        )}
       </span>
     );
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
+import { execSync } from "node:child_process";
 
 // Tauri dev runs us via `tauri dev`. The default port is 1420; set the
 // PORT env var to run on another port (`PORT=1430 npm run tauri:dev`) —
@@ -9,6 +10,23 @@ import path from "node:path";
 // port+1. strictPort stays true — a silent fallback port would just
 // leave Tauri loading a blank window.
 const devPort = Number(process.env.PORT) || 1420;
+
+// Surface which branch a dev window is running so multiple `tauri:dev`
+// instances (one per worktree) are distinguishable in the DEV/E2E pill
+// (UpdaterBanner.tsx). Setting process.env here (rather than a `define`)
+// lets Vite's normal VITE_-prefix pickup expose it as
+// import.meta.env.VITE_GIT_BRANCH, the same mechanism as VITE_MOCK_UPDATE.
+if (!process.env.VITE_GIT_BRANCH) {
+  try {
+    process.env.VITE_GIT_BRANCH = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd: __dirname,
+    })
+      .toString()
+      .trim();
+  } catch {
+    // Not a git checkout (e.g. a release build's source archive), leave unset.
+  }
+}
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,11 @@ if (!process.env.VITE_GIT_BRANCH) {
   try {
     process.env.VITE_GIT_BRANCH = execSync("git rev-parse --abbrev-ref HEAD", {
       cwd: __dirname,
+      // Silence git's own stderr. Building from a source archive with no
+      // .git would otherwise print "fatal: not a git repository" on every
+      // start, which reads like a build failure when it is the expected
+      // fallback below.
+      stdio: ["ignore", "pipe", "ignore"],
     })
       .toString()
       .trim();


### PR DESCRIPTION
A dev window gives no sign of which branch it is running. That costs in two ways: several `tauri:dev` windows (one per worktree) look identical on screen, and even a single window leaves you to remember what is actually under test. This puts the current git branch in the existing DEV/E2E pill, so the answer is on screen rather than recalled.

## UX

<img width="524" height="173" alt="image" src="https://github.com/user-attachments/assets/3132bf9a-0950-467b-98a5-f7e649f286c5" />
<img width="515" height="158" alt="image" src="https://github.com/user-attachments/assets/260b90c8-551c-46b4-8b13-b232a4dc7f42" />


In a dev build the pill now reads `DEV feature/my-branch` instead of a bare `DEV`, with the branch in a smaller monospace face at reduced opacity so the badge still reads as the primary element. Under the e2e automation bridge the same treatment applies to the red `E2E` pill. The tooltip gains a `Branch: <name>.` sentence.

The point is not only telling parallel windows apart. It is a standing reminder of what you are testing, visible for as long as the window is open. Without it the failure mode is quiet and expensive: you exercise a fix, see it work, and only later find the window was running a different branch. A wrong-window pass is worse than no test, because it reads as a confirmation.

Long branch names truncate with an ellipsis at 220px so the pill cannot push the rest of the bar around.

Three cases render exactly as they do today:

- Release builds, where the var is never set
- A source tree that is not a git checkout
- `VITE_HIDE_DEV_PILL=1`, the existing opt out for screen recordings

The Beta pill is deliberately untouched, since it already names the branch it was built from.

## Technical change

`vite.config.ts` runs `git rev-parse --abbrev-ref HEAD` once at dev-server startup and assigns the result to `process.env.VITE_GIT_BRANCH`. Setting the env var rather than adding a `define` means Vite's normal `VITE_` prefix pickup exposes it as `import.meta.env.VITE_GIT_BRANCH`, the same mechanism `VITE_MOCK_UPDATE` already uses, so no new build plumbing is introduced.

Two details worth noting for review:

- The `execSync` call is wrapped in `try`/`catch`. A source archive with no `.git` leaves the var unset, and `UpdaterBanner` already guards on `branch &&`, so the pill falls back to its current appearance.
- The assignment is guarded by `if (!process.env.VITE_GIT_BRANCH)`, which lets a caller override the value explicitly.

Because the value is read once at startup, a branch switch inside a running dev server leaves the pill stale until restart. Worth knowing given the reminder framing above, though in the worktree-per-branch workflow this drives, a window's branch does not change under it.

The env var is set on every Vite invocation, not just dev, but the render path sits behind `import.meta.env.DEV`. I verified the branch name does not reach shipped artifacts: after `npm run build`, neither the branch string nor the `VITE_GIT_BRANCH` token appears anywhere in `dist/`, because the statically false `DEV` branch is dead-code eliminated.

## Test coverage

No new automated tests. The change is a dev-only render path plus a build-config env assignment, and the existing suite has no coverage of `UpdaterBanner`'s pill variants to extend.

Verified manually:

- `npx tsc -b` clean, `npm run build` succeeds
- Full suite green, 493 tests across 33 files
- Ran the app through the e2e automation bridge and read the rendered pill: text `E2E feature/branch-indicator`, tooltip `Driven by the e2e automation bridge (TERMIC_AUTOMATION=1). Branch: feature/branch-indicator.`
- Measured the branch span in the live webview at `scrollWidth === clientWidth === 144`, confirming no truncation at the 220px cap

Known gap: the non-git fallback and the release-build path were reasoned through and checked against the built bundle, but not exercised in a real packaged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
