### PR TITLE
Pin that task_file_fp rejects a symlink escaping the worktree

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11373,6 +11373,25 @@ mod tests {
     }
 
     #[test]
+    fn task_file_fp_for_task_rejects_a_symlink_escaping_the_worktree() {
+        // A `.pdf` NAME is not a `.pdf` LOCATION: containment is decided by
+        // `safe_task_path`, which canonicalizes through the symlink before
+        // the extension is ever looked at, so an in-worktree link pointing
+        // out cannot turn this into a stat oracle for the whole disk.
+        let outside = tempdir().unwrap();
+        fs::write(outside.path().join("elsewhere.pdf"), b"%PDF-1.4\n").unwrap();
+        let ws = tempdir().unwrap();
+        std::os::unix::fs::symlink(
+            outside.path().join("elsewhere.pdf"),
+            ws.path().join("looks-local.pdf"),
+        )
+        .unwrap();
+        let task = Task { path: ws.path().to_string_lossy().into_owned(), ..Default::default() };
+
+        assert!(task_file_fp_for_task(&task, "looks-local.pdf").is_err());
+    }
+
+    #[test]
     fn task_file_fp_for_task_errors_on_a_missing_file() {
         // Same answer the base64 read gives; the PDF pane keeps whatever it
         // has on screen rather than reloading on it.


### PR DESCRIPTION
Follow-up to the review question on #148: would a symlink named `.pdf`, pointing outside the worktree, pass `task_file_fp`'s extension check?

It would pass the extension check, but that check is not what holds the line, and the ordering is easy to misread from the diff:

```rust
let abs = safe_task_path(&cwd, &rel)?;                 // canonicalizes, then contains
preview_mime_for_ext(&abs).ok_or_else(...)?;           // only then, on the real path
Ok(file_fp(&abs))
```

`safe_task_path` canonicalizes the target, which resolves the symlink, and rejects anything whose real path falls outside the task root. `preview_mime_for_ext` runs afterwards and answers "what kind of file is this", not "is this file mine to read". Same order as `task_file_read_base64_for_task` and `read_preview_file_for_task`.

So the behavior was already correct, but inherited rather than stated. This states it: a symlink inside the worktree, a real `.pdf` outside, and an assertion that the fingerprint is refused. `safe_task_path_rejects_symlink_escape` already covers the helper; this covers the caller, which is where a future reordering would do the damage.

Two limits it deliberately does not claim:

- A `repo_root` composition member canonicalizes outside the wrapper by design, since its own root is the base.
- There is a TOCTOU window between `canonicalize` and `metadata` that leaks at most `mtime:len`. The base64 read shares it, with a far bigger prize behind it.

Test only, no production change. `cargo test` 286 passing, `make check-all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)