### PR TITLE
Double-click a file in the tree to open it in the OS default app

### DIFF
--- a/e2e/specs/files.e2e.ts
+++ b/e2e/specs/files.e2e.ts
@@ -385,22 +385,18 @@ describe("file tree", () => {
   });
 });
 
-// P2: double-clicking a file row hands it to the OS default app (GH #147).
-// Cases: a binary the editor can't render (.blend) and a text file the editor
-// CAN render (.scad) both fire the external open — that is the whole point of
-// the branch choice, since restricting it to unreadable files would have
-// missed .scad, where the user wants OpenSCAD rather than the source again.
-// Plus the negative: an ordinary single click must NOT launch anything.
+// P2: the file row's right-click menu hands the file to the OS (GH #147).
+// Cases: the two OS actions lead the menu in the agreed order; a binary the
+// editor can't render (.blend), a text file it CAN render (.scad) and an image
+// with its own in-app viewer (.png) all open externally; a folder offers no
+// "Open in default app"; and double-click still PINS rather than launching.
 //
-// SCOPE, and why the clicks below are synthetic. WebDriver cannot express a
-// double-click in this WKWebView: a driven `doubleClick()` emits two `click`
-// events with `detail: 0` and NO `dblclick` at all (measured). So no spec can
-// prove the OS-level gesture arrives; these dispatch the click the handler
-// actually reads (`detail: 2`) and cover everything downstream of it — the
-// branch, the path handed to the backend, and the single-click regression.
-// The gesture itself is a manual check.
+// The .scad case is the one that settled the design discussion: it is plain
+// text, so the editor renders it perfectly, yet the user still wants OpenSCAD.
+// No "is this file renderable" heuristic can express that, which is why this
+// lives on an explicit menu entry rather than a gesture.
 //
-// The e2e binary records the open instead of running it (see
+// The e2e binary records opens to a log instead of running them (see
 // `open_file_external` in lib.rs): the suite must not launch Blender, and the
 // reveal fallback would pop a Finder window over the window under test.
 describe("open a file in its default app", () => {
@@ -409,9 +405,10 @@ describe("open a file in its default app", () => {
 
   after(async () => {
     rmSync(openedLog, { force: true });
-    rmSync(path.join(fixture, "e2e-model.blend"), { force: true });
-    rmSync(path.join(fixture, "e2e-part.scad"), { force: true });
-    rmSync(path.join(fixture, "e2e-shot.png"), { force: true });
+    for (const f of ["e2e-model.blend", "e2e-part.scad", "e2e-shot.png"]) {
+      rmSync(path.join(fixture, f), { force: true });
+    }
+    rmSync(path.join(fixture, "e2e-open-dir"), { force: true, recursive: true });
     if (taskId) await archiveTask(taskId);
   });
 
@@ -423,31 +420,71 @@ describe("open a file in its default app", () => {
     }
   };
 
-  // `detail` is the UA's click count; 2 is the second click of a pair, which
-  // is what FileTree reads instead of a dblclick handler (see the comment on
-  // its onClick for why).
-  const clickRowWithDetail = (rel: string, detail: number) =>
-    browser.execute(
-      (sel, d) => {
-        const el = document.querySelector(sel) as HTMLElement;
-        if (!el) throw new Error(`no row ${sel}`);
-        el.dispatchEvent(new MouseEvent("click", { detail: d, bubbles: true, cancelable: true }));
-      },
-      `[data-path="${rel}"]`,
-      detail,
-    );
+  // Dispatched, not driven: a WebDriver right-click does not reach Radix's
+  // onContextMenu in this WKWebView (measured), the same class of gap as its
+  // double-click. A `contextmenu` MouseEvent goes through the real Radix
+  // trigger, so everything from the menu opening downwards is genuinely
+  // exercised — which the gesture-based version could never claim.
+  const openRowMenu = async (rel: string) => {
+    await browser.execute((sel) => {
+      const el = document.querySelector(sel) as HTMLElement;
+      if (!el) throw new Error(`no row ${sel}`);
+      const r = el.getBoundingClientRect();
+      el.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true, cancelable: true, button: 2,
+          clientX: r.left + 10, clientY: r.top + 10,
+        }),
+      );
+    }, `[data-path="${rel}"]`);
+    await browser.waitUntil(async () => (await menuItems()).length > 0, {
+      timeout: 8_000,
+      timeoutMsg: `the context menu never opened for ${rel}`,
+    });
+  };
 
-  const doubleClickRow = async (rel: string) => {
+  // Scoped to the menu that holds the path items, never a bare [role="menu"]:
+  // menus stack, and a closing one can linger in the DOM (see the e2e skill).
+  //
+  // Labels come from innerText, one line per item, NOT from a [role="menuitem"]
+  // query: ContextMenuItem passes role={undefined} for plain items (it only
+  // sets a role for the radio variant), so the ARIA selector matches nothing.
+  const menuItems = () =>
+    browser.execute(() => {
+      const menu = [...document.querySelectorAll('[role="menu"]')].find((m) =>
+        (m as HTMLElement).innerText.includes("Copy path"),
+      ) as HTMLElement | undefined;
+      if (!menu) return [] as string[];
+      return menu.innerText.split("\n").map((s) => s.trim()).filter(Boolean);
+    });
+
+  const clickMenuItem = (label: string) =>
+    browser.execute((text) => {
+      const menu = [...document.querySelectorAll('[role="menu"]')].find((m) =>
+        (m as HTMLElement).innerText.includes("Copy path"),
+      ) as HTMLElement | undefined;
+      if (!menu) throw new Error("the path context menu is not open");
+      // Deepest element whose own text is exactly the label, so a wrapper that
+      // happens to contain it doesn't get clicked instead.
+      const item = [...menu.querySelectorAll("*")]
+        .reverse()
+        .find((i) => (i as HTMLElement).innerText?.trim() === text) as HTMLElement | undefined;
+      if (!item) throw new Error(`no menu item "${text}"`);
+      item.click();
+    }, label);
+
+  const openExternally = async (rel: string) => {
     rmSync(openedLog, { force: true });
-    await clickRowWithDetail(rel, 2);
+    await openRowMenu(rel);
+    await clickMenuItem("Open in default app");
     await browser.waitUntil(() => opened().length > 0, {
       timeout: 8_000,
-      timeoutMsg: `double-clicking ${rel} never reached open_file_external`,
+      timeoutMsg: `"Open in default app" on ${rel} never reached the backend`,
     });
     return opened();
   };
 
-  it("opens a binary the editor cannot render", async () => {
+  it("leads the menu with the two OS actions, in order", async () => {
     await waitForAppShell();
     await requireTermicApi();
 
@@ -455,8 +492,10 @@ describe("open a file in its default app", () => {
     // up on its initial load rather than through a mid-run refresh.
     writeFileSync(path.join(fixture, "e2e-model.blend"), Buffer.from([0x00, 0xff, 0x00]));
     writeFileSync(path.join(fixture, "e2e-part.scad"), "cube([1,1,1]);\n");
-    // A 1x1 PNG: the third routing class, the one with its OWN in-app viewer
-    // (previewPaths → PreviewPane) rather than the editor.
+    // This describe's own folder, so the dir case does not depend on one that
+    // another describe creates in a different task.
+    mkdirSync(path.join(fixture, "e2e-open-dir"), { recursive: true });
+    // A 1x1 PNG: the routing class with its OWN in-app viewer (previewPaths).
     writeFileSync(
       path.join(fixture, "e2e-shot.png"),
       Buffer.from(
@@ -473,67 +512,86 @@ describe("open a file in its default app", () => {
       { timeout: 15_000, timeoutMsg: "the .blend row never appeared in the tree" },
     );
 
-    // .blend is not valid UTF-8, so a single click only ever gets the "it
-    // looks binary" editor message. The case with no in-app answer at all.
-    const paths = await doubleClickRow("e2e-model.blend");
+    await openRowMenu("e2e-model.blend");
+    const items = await menuItems();
+    expect(items[0]).toBe("Open in default app");
+    expect(items[1]).toMatch(/^Reveal in /);
+    await snap("file-context-menu.png");
+    await browser.keys(["Escape"]);
+  });
+
+  it("opens a binary the editor cannot render", async () => {
+    // .blend is not valid UTF-8, so clicking it only ever gets the "it looks
+    // binary" editor message. The case with no in-app answer at all.
+    const paths = await openExternally("e2e-model.blend");
     expect(paths.some((p) => p.endsWith("/e2e-model.blend"))).toBe(true);
     // Absolute, not task-relative: the backend shells out with no task context.
     expect(paths[paths.length - 1].startsWith("/")).toBe(true);
-    await snap("file-open-default-app.png");
   });
 
   it("opens a text file the editor renders perfectly well", async () => {
-    // .scad is plain text — the editor shows it fine, and that is exactly why
-    // "only for files the editor can't render" was the wrong rule.
-    const paths = await doubleClickRow("e2e-part.scad");
+    const paths = await openExternally("e2e-part.scad");
     expect(paths.some((p) => p.endsWith("/e2e-part.scad"))).toBe(true);
   });
 
   it("opens an image that has its own in-app viewer", async () => {
-    // A PNG already previews inside the app, so this is the case where the
-    // external open is a genuine ADDITION rather than the only way to see the
-    // file. It must still fire: "the app can show it" is not a reason to keep
-    // the user from opening it in a real image editor.
-    const paths = await doubleClickRow("e2e-shot.png");
+    // A PNG already previews in the app, so the external open is an ADDITION
+    // here. "termic can show it" is not a reason to withhold the real editor.
+    const paths = await openExternally("e2e-shot.png");
     expect(paths.some((p) => p.endsWith("/e2e-shot.png"))).toBe(true);
   });
 
-  it("still routes a single click to the in-app preview pane", async () => {
-    // The other half of the PNG case: single click must NOT launch anything,
-    // it must open the tab the preview pane renders (previewPaths routes on
-    // extension, so the tab is an "edit" tab that PreviewPane picks up).
-    rmSync(openedLog, { force: true });
-    await clickRowWithDetail("e2e-shot.png", 1);
-    await browser.waitUntil(
-      () =>
-        browser.execute(
-          (id) =>
-            (window.__termic!.useApp.getState().tabs[id] ?? []).some(
-              (t: any) => t.type === "edit" && t.path === "e2e-shot.png",
-            ),
-          taskId,
-        ),
-      { timeout: 8_000, timeoutMsg: "a single click no longer opens the image tab" },
-    );
-    expect(opened()).toEqual([]);
+  it("offers no default-app entry for a folder", async () => {
+    // `openPath` on a directory already means "open it in the file manager",
+    // so a folder would otherwise show the same action twice.
+    await openRowMenu("e2e-open-dir");
+    const items = await menuItems();
+    expect(items).not.toContain("Open in default app");
+    expect(items[0]).toMatch(/^Open in /);   // the file-manager entry leads
+    await browser.keys(["Escape"]);
   });
 
-  it("opens the editor tab on a single click, launching nothing", async () => {
-    // The other half of the branch: single click keeps its old job, and must
-    // NOT hand the file to the OS. A regression here would launch an app on
-    // every click in the tree.
+  it("keeps double-click as pin, launching nothing", async () => {
+    // The convention Simion flagged: single click previews, double click keeps
+    // the tab. A regression here would launch an app from a gesture that every
+    // major editor uses for pinning.
     rmSync(openedLog, { force: true });
-    await clickRowWithDetail("e2e-part.scad", 1);
+    const previewTabs = () =>
+      browser.execute(
+        (id) =>
+          (window.__termic!.useApp.getState().tabs[id] ?? [])
+            .filter((t: any) => t.type === "edit" && t.path === "e2e-part.scad").length,
+        taskId,
+      );
+    await browser.execute(
+      (sel) => (document.querySelector(sel) as HTMLElement).click(),
+      '[data-path="e2e-part.scad"]',
+    );
+    // Wait for the tab before the second click: onDoubleClick looks the tab up
+    // in the `tabs` array from its own render, so firing both in one
+    // synchronous block would hand it a stale list and pin nothing. A real
+    // user's two clicks are separated by a re-render; this reproduces that.
+    await browser.waitUntil(async () => (await previewTabs()) > 0, {
+      timeout: 8_000,
+      timeoutMsg: "the first click never opened a preview tab",
+    });
+    await browser.execute(
+      (sel) =>
+        (document.querySelector(sel) as HTMLElement).dispatchEvent(
+          new MouseEvent("dblclick", { bubbles: true, cancelable: true }),
+        ),
+      '[data-path="e2e-part.scad"]',
+    );
     await browser.waitUntil(
       () =>
         browser.execute(
           (id) =>
             (window.__termic!.useApp.getState().tabs[id] ?? []).some(
-              (t: any) => t.type === "edit" && t.path === "e2e-part.scad",
+              (t: any) => t.type === "edit" && t.path === "e2e-part.scad" && !t.preview,
             ),
           taskId,
         ),
-      { timeout: 8_000, timeoutMsg: "a single click no longer opens the editor tab" },
+      { timeout: 8_000, timeoutMsg: "double-click no longer pins the preview tab" },
     );
     expect(opened()).toEqual([]);
   });

--- a/e2e/specs/files.e2e.ts
+++ b/e2e/specs/files.e2e.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { archiveTask, dismissOverlays, ensureActiveTask, openTask, requireTermicApi, snap, waitForAppShell } from "../helpers";
 
@@ -385,3 +385,156 @@ describe("file tree", () => {
   });
 });
 
+// P2: double-clicking a file row hands it to the OS default app (GH #147).
+// Cases: a binary the editor can't render (.blend) and a text file the editor
+// CAN render (.scad) both fire the external open — that is the whole point of
+// the branch choice, since restricting it to unreadable files would have
+// missed .scad, where the user wants OpenSCAD rather than the source again.
+// Plus the negative: an ordinary single click must NOT launch anything.
+//
+// SCOPE, and why the clicks below are synthetic. WebDriver cannot express a
+// double-click in this WKWebView: a driven `doubleClick()` emits two `click`
+// events with `detail: 0` and NO `dblclick` at all (measured). So no spec can
+// prove the OS-level gesture arrives; these dispatch the click the handler
+// actually reads (`detail: 2`) and cover everything downstream of it — the
+// branch, the path handed to the backend, and the single-click regression.
+// The gesture itself is a manual check.
+//
+// The e2e binary records the open instead of running it (see
+// `open_file_external` in lib.rs): the suite must not launch Blender, and the
+// reveal fallback would pop a Finder window over the window under test.
+describe("open a file in its default app", () => {
+  let taskId: string | undefined;
+  const openedLog = path.join(process.cwd(), ".e2e", "profile", "e2e-opened.log");
+
+  after(async () => {
+    rmSync(openedLog, { force: true });
+    rmSync(path.join(fixture, "e2e-model.blend"), { force: true });
+    rmSync(path.join(fixture, "e2e-part.scad"), { force: true });
+    rmSync(path.join(fixture, "e2e-shot.png"), { force: true });
+    if (taskId) await archiveTask(taskId);
+  });
+
+  const opened = () => {
+    try {
+      return readFileSync(openedLog, "utf8").split("\n").filter(Boolean);
+    } catch {
+      return [];   // not written yet — the caller is inside a waitUntil
+    }
+  };
+
+  // `detail` is the UA's click count; 2 is the second click of a pair, which
+  // is what FileTree reads instead of a dblclick handler (see the comment on
+  // its onClick for why).
+  const clickRowWithDetail = (rel: string, detail: number) =>
+    browser.execute(
+      (sel, d) => {
+        const el = document.querySelector(sel) as HTMLElement;
+        if (!el) throw new Error(`no row ${sel}`);
+        el.dispatchEvent(new MouseEvent("click", { detail: d, bubbles: true, cancelable: true }));
+      },
+      `[data-path="${rel}"]`,
+      detail,
+    );
+
+  const doubleClickRow = async (rel: string) => {
+    rmSync(openedLog, { force: true });
+    await clickRowWithDetail(rel, 2);
+    await browser.waitUntil(() => opened().length > 0, {
+      timeout: 8_000,
+      timeoutMsg: `double-clicking ${rel} never reached open_file_external`,
+    });
+    return opened();
+  };
+
+  it("opens a binary the editor cannot render", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+
+    // Written BEFORE the task opens, at the repo root, so the tree picks them
+    // up on its initial load rather than through a mid-run refresh.
+    writeFileSync(path.join(fixture, "e2e-model.blend"), Buffer.from([0x00, 0xff, 0x00]));
+    writeFileSync(path.join(fixture, "e2e-part.scad"), "cube([1,1,1]);\n");
+    // A 1x1 PNG: the third routing class, the one with its OWN in-app viewer
+    // (previewPaths → PreviewPane) rather than the editor.
+    writeFileSync(
+      path.join(fixture, "e2e-shot.png"),
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+        "base64",
+      ),
+    );
+
+    taskId = await openTask("e2e-open");
+    await dismissOverlays();
+    await ensureActiveTask(taskId);
+    await browser.waitUntil(
+      () => browser.execute(() => !!document.querySelector('[data-path="e2e-model.blend"]')),
+      { timeout: 15_000, timeoutMsg: "the .blend row never appeared in the tree" },
+    );
+
+    // .blend is not valid UTF-8, so a single click only ever gets the "it
+    // looks binary" editor message. The case with no in-app answer at all.
+    const paths = await doubleClickRow("e2e-model.blend");
+    expect(paths.some((p) => p.endsWith("/e2e-model.blend"))).toBe(true);
+    // Absolute, not task-relative: the backend shells out with no task context.
+    expect(paths[paths.length - 1].startsWith("/")).toBe(true);
+    await snap("file-open-default-app.png");
+  });
+
+  it("opens a text file the editor renders perfectly well", async () => {
+    // .scad is plain text — the editor shows it fine, and that is exactly why
+    // "only for files the editor can't render" was the wrong rule.
+    const paths = await doubleClickRow("e2e-part.scad");
+    expect(paths.some((p) => p.endsWith("/e2e-part.scad"))).toBe(true);
+  });
+
+  it("opens an image that has its own in-app viewer", async () => {
+    // A PNG already previews inside the app, so this is the case where the
+    // external open is a genuine ADDITION rather than the only way to see the
+    // file. It must still fire: "the app can show it" is not a reason to keep
+    // the user from opening it in a real image editor.
+    const paths = await doubleClickRow("e2e-shot.png");
+    expect(paths.some((p) => p.endsWith("/e2e-shot.png"))).toBe(true);
+  });
+
+  it("still routes a single click to the in-app preview pane", async () => {
+    // The other half of the PNG case: single click must NOT launch anything,
+    // it must open the tab the preview pane renders (previewPaths routes on
+    // extension, so the tab is an "edit" tab that PreviewPane picks up).
+    rmSync(openedLog, { force: true });
+    await clickRowWithDetail("e2e-shot.png", 1);
+    await browser.waitUntil(
+      () =>
+        browser.execute(
+          (id) =>
+            (window.__termic!.useApp.getState().tabs[id] ?? []).some(
+              (t: any) => t.type === "edit" && t.path === "e2e-shot.png",
+            ),
+          taskId,
+        ),
+      { timeout: 8_000, timeoutMsg: "a single click no longer opens the image tab" },
+    );
+    expect(opened()).toEqual([]);
+  });
+
+  it("opens the editor tab on a single click, launching nothing", async () => {
+    // The other half of the branch: single click keeps its old job, and must
+    // NOT hand the file to the OS. A regression here would launch an app on
+    // every click in the tree.
+    rmSync(openedLog, { force: true });
+    await clickRowWithDetail("e2e-part.scad", 1);
+    await browser.waitUntil(
+      () =>
+        browser.execute(
+          (id) =>
+            (window.__termic!.useApp.getState().tabs[id] ?? []).some(
+              (t: any) => t.type === "edit" && t.path === "e2e-part.scad",
+            ),
+          taskId,
+        ),
+      { timeout: 8_000, timeoutMsg: "a single click no longer opens the editor tab" },
+    );
+    expect(opened()).toEqual([]);
+  });
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8334,6 +8334,90 @@ fn reveal_path(path: String) -> Result<(), String> {
     Ok(())
 }
 
+/// What to do once the OS launcher has been run for a file (GH #147).
+/// Only the real (non-e2e) build shells out, so the e2e binary never reaches
+/// the decision — the unit tests below still cover it in either build.
+#[cfg_attr(feature = "e2e", allow(dead_code))]
+#[derive(Debug, PartialEq, Eq)]
+enum AfterOpen {
+    /// The default app took it (or we cannot tell, so assume it did).
+    Done,
+    /// Nothing is registered for this file, so show it in the file manager.
+    Reveal,
+}
+
+/// Decide whether `open_file_external` falls back to revealing the file.
+///
+/// `open_path` treats only a SPAWN failure as an error and ignores the exit
+/// status. That is right for URLs but wrong for files: `open` (macOS) and
+/// `xdg-open` (Linux, exit 3) both exit non-zero when no handler is
+/// registered for the extension, which is the case the fallback exists for.
+///
+/// Windows is deliberately excluded. `explorer.exe` exits non-zero even on
+/// success (see `open_command`), so its status carries no signal and keying
+/// on it would reveal the file on every single open. Windows instead gets
+/// explorer's own "how do you want to open this file?" picker, which covers
+/// the same need natively.
+#[cfg_attr(feature = "e2e", allow(dead_code))]
+fn after_open(os: &str, spawned: bool, exit_ok: bool) -> AfterOpen {
+    if !spawned {
+        // The launcher binary itself is missing or unrunnable. Nothing was
+        // handed to the OS, so the file manager is the only thing left.
+        return AfterOpen::Reveal;
+    }
+    if os == "windows" || exit_ok {
+        return AfterOpen::Done;
+    }
+    AfterOpen::Reveal
+}
+
+/// E2E-ONLY (`--features e2e`): record an external-open instead of running
+/// it. A spec that double-clicks a `.blend` row must not launch Blender on
+/// the machine running the suite, and the reveal fallback would pop a Finder
+/// window over the window under test. One path per line in the isolated
+/// profile dir, so the spec reads it with plain `fs` and needs no extra IPC
+/// command (which would otherwise linger in release builds).
+#[cfg(feature = "e2e")]
+fn e2e_record_open(path: &str) {
+    if let Ok(dir) = data_dir() {
+        let _ = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join("e2e-opened.log"))
+            .and_then(|mut f| writeln!(f, "{path}"));
+    }
+}
+
+/// Hand an ABSOLUTE file path to the OS default app, falling back to
+/// revealing it in the file manager when nothing is registered for it
+/// (GH #147, the file tree's double-click).
+///
+/// Returns "opened" or "revealed" so the frontend can tell the user which
+/// happened. `Err` only when the fallback ALSO failed, i.e. the file reached
+/// neither an app nor the file manager.
+#[tauri::command]
+fn open_file_external(path: String) -> Result<String, String> {
+    #[cfg(feature = "e2e")]
+    {
+        e2e_record_open(&path);
+        return Ok("opened".to_string());
+    }
+    #[cfg(not(feature = "e2e"))]
+    {
+        let os = std::env::consts::OS;
+        let (program, args) = open_command(os, &path);
+        let status = Command::new(program).args(&args).status();
+        let spawned = status.is_ok();
+        let exit_ok = status.as_ref().map(|s| s.success()).unwrap_or(false);
+        if after_open(os, spawned, exit_ok) == AfterOpen::Done {
+            return Ok("opened".to_string());
+        }
+        let (program, args) = reveal_command(os, &path);
+        Command::new(program).args(&args).status().map_err(|e| e.to_string())?;
+        Ok("revealed".to_string())
+    }
+}
+
 /// The argv for opening `target` (a URL or filesystem path) in the OS
 /// default handler. Split out from the side-effecting spawn so the
 /// per-platform dispatch is unit-testable. `os` is
@@ -10483,7 +10567,7 @@ pub fn run() {
             task_path_rename, task_path_delete, task_reveal_path,
             task_rename, project_rename,
             pty_spawn, pty_write, pty_resize, pty_kill,
-            notify, open_path, reveal_path, home_dir, default_shell, path_exists, path_is_git_repo, log_line, pty_debug_append, terminal_stage_file, install_notification_sound, play_completion_sound,
+            notify, open_path, reveal_path, open_file_external, home_dir, default_shell, path_exists, path_is_git_repo, log_line, pty_debug_append, terminal_stage_file, install_notification_sound, play_completion_sound,
             settings_load, settings_save, discovery_dismiss, agents_save, agents_defaults, run_capture_command, discover_repos, detect_clis,
             automation::automation_result,
             automation::automation_armed,
@@ -11293,6 +11377,41 @@ mod tests {
     fn open_command_unknown_os_falls_back_to_xdg_open() {
         let (prog, _) = open_command("freebsd", "https://x.com");
         assert_eq!(prog, "xdg-open");
+    }
+
+    #[test]
+    fn after_open_reveals_when_no_handler_is_registered() {
+        // The whole point of the fallback (#147): `open` on macOS and
+        // `xdg-open` on Linux (exit 3) both fail when nothing claims the
+        // extension, e.g. a .blend with no Blender installed.
+        assert_eq!(after_open("macos", true, false), AfterOpen::Reveal);
+        assert_eq!(after_open("linux", true, false), AfterOpen::Reveal);
+    }
+
+    #[test]
+    fn after_open_keeps_quiet_when_the_app_took_it() {
+        // A clean exit means an app launched, so no Finder window on top.
+        assert_eq!(after_open("macos", true, true), AfterOpen::Done);
+        assert_eq!(after_open("linux", true, true), AfterOpen::Done);
+    }
+
+    #[test]
+    fn after_open_never_reveals_on_windows() {
+        // explorer.exe exits non-zero even on SUCCESS (see open_command), so
+        // keying the fallback on its status would pop a file-manager window
+        // on every single open. Windows gets explorer's own picker instead.
+        assert_eq!(after_open("windows", true, false), AfterOpen::Done);
+        assert_eq!(after_open("windows", true, true), AfterOpen::Done);
+    }
+
+    #[test]
+    fn after_open_reveals_when_the_launcher_cannot_spawn() {
+        // No `open`/`xdg-open` binary at all: nothing reached the OS, so the
+        // file manager is the only thing left to try. Windows included here
+        // — a missing explorer.exe is a real spawn failure, not exit noise.
+        assert_eq!(after_open("macos", false, false), AfterOpen::Reveal);
+        assert_eq!(after_open("linux", false, false), AfterOpen::Reveal);
+        assert_eq!(after_open("windows", false, false), AfterOpen::Reveal);
     }
 
     #[test]

--- a/src/components/task/CopyPathItems.tsx
+++ b/src/components/task/CopyPathItems.tsx
@@ -1,9 +1,14 @@
 // Shared path context-menu items, reused everywhere a file/folder can be
 // right-clicked (Git panel, file tree, diff header, editor breadcrumb). Keeps
-// the wording + ordering identical across surfaces. Mirrors VS Code:
-//   - "Copy path (relative)"  → path relative to the task root
-//   - "Copy path (absolute)"  → full on-disk path
-//   - Open / Show in <file manager> → folders open, files are revealed/selected
+// the wording + ordering identical across surfaces:
+//   - "Open in default app"    → hand the FILE to the OS (GH #147)
+//   - Reveal / Open in <file manager> → folders open, files are selected
+//   - "Copy path (relative)"   → path relative to the task root
+//   - "Copy path (absolute)"   → full on-disk path
+//
+// The two OS actions lead because they act on the file itself; copying a path
+// is the secondary, clipboard-only pair. Mirrors what VS Code, Sublime and
+// JetBrains all put at the top of a file-tree context menu.
 //
 // `rel` is task-relative; `root` is the task's absolute disk path.
 // Rendered inside a <ContextMenuContent>, so it emits items only (no wrapper).
@@ -13,14 +18,16 @@
 import { ContextMenuItem, ContextMenuSeparator } from "@/components/ui/ContextMenu";
 import { copyToClipboard, joinPath } from "@/lib/clipboard";
 import { openPath, revealPath } from "@/lib/ipc";
+import { openInDefaultApp } from "@/lib/openExternal";
 import { useUI } from "@/store/ui";
 import { IS_MAC } from "@/lib/shortcuts";
-import { Copy, CornerUpLeft, FolderOpen } from "lucide-react";
+import { Copy, CornerUpLeft, ExternalLink, FolderOpen } from "lucide-react";
 
 const FILE_MANAGER = IS_MAC ? "Finder" : "File Manager";
 
 export function CopyPathItems({ rel, root, isDir = false }: { rel: string; root: string; isDir?: boolean }) {
   const abs = joinPath(root, rel);
+  const name = rel.split("/").pop() || rel;
   const revealInFileManager = () => {
     // Folders open (show their contents); files are revealed/selected in
     // their parent. Both resolve per-OS in Rust (open_command / reveal_command).
@@ -29,15 +36,22 @@ export function CopyPathItems({ rel, root, isDir = false }: { rel: string; root:
   };
   return (
     <>
+      {/* Files only: `openPath` on a DIRECTORY already means "open it in the
+          file manager", so for a folder this would duplicate the entry below. */}
+      {!isDir && (
+        <ContextMenuItem onSelect={() => void openInDefaultApp(abs, name)}>
+          <ExternalLink /> Open in default app
+        </ContextMenuItem>
+      )}
+      <ContextMenuItem onSelect={revealInFileManager}>
+        <FolderOpen /> {isDir ? `Open in ${FILE_MANAGER}` : `Reveal in ${FILE_MANAGER}`}
+      </ContextMenuItem>
+      <ContextMenuSeparator />
       <ContextMenuItem onSelect={() => copyToClipboard(rel, "relative path")}>
         <CornerUpLeft /> Copy path (relative)
       </ContextMenuItem>
       <ContextMenuItem onSelect={() => copyToClipboard(abs, "path")}>
         <Copy /> Copy path (absolute)
-      </ContextMenuItem>
-      <ContextMenuSeparator />
-      <ContextMenuItem onSelect={revealInFileManager}>
-        <FolderOpen /> {isDir ? `Open in ${FILE_MANAGER}` : `Show in ${FILE_MANAGER}`}
       </ContextMenuItem>
     </>
   );

--- a/src/components/task/FileTree.tsx
+++ b/src/components/task/FileTree.tsx
@@ -15,7 +15,6 @@ import { fileIconUrl, folderIconUrl } from "@/lib/explorer/iconResolver";
 import { ContextMenuRoot, ContextMenuTrigger, ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from "@/components/ui/ContextMenu";
 import { CopyPathItems } from "./CopyPathItems";
 import { startPathDrag } from "@/lib/terminalDrop";
-import { openInDefaultApp } from "@/lib/openExternal";
 import { joinPath } from "@/lib/clipboard";
 import { launchCustomRun } from "@/lib/runTabs";
 import { resolveCustomCommands, removeCommandByCommand, defaultCommandFor } from "@/lib/runCommands";
@@ -279,6 +278,7 @@ interface NodeProps {
 
 function TreeNode({ taskId, entry, depth, rel, root, expanded, children_, toggle, revealed, refetch, projectId, savedCmds, reloadCmds }: NodeProps) {
   const openPreviewTab = useApp(s => s.openPreviewTab);
+  const persistTab = useApp(s => s.persistTab);
   const closeTab = useApp(s => s.closeTab);
   const tabs = useApp(s => s.tabs[taskId] || []);
   const activeTabId = useApp(s => s.activeTab[taskId]);
@@ -375,41 +375,24 @@ function TreeNode({ taskId, entry, depth, rel, root, expanded, children_, toggle
   const activeTab = tabs.find(t => t.id === activeTabId);
   const isActive = activeTab?.type === "edit" && activeTab.path === rel;
 
-  // Double-click hands the file to the OS default app, falling back to the
-  // file manager when nothing claims the extension (GH #147).
-  //
-  // Read off the CLICK's UA click-count, not a `dblclick` handler. The row
-  // calls preventDefault() on pointerdown (startPathDrag, to kill text
-  // selection), which per the pointer-events spec suppresses the compat mouse
-  // events; `click` is explicitly exempt and demonstrably still fires (it is
-  // what opens files today), while `dblclick` under a cancelled pointerdown
-  // is not something this codebase can verify — WebDriver cannot synthesize a
-  // real double-click in WKWebView (its clicks carry detail 0 and emit no
-  // dblclick at all), so no test could ever have caught it regressing.
-  // Keying on the event that provably survives avoids the question.
-  //
-  // `detail === 2` exactly, not `>= 2`, so a triple-click opens once.
-  //
-  // This REPLACES pinning the preview tab (the VS Code gesture). Limiting the
-  // external open to files the editor can't render would have missed the
-  // motivating case: .scad is plain text, so it renders fine, but a
-  // double-click on it still means "open this in OpenSCAD". Pinning is
-  // unchanged on the tab pill itself (TabBar), where the muscle memory is.
-  //
-  // The first click of the pair still opens the preview tab underneath. Left
-  // that way deliberately: it's a preview tab that the next single click
-  // replaces, and suppressing it would mean holding EVERY single click in the
-  // tree behind the double-click threshold.
-  function onClick(e: React.MouseEvent) {
+  function onClick() {
     if (entry.is_dir) {
       toggle(rel);
-      return;
+    } else {
+      openPreviewTab(taskId, { type: "edit", path: rel, title: entry.name });
     }
-    if (e.detail === 2) {
-      void openInDefaultApp(joinPath(root, rel), entry.name);
-      return;
+  }
+
+  // Double-click pins the preview tab, the Sublime/VS Code/JetBrains gesture
+  // (single click = temporary preview, double = keep). Opening the file in its
+  // OS default app lives in the right-click menu instead (CopyPathItems), where
+  // every one of those editors also puts it. See the discussion on GH #147.
+  function onDoubleClick() {
+    if (entry.is_dir) return;
+    const existing = tabs.find(t => t.type === "edit" && t.path === rel);
+    if (existing) {
+      persistTab(taskId, existing.id);
     }
-    openPreviewTab(taskId, { type: "edit", path: rel, title: entry.name });
   }
 
   const iconUrl = entry.is_dir ? folderIconUrl(entry.name, isOpen) : fileIconUrl(entry.name);
@@ -441,6 +424,7 @@ function TreeNode({ taskId, entry, depth, rel, root, expanded, children_, toggle
       <ContextMenuTrigger asChild>
       <button
         onClick={onClick}
+        onDoubleClick={onDoubleClick}
         // Drag a row onto a terminal to type its path at the prompt (GH #136),
         // the same affordance as dragging a file in from Finder. Pointer-based,
         // not HTML5 DnD — see the note in lib/terminalDrop.

--- a/src/components/task/FileTree.tsx
+++ b/src/components/task/FileTree.tsx
@@ -15,6 +15,7 @@ import { fileIconUrl, folderIconUrl } from "@/lib/explorer/iconResolver";
 import { ContextMenuRoot, ContextMenuTrigger, ContextMenuContent, ContextMenuItem, ContextMenuSeparator } from "@/components/ui/ContextMenu";
 import { CopyPathItems } from "./CopyPathItems";
 import { startPathDrag } from "@/lib/terminalDrop";
+import { openInDefaultApp } from "@/lib/openExternal";
 import { joinPath } from "@/lib/clipboard";
 import { launchCustomRun } from "@/lib/runTabs";
 import { resolveCustomCommands, removeCommandByCommand, defaultCommandFor } from "@/lib/runCommands";
@@ -278,7 +279,6 @@ interface NodeProps {
 
 function TreeNode({ taskId, entry, depth, rel, root, expanded, children_, toggle, revealed, refetch, projectId, savedCmds, reloadCmds }: NodeProps) {
   const openPreviewTab = useApp(s => s.openPreviewTab);
-  const persistTab = useApp(s => s.persistTab);
   const closeTab = useApp(s => s.closeTab);
   const tabs = useApp(s => s.tabs[taskId] || []);
   const activeTabId = useApp(s => s.activeTab[taskId]);
@@ -375,20 +375,41 @@ function TreeNode({ taskId, entry, depth, rel, root, expanded, children_, toggle
   const activeTab = tabs.find(t => t.id === activeTabId);
   const isActive = activeTab?.type === "edit" && activeTab.path === rel;
 
-  function onClick() {
+  // Double-click hands the file to the OS default app, falling back to the
+  // file manager when nothing claims the extension (GH #147).
+  //
+  // Read off the CLICK's UA click-count, not a `dblclick` handler. The row
+  // calls preventDefault() on pointerdown (startPathDrag, to kill text
+  // selection), which per the pointer-events spec suppresses the compat mouse
+  // events; `click` is explicitly exempt and demonstrably still fires (it is
+  // what opens files today), while `dblclick` under a cancelled pointerdown
+  // is not something this codebase can verify — WebDriver cannot synthesize a
+  // real double-click in WKWebView (its clicks carry detail 0 and emit no
+  // dblclick at all), so no test could ever have caught it regressing.
+  // Keying on the event that provably survives avoids the question.
+  //
+  // `detail === 2` exactly, not `>= 2`, so a triple-click opens once.
+  //
+  // This REPLACES pinning the preview tab (the VS Code gesture). Limiting the
+  // external open to files the editor can't render would have missed the
+  // motivating case: .scad is plain text, so it renders fine, but a
+  // double-click on it still means "open this in OpenSCAD". Pinning is
+  // unchanged on the tab pill itself (TabBar), where the muscle memory is.
+  //
+  // The first click of the pair still opens the preview tab underneath. Left
+  // that way deliberately: it's a preview tab that the next single click
+  // replaces, and suppressing it would mean holding EVERY single click in the
+  // tree behind the double-click threshold.
+  function onClick(e: React.MouseEvent) {
     if (entry.is_dir) {
       toggle(rel);
-    } else {
-      openPreviewTab(taskId, { type: "edit", path: rel, title: entry.name });
+      return;
     }
-  }
-
-  function onDoubleClick() {
-    if (entry.is_dir) return;
-    const existing = tabs.find(t => t.type === "edit" && t.path === rel);
-    if (existing) {
-      persistTab(taskId, existing.id);
+    if (e.detail === 2) {
+      void openInDefaultApp(joinPath(root, rel), entry.name);
+      return;
     }
+    openPreviewTab(taskId, { type: "edit", path: rel, title: entry.name });
   }
 
   const iconUrl = entry.is_dir ? folderIconUrl(entry.name, isOpen) : fileIconUrl(entry.name);
@@ -420,7 +441,6 @@ function TreeNode({ taskId, entry, depth, rel, root, expanded, children_, toggle
       <ContextMenuTrigger asChild>
       <button
         onClick={onClick}
-        onDoubleClick={onDoubleClick}
         // Drag a row onto a terminal to type its path at the prompt (GH #136),
         // the same affordance as dragging a file in from Finder. Pointer-based,
         // not HTML5 DnD — see the note in lib/terminalDrop.

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -667,6 +667,12 @@ export const openPath  = (path: string) => invoke<void>("open_path", { path });
 /** Reveal an absolute path in the OS file manager (select it on macOS/Windows,
  *  open its parent on Linux). For task-relative paths use taskRevealPath. */
 export const revealPath = (path: string) => invoke<void>("reveal_path", { path });
+/** Hand an absolute FILE path to the OS default app, falling back to revealing
+ *  it when nothing is registered for the extension. Resolves to which of the
+ *  two happened; rejects only when neither worked. Unlike openPath it inspects
+ *  the launcher's exit status, so it is for files, not URLs. */
+export const openFileExternal = (path: string) =>
+  invoke<"opened" | "revealed">("open_file_external", { path });
 export const homeDir   = () => invoke<string>("home_dir");
 export const pathExists= (path: string) => invoke<boolean>("path_exists", { path });
 export const pathIsGitRepo = (path: string) => invoke<boolean>("path_is_git_repo", { path });

--- a/src/lib/openExternal.test.ts
+++ b/src/lib/openExternal.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocks must be declared before the module under test is imported.
+vi.mock("@/lib/ipc", () => ({ openFileExternal: vi.fn() }));
+
+import { openInDefaultApp } from "@/lib/openExternal";
+import { openFileExternal } from "@/lib/ipc";
+import { useUI } from "@/store/ui";
+
+const mocked = openFileExternal as unknown as ReturnType<typeof vi.fn>;
+const toasts = () => useUI.getState().toasts;
+
+describe("openInDefaultApp", () => {
+  beforeEach(() => {
+    mocked.mockReset();
+    useUI.setState({ toasts: [] });
+  });
+
+  it("stays silent when the default app took the file", async () => {
+    // The app coming to the front is the feedback; a toast on top of it is
+    // noise on the common path.
+    mocked.mockResolvedValue("opened");
+    await openInDefaultApp("/w/model.blend", "model.blend");
+    expect(mocked).toHaveBeenCalledWith("/w/model.blend");
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it("explains the file-manager fallback when nothing claims the file", async () => {
+    // Otherwise a Finder window just appears with no reason given.
+    mocked.mockResolvedValue("revealed");
+    await openInDefaultApp("/w/model.blend", "model.blend");
+    const [toast] = toasts();
+    expect(toast.kind).toBe("info");
+    expect(toast.msg).toContain("model.blend");
+  });
+
+  it("reports a failure instead of swallowing it", async () => {
+    // Both the open AND the reveal failed: without this the double-click is
+    // indistinguishable from the dead gesture #147 set out to fix.
+    mocked.mockRejectedValue("xdg-open: not found");
+    await openInDefaultApp("/w/model.blend", "model.blend");
+    const [toast] = toasts();
+    expect(toast.kind).toBe("error");
+    expect(toast.msg).toContain("model.blend");
+    expect(toast.msg).toContain("xdg-open: not found");
+  });
+
+  it("never rejects, so a click handler can fire and forget", async () => {
+    mocked.mockRejectedValue(new Error("boom"));
+    await expect(openInDefaultApp("/w/a.txt", "a.txt")).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/openExternal.ts
+++ b/src/lib/openExternal.ts
@@ -1,0 +1,31 @@
+// Handing a file to the OS default app (GH #147), the file tree's
+// double-click. Split from the component so the outcome-to-toast mapping is
+// testable without mounting React.
+//
+// The open/reveal fallback itself lives in Rust (`open_file_external`): only
+// the backend can see the launcher's exit status, which is what says "nothing
+// is registered for .blend". This module just reports the outcome.
+
+import { openFileExternal } from "@/lib/ipc";
+import { useUI } from "@/store/ui";
+import { IS_MAC } from "@/lib/shortcuts";
+
+const FILE_MANAGER = IS_MAC ? "Finder" : "File Manager";
+
+/** Open `abs` in its default app. `name` is the basename, used in the toast.
+ *  Never throws: a failure to open is reported to the user, not to the
+ *  caller, since every call site is a click handler with nowhere to put it. */
+export async function openInDefaultApp(abs: string, name: string): Promise<void> {
+  const toast = useUI.getState().pushToast;
+  try {
+    const outcome = await openFileExternal(abs);
+    // A successful launch speaks for itself (the app comes to the front), so
+    // only the fallback needs saying. Without this the user sees a file
+    // manager pop up with no explanation of why the app didn't open.
+    if (outcome === "revealed") {
+      toast(`No app is set to open ${name}. Showed it in ${FILE_MANAGER}.`, "info");
+    }
+  } catch (e) {
+    toast(`Could not open ${name}: ${String(e)}`, "error");
+  }
+}


### PR DESCRIPTION
Fixes #147

Adds "Open in default app" to the file tree's right-click menu, so a file termic cannot usefully show (or that the user simply wants elsewhere) can be handed to the OS. Falls back to revealing the file in the file manager when nothing claims the extension.

Revised after review: this started as a double-click gesture. Double-click already means "pin the preview tab" here, the same as Sublime, VS Code and JetBrains, so it now stays that way and the external open lives on the context menu instead.

## UX

Right-click any file row in the "All files" tree:

```
Open in default app      <- new, files only
Reveal in Finder
-------------------
Copy path (relative)
Copy path (absolute)
```

The two OS actions lead because they act on the file itself; copying a path is the secondary, clipboard-only pair. Single click still previews, double click still pins.

"Open in default app" is files-only. `openPath` on a directory already means "open it in the file manager", so a folder would otherwise show the same action twice.

When nothing is registered for the extension, the file is revealed and a toast explains why, rather than leaving an unexplained Finder window:

> (i) No app is set to open .book.stamp. Showed it in Finder.

This lives in `CopyPathItems`, the shared component behind the path actions on all four surfaces that show them (file tree, Git panel, diff header, editor breadcrumb). That component exists to keep wording and ordering identical across them, so the entry went there rather than being inlined in the tree with a prop to suppress the duplicate reveal. The Git panel and breadcrumb gain the same entry. Happy to scope it to the tree alone if you would rather.

## Technical change

**`open_file_external` (new Rust command)** rather than reusing `open_path`. The fallback needs the launcher's exit status, which `open_path` deliberately ignores: `open` on macOS and `xdg-open` on Linux (exit 3) both fail when no handler is registered. Windows is excluded from the fallback because `explorer.exe` exits non-zero even on success, so its status carries no signal; it gets explorer's own "how do you want to open this file?" picker instead. `after_open(os, spawned, exit_ok)` isolates that three-way decision so it is unit-testable.

**`src/lib/openExternal.ts`** holds the outcome-to-toast mapping, split from the component so it is testable without mounting React. It never rejects, since every call site is a menu handler with nowhere to put an error.

An earlier draft tried "external open only for files the editor cannot render". That is in the history rather than the diff because it cannot express the `.scad` case from the issue: plain text the editor renders perfectly, that the user still wants in OpenSCAD. An explicit menu entry sidesteps detection entirely.

## Test coverage

- **Rust unit tests** cover the `after_open` matrix: no handler on macOS/Linux reveals, a clean exit does not, Windows never reveals on exit status, and a spawn failure reveals on every OS.
- **Vitest** (`openExternal.test.ts`) covers the toast branches: silent on success, an info toast on the reveal fallback, an error toast on failure, and never rejecting.
- **e2e** (`files.e2e.ts`) asserts the menu order, then opens externally from the menu for all three routing classes: a binary the editor cannot render (`.blend`), a text file it renders fine (`.scad`), and an image with its own in-app viewer (`.png`). Plus the negatives: a folder offers no default-app entry, and double-click still pins while launching nothing.
- The e2e binary records opens to a log in the isolated profile instead of shelling out, so the suite never launches Blender or pops a Finder window over the window under test.

Moving to the menu also removed the coverage gap the first version had. A double-click cannot be driven in this WKWebView at all (a driven `doubleClick()` emits two clicks with `detail: 0` and no `dblclick`), so the gesture was manual-only. The menu route is reachable, so everything from opening the menu to the backend call is now covered by the suite.

Full run: 497 vitest, 281 cargo, 15/15 in the files e2e spec.
