### PR TITLE
feat(cli): termic tab and termic agents (GH #138 part 1)

### DIFF
--- a/docs/plans/cli.md
+++ b/docs/plans/cli.md
@@ -11,12 +11,12 @@ advertisement (protocol v2). Phase 2 implemented on top - `send`
 (+`--shell`, backlog replay, detach keys, opt-in `--resize`), `apply`
 (exit 10 goes live), `diff`, `path`, and the result readers `logs`
 (per-PTY ring buffer) and `result` (claude transcript reader), protocol
-v4. Phase 3 in progress - windowless mode landed, `termic quit` landed;
-tab management (GH #138) specced and adopted, not yet built. Homebrew is
-settled, not pending: the cask ships, a CLI-only formula is a non-goal
-(see Distribution). `termic events --json` is deferred pending the Claude
-Code hooks path: a versioned public event stream built on heuristic settle
-detection is not something to support forever.
+v5. Phase 3 in progress - windowless mode landed, `termic quit` landed;
+tab management (GH #138) part 1 landed (`termic tab` + stable tab ids),
+part 2 (`--tab` targeting, `status` listing, `tab -p`) pending. Homebrew
+is settled, not pending: the cask ships, a CLI-only formula is a non-goal
+(see Distribution). `termic events --json` is SEQUENCED BEHIND hooks, not
+merely deferred: see Phasing.
 `termic mcp` stays parked under discussion and NOT approved (see
 Phasing). Sections below note where the implementation refined the
 original design.
@@ -293,7 +293,11 @@ termic quit [--yes]                           # the only shell-side teardown for
                                               # sessions (force-checkout of MAIN), so the
                                               # confirmation names what dies. Never
                                               # launches; exits 0 if not running
-termic tab <task> [--agent <id>|--terminal <id>|--shell] [-p]  # GH #138. A tab INSIDE a
+termic agents                                 # what --agent / --terminal accept:
+                                              # id, kind, enabled, installed, usable.
+                                              # The registry is per-user and editable,
+                                              # so static help cannot carry it
+termic tab <task> [--agent <id>|--terminal <id>|--shell]      # GH #138. A tab INSIDE a
                                               # running task: the "+" menu as a verb, and
                                               # like that menu it distinguishes agent /
                                               # custom-terminal / aux-shell kinds, because
@@ -366,7 +370,21 @@ agent tab" (`PtyRole.is_default`, already the target `attach`/`logs` resolve
 to). So a second claude tab is unreachable, and `status` reports a `sessions`
 COUNT with no way to ask what those sessions are.
 
-Adopted into Phase 3.
+Adopted into Phase 3, landing in two parts. **Part 1 (landed):** `termic tab`
+plus `PtyRole.tab_id`, i.e. creating tabs and having a stable name for them.
+**Part 2 (pending):** `--tab <n|id|title>` on send/wait/attach/logs, tabs
+listed in `status`, and `tab -p`. Split because part 2 depends on the selector
+decision and part 1 does not.
+
+**Part 2 must start by covering `tab_id` end to end.** Part 1 threads the
+webview's tab uuid into `PtyRole.tab_id`, but NOTHING consumes it yet, so
+nothing tests it: the value is set in TerminalPane's spawn call, which has no
+test infrastructure, and every suite stays green if that field is dropped,
+misspelled, or wired to the wrong id. The failure would surface only as
+"`--tab` resolves nothing" once part 2 exists, at which point the bug looks
+like a part 2 bug. First task of part 2, before any selector work: an
+assertion that a tab opened by `termic tab` is addressable by the id that
+command returned (e2e is the natural level, since it needs a real spawn).
 
 **Picking what to open is the hard part, and it is not a binary.** The GUI's
 "+" menu already offers three distinct things and gates them: `kind: "agent"`
@@ -385,7 +403,25 @@ would model none of that. So:
   `--agent` for the same reason `--shell` is: the kinds differ in resume, YOLO
   and sandbox behaviour, so one `--kind <string>` flag would let a typo land
   you in the wrong semantics silently.
-- **`--shell`** stays the task's aux terminal, matching `attach --shell`.
+- **`--shell`** opens a plain login shell tab in the strip. NOTE this is not
+  the aux terminal `attach --shell` resolves; that is a separate pane.
+
+**Terminal tabs are write-only from the CLI, and that is accepted.** `--shell`
+and `--terminal` tabs open and are fully usable in the window, but `attach`
+and `logs` cannot reach them and no output ring is kept, because only agent
+tabs carry a `PtyRole` and that is what both resolve against. Everything else
+that separates the kinds follows from the same place: no work-done detection
+(so `--wait` means nothing for them), no resume, no YOLO args, and shells are
+not persisted across a restart. SANDBOXING IS A SEPARATE SWITCH, keyed on
+`pty_spawn`'s `task_id` argument rather than on the role: terminal tabs are
+deliberately never caged, which is what makes them usable for git and ssh
+(#32). Giving them a role in part 2 would make them addressable without
+caging them, but that is the wrong way round: it would put an UNCAGED PTY on
+the control socket where it can be driven remotely. Not an escalation (a caged
+agent cannot reach the socket, and `attach --shell` already drives the uncaged
+aux terminal), but it widens the socket's reach for no use case we have. The
+retained-output ring per shell is the smaller cost. Decide it only if part 2
+turns up a real need to drive a shell from a script.
 - **Omitted** = the task's own `cli`, i.e. "another one of what this task
   already runs", which is the common case and matches what the `+` button
   does before you pick anything.
@@ -404,16 +440,13 @@ Then the targeting half:
 
 Open questions, deliberately not settled here:
 
-- **Selector stability.** Index is what the user sees in the tab strip but
-  shifts when a tab closes; title is agent-authored and changes mid-turn (it
-  is the same OSC stream the work-done classifier reads, lib/terminalTitle.ts).
-  Neither is a stable id. A stable per-tab id exists app-side and is the
-  honest thing for scripts, with index/title as human conveniences that
-  resolve to it. Note this is NOT free: `PtyRole` is `{task_id, kind,
-  is_default}` with no id and no title, and titles live in the webview store,
-  so exposing one means extending the role or adding a webview RPC. That is an
-  IPC change on top of the protocol change, and it partly answers the question:
-  whatever id is exposed has to be plumbed into the role anyway.
+- **Selector stability: SETTLED, tab ids are the identity.** Index shifts
+  when a tab closes and titles are agent-authored and change mid-turn (the
+  same OSC stream the work-done classifier reads, lib/terminalTitle.ts), so
+  neither can be the identity. The webview already minted a uuid per tab; it
+  is now carried on `PtyRole.tab_id`, so Rust can resolve a selector without a
+  webview round-trip. `termic tab` prints it. Index and title remain human
+  conveniences that resolve to it, which is the part still to build.
 - **Ambiguity is an error, not a guess.** Two tabs titled `claude` must fail
   with both selectors printed, the same shape as the existing ambiguous-task
   error, rather than picking the lower index.
@@ -424,11 +457,12 @@ Open questions, deliberately not settled here:
   CLI has no equivalent at any level. Out of scope here, but it is the obvious
   next ask once tabs are addressable, and `--tab` selectors are what it would
   hang off.
-- **Whether `tab` waits.** `new` has `--wait` and a delivery-confirmation
-  contract; `tab -p` would need the same or it inherits the silently-dropped
-  prompt problem Phase 1 exists to avoid. Cheapest answer is to reuse
-  `send`'s path outright: open the tab, then deliver through the confirmed
-  route rather than a second injection recipe.
+- **`tab -p` lands with targeting, not before.** `send_prompt` is the
+  confirmed delivery route, and it picks from a task's SENDABLE AGENT TABS
+  rather than a named one, so delivering into a specific new tab needs `--tab`
+  to exist first. Writing a second injection recipe instead would reintroduce
+  exactly the silently-dropped prompt Phase 1 exists to prevent, so `-p` waits
+  for part 2.
 
 Protocol impact is additive (a new verb plus optional fields), so this is a
 version bump when it lands, not a breaking change.
@@ -802,13 +836,22 @@ client whose server is missing.
     unbuilt; docs/cli-agent-instructions.md remains paste-your-own.
 - **Phase 3**: windowless daemon mode (activation policy + run without a
   window), `termic quit`, tab management inside a running task (GH #138, see
-  "Tabs inside a running task"), `termic events --json` (standing
-  subscription:
-  one JSON line per task event - done, waiting, created - fed by the same
-  settle signal as `--wait`). The event stream is also what would make
-  app-side hooks ("on task done, run this command" in settings) trivial
-  later; hooks themselves are a separate future feature, not part of this
-  plan.
+  "Tabs inside a running task").
+
+  `termic events --json` (a standing subscription: one JSON line per task
+  event, done / waiting / created) is SEQUENCED BEHIND agent hooks rather
+  than deferred indefinitely. The order is the whole point. Termic's settle
+  detection is heuristic by product design (PTY-native, so done-ness is
+  inferred from title signals and output scans), and `--wait` carries that
+  caveat in --help because its blast radius is one command with a human
+  watching. An event stream is a VERSIONED PUBLIC API consumed by scripts
+  with nobody watching, so publishing `{"event":"done"}` on a guess means
+  owning those semantics forever. Installing Claude Code Stop/Notification
+  hooks into spawned agents replaces the guess with exact push-based
+  signals; build the stream on that. So the work item is HOOKS FIRST, then
+  the stream, Claude-only at first, with the heuristic staying as the
+  fallback for agents that have no hook surface. Neither is scheduled yet;
+  what is settled is that the stream does not ship before the hooks.
 
   `termic quit` (protocol v4): the only shell-side teardown for a
   windowless instance, since the menu-bar Quit is otherwise the sole

--- a/docs/plans/e2e-coverage.md
+++ b/docs/plans/e2e-coverage.md
@@ -25,6 +25,7 @@ until `make e2e` is green and this file reflects it.
 | ✅ Task spawn | Task created; agent PTY comes alive; PTY write round-trips; agent OSC title reaches the app | `task.e2e.ts` |
 | ✅ Agent working | After a real submit, the agent enters the working state | `agent.e2e.ts` |
 | ✅ Agent attention | An agent you are not viewing flags completion (unread/done) when it finishes | `agent.e2e.ts` |
+| ✅ CLI tabs (unit) | `termic tab` on an UNMOUNTED task keeps every persisted agent and its session id, does not steal the default-target role, and a shell tab does not strand the task agentless | `store/cliTab.integration.test.ts` |
 | ✅ Windowless completion | An agent finishing while Termic is windowless still flags unread/done, even for the task that was active | `app.e2e.ts` |
 | ✅ Pending work defers done | An agent that backgrounds work and returns to its idle title holds the done badge back past byte-quiet (4s) and the settle timer (5s); done fires once its status line clears | `agent.e2e.ts` |
 | ✅ A hold that never clears ends | A status line that never clears cannot pin a tab to "working": the absolute ceiling force-clears it (shortened for the test via `localStorage.workDoneCeilingMs`) | `agent.e2e.ts` |

--- a/src-tauri/src/cli_server.rs
+++ b/src-tauri/src/cli_server.rs
@@ -649,6 +649,8 @@ pub(crate) fn handle_request(req: &Request, host: &dyn CliHost, sink: &mut dyn E
                 }),
             )
         }
+        Command::Agents => handle_agents(req, host),
+        Command::Tab { .. } => handle_tab(req, host),
         Command::Archive { task, project } => {
             handle_archive(&req.id, host, task, project.as_deref())
         }
@@ -1872,6 +1874,91 @@ fn handle_result(
             transcript: file.display().to_string(),
             text,
         }),
+    )
+}
+
+// ──────────────────────── tabs + registry (GH #138) ──────────────────
+
+/// `termic agents` (GH #138). Goes through the webview rather than
+/// `host.agents()` on purpose: installed-ness comes from a login-shell probe
+/// per agent that the webview already caches, and the same cached view is what
+/// `new_tab` validates against. Reading the registry from Rust here would give
+/// a second answer to "is this agent usable?" that could disagree with the one
+/// that actually gates tab creation.
+fn handle_agents(req: &Request, host: &dyn CliHost) -> Reply {
+    let id = &req.id;
+    let value = match host.rpc("list_agents", serde_json::json!({}), OPEN_TIMEOUT) {
+        Ok(v) => v,
+        Err(e) => return Reply::err(id, ErrorCode::Internal, &e),
+    };
+    let agents: Vec<proto::AgentEntry> =
+        match serde_json::from_value(value.get("agents").cloned().unwrap_or_default()) {
+            Ok(a) => a,
+            Err(e) => {
+                return Reply::err(id, ErrorCode::Internal, format!("bad list_agents reply: {e}"))
+            }
+        };
+    Reply::ok(id, ReplyData::Agents(proto::AgentsData { agents }))
+}
+
+/// `termic tab` (GH #138). Tab creation lives in the webview (the store owns
+/// the tab list and TerminalPane spawns the PTY from it), so this resolves the
+/// task here and hands the rest to `new_tab`, which owns registry validation:
+/// the GUI hides an unusable agent, but a CLI caller needs to be told why.
+fn handle_tab(req: &Request, host: &dyn CliHost) -> Reply {
+    let Command::Tab { task, project, kind, cwd } = &req.cmd else {
+        unreachable!("handle_tab called with a non-tab command")
+    };
+    let id = &req.id;
+    let (projects, tasks) = host.projects_tasks();
+    let t = match resolve_task_arg(
+        &projects,
+        &tasks,
+        task.as_deref(),
+        project.as_deref(),
+        cwd.as_deref(),
+    ) {
+        Ok(t) => t.clone(),
+        Err(e) => return Reply::err(id, e.code, &e.message),
+    };
+
+    let (kind_str, agent_id) = match kind {
+        proto::TabKind::Agent { id } => ("agent", Some(id.clone())),
+        proto::TabKind::Terminal { id } => ("terminal", Some(id.clone())),
+        proto::TabKind::Shell => ("shell", None),
+        proto::TabKind::Default => ("default", None),
+    };
+
+    let value = match host.rpc(
+        "new_tab",
+        serde_json::json!({ "taskId": t.id, "kind": kind_str, "id": agent_id }),
+        OPEN_TIMEOUT,
+    ) {
+        Ok(v) => v,
+        // The webview owns the "which agents are usable" answer, so its
+        // message is the useful one; pass it through rather than flattening
+        // it into a generic failure.
+        //
+        // BadRequest is chosen for the DOMINANT case (a caller naming an
+        // agent that is unknown, disabled, or not installed), which is a
+        // genuine bad request. A transport failure here (timeout, dead
+        // webview) is technically Internal and gets this code too. That is
+        // deliberate, not an oversight: both map to exit_code::ERROR and the
+        // message passes through either way, so the distinction is invisible
+        // to callers, and Internal would mis-tag the common case.
+        Err(e) => return Reply::err(id, ErrorCode::BadRequest, &e),
+    };
+
+    let tab_id = value.get("tabId").and_then(|v| v.as_str()).unwrap_or_default().to_string();
+    let cli = value.get("cli").and_then(|v| v.as_str()).unwrap_or_default().to_string();
+    let title = value.get("title").and_then(|v| v.as_str()).unwrap_or_default().to_string();
+    if tab_id.is_empty() {
+        return Reply::err(id, ErrorCode::Internal, "new_tab returned no tab id");
+    }
+
+    Reply::ok(
+        id,
+        ReplyData::Tab(proto::TabData { task_id: t.id, tab_id, cli, title }),
     )
 }
 
@@ -3919,6 +4006,133 @@ mod tests {
         host.script_rpc("new_task", Ok(serde_json::json!({ "taskId": "nw1" })));
         let reply = handle(&req(new_cmd("shiny", Some("web")), Some("tok")), &host);
         assert!(reply.ok, "{reply:?}");
+    }
+
+    // ── tab / agents (GH #138) ───────────────────────────────────────
+
+    fn tab_cmd(task: &str, kind: proto::TabKind) -> Command {
+        Command::Tab {
+            task: Some(task.into()),
+            project: None,
+            kind,
+            cwd: None,
+        }
+    }
+
+    #[test]
+    fn tab_sends_the_kind_strings_the_webview_switches_on() {
+        // These four literals are a CONTRACT with newTabHandler's switch in
+        // src/lib/cliRpc.ts. A typo here does not fail to compile on either
+        // side; it fails at runtime with "unknown tab kind" after the app has
+        // already launched. Pin every arm.
+        let cases: Vec<(proto::TabKind, &str, Option<&str>)> = vec![
+            (proto::TabKind::Default, "default", None),
+            (proto::TabKind::Shell, "shell", None),
+            (proto::TabKind::Agent { id: "codex".into() }, "agent", Some("codex")),
+            (proto::TabKind::Terminal { id: "btop".into() }, "terminal", Some("btop")),
+        ];
+        for (kind, want_kind, want_id) in cases {
+            let host = StubHost::default();
+            host.script_rpc(
+                "new_tab",
+                Ok(serde_json::json!({ "tabId": "t1", "cli": "codex", "title": "Codex" })),
+            );
+            let reply = handle(&req(tab_cmd("solo", kind), Some("tok")), &host);
+            assert!(reply.ok, "{want_kind}: {reply:?}");
+            let calls = host.rpc_calls.lock().unwrap();
+            assert_eq!(calls[0].0, "new_tab");
+            assert_eq!(calls[0].1["kind"], want_kind);
+            assert_eq!(calls[0].1["taskId"], "w3");
+            match want_id {
+                Some(id) => assert_eq!(calls[0].1["id"], id, "{want_kind}"),
+                None => assert!(calls[0].1["id"].is_null(), "{want_kind}"),
+            }
+        }
+    }
+
+    #[test]
+    fn tab_resolves_the_task_before_touching_the_webview() {
+        // An ambiguous or unknown name must fail here, not open something.
+        let host = StubHost::default();
+        // "fix-auth" exists in BOTH fixture projects.
+        let err = handle(&req(tab_cmd("fix-auth", proto::TabKind::Shell), Some("tok")), &host)
+            .error
+            .expect("ambiguous name should error");
+        assert_eq!(err.code, ErrorCode::Ambiguous);
+        assert!(host.rpc_calls.lock().unwrap().is_empty(), "must not spawn a tab");
+
+        let host = StubHost::default();
+        let err = handle(&req(tab_cmd("nope", proto::TabKind::Shell), Some("tok")), &host)
+            .error
+            .expect("unknown name should error");
+        assert_eq!(err.code, ErrorCode::NotFound);
+        assert!(host.rpc_calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn tab_rejects_a_reply_with_no_tab_id() {
+        // The tab id is what part 2's --tab resolves against, so a webview
+        // that answers without one is a bug, not a success.
+        let host = StubHost::default();
+        host.script_rpc("new_tab", Ok(serde_json::json!({ "cli": "claude", "title": "Claude" })));
+        let err = handle(&req(tab_cmd("solo", proto::TabKind::Shell), Some("tok")), &host)
+            .error
+            .expect("empty tabId should error");
+        assert_eq!(err.code, ErrorCode::Internal);
+    }
+
+    #[test]
+    fn tab_passes_the_webview_refusal_through() {
+        // The webview owns "is this agent usable", and its message names the
+        // alternatives. Flattening it would strip the only useful part.
+        let host = StubHost::default();
+        host.script_rpc(
+            "new_tab",
+            Err("unknown agent: gemni. Available: claude, codex (see `termic agents`)".into()),
+        );
+        let err = handle(
+            &req(tab_cmd("solo", proto::TabKind::Agent { id: "gemni".into() }), Some("tok")),
+            &host,
+        )
+        .error
+        .expect("refusal should error");
+        assert!(err.message.contains("Available: claude, codex"), "{}", err.message);
+    }
+
+    #[test]
+    fn agents_parses_the_registry_reply_and_needs_a_token() {
+        let host = StubHost::default();
+        host.script_rpc(
+            "list_agents",
+            Ok(serde_json::json!({ "agents": [
+                { "id": "claude", "kind": "agent",
+                  "enabled": true, "installed": true, "usable": true },
+                // installed: null is the "not detected yet" case, distinct
+                // from false; it must survive the round trip.
+                { "id": "btop", "kind": "terminal",
+                  "enabled": false, "installed": null, "usable": false },
+            ]})),
+        );
+        let reply = handle(&req(Command::Agents, Some("tok")), &host);
+        assert!(reply.ok, "{reply:?}");
+        let Some(ReplyData::Agents(d)) = reply.data else { panic!("{reply:?}") };
+        assert_eq!(d.agents.len(), 2);
+        assert_eq!(d.agents[0].id, "claude");
+        assert_eq!(d.agents[0].installed, Some(true));
+        assert_eq!(d.agents[1].installed, None);
+        assert!(!d.agents[1].enabled);
+        assert!(!d.agents[1].usable);
+
+        // Both verbs sit behind auth_gate; neither joins hello/raise.
+        let host = StubHost::default();
+        assert_eq!(
+            handle(&req(Command::Agents, None), &host).error.unwrap().code,
+            ErrorCode::Auth,
+        );
+        assert_eq!(
+            handle(&req(tab_cmd("solo", proto::TabKind::Shell), None), &host).error.unwrap().code,
+            ErrorCode::Auth,
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1375,6 +1375,18 @@ fn next_pty_seq() -> u64 {
 #[derive(Clone, Debug, Deserialize)]
 pub struct PtyRole {
     pub task_id: String,
+    /// The webview's tab id (a uuid minted when the tab is created). The
+    /// STABLE selector `--tab` resolves to: index shifts when a tab closes
+    /// and titles are agent-authored and change mid-turn, so neither can be
+    /// the identity. Optional for back-compat with PTYs spawned before this
+    /// field existed; those simply cannot be addressed by id.
+    ///
+    /// `default` only: PtyRole is Deserialize-only (it arrives from the
+    /// webview and is never sent back), so a `skip_serializing_if` here
+    /// would be inert and would imply a serialization path that does not
+    /// exist.
+    #[serde(default)]
+    pub tab_id: Option<String>,
     /// "agent" (an agent CLI tab) or "aux" (the task's aux terminal).
     pub kind: String,
     /// The task's default agent tab: `attach`/`logs`' default target.
@@ -10973,7 +10985,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn role(kind: &str, task: &str) -> PtyRole {
-        PtyRole { task_id: task.into(), kind: kind.into(), is_default: false }
+        PtyRole { task_id: task.into(), tab_id: None, kind: kind.into(), is_default: false }
     }
 
     // `termic quit`'s confirmation says "kills N agents across M tasks", and

--- a/src/components/task/TerminalPane.tsx
+++ b/src/components/task/TerminalPane.tsx
@@ -1546,7 +1546,14 @@ const captureArmedRef = useRef(false);
           // `termic attach` with several agents open stays
           // deterministic.
           role: isAgent
-            ? { task_id: task.id, kind: "agent" as const, is_default: isPrimaryTab && tab.cli === task.cli }
+            ? {
+                task_id: task.id,
+                // The stable selector `--tab` resolves to. Index and title
+                // both move; this does not.
+                tab_id: tab.id,
+                kind: "agent" as const,
+                is_default: isPrimaryTab && tab.cli === task.cli,
+              }
             : undefined,
           rows, cols,
         });

--- a/src/lib/cliRpc.ts
+++ b/src/lib/cliRpc.ts
@@ -39,7 +39,9 @@ import { withCreateLock } from "@/lib/createLock";
 import { markUnattendedSpawn } from "@/lib/unattendedSpawns";
 import { reportCliPromptDelivery } from "@/lib/cliPromptReports";
 import { deliverMessage } from "@/lib/agentSend";
-import { agentDisplayName, isTerminalCli, workDoneCapable } from "@/lib/agents";
+import {
+  agentDisplayName, isTerminalCli, isTerminalEntry, visibleCliIds, workDoneCapable,
+} from "@/lib/agents";
 import { launchSetupTab } from "@/lib/runTabs";
 import {
   derivedBranch,
@@ -568,11 +570,238 @@ async function projectRemoveHandler(params: unknown): Promise<null> {
   return null;
 }
 
+// ─────────────────── registry view shared by tab + agents ────────────
+//
+// ONE definition of "can I open a tab with this?", so `termic agents` cannot
+// advertise something `termic tab` then refuses. Both read the same cached
+// registry + detection the "+" menu does; detection is a login-shell probe per
+// agent, so re-running it per call would put hundreds of ms on a hot path.
+
+interface RegistryEntry {
+  id: string;
+  kind: string;
+  enabled: boolean;
+  installed: boolean | null;
+  usable: boolean;
+}
+
+function registryView(): RegistryEntry[] {
+  const app = useApp.getState();
+  const detected = app.detectedClis;
+  const detectionRan = Object.keys(detected).length > 0;
+  const usableAgents = visibleCliIds(app.agents.map(a => a.id), app.agents, detected);
+  return app.agents.map(a => {
+    const terminal = isTerminalEntry(a);
+    const enabled = !a.disabled;
+    // `null` means detection has not run, which is NOT "not installed" and
+    // must not be rendered as a cross.
+    const installed = !detectionRan || terminal ? null : (detected[a.id]?.found ?? null);
+    return {
+      id: a.id,
+      kind: terminal ? "terminal" : "agent",
+      enabled,
+      installed,
+      // Terminal entries have nothing to detect; agents defer to the same
+      // visibleCliIds the "+" menu filters on.
+      usable: terminal ? enabled : usableAgents.has(a.id),
+    };
+  });
+}
+
+/** Hydrate what `registryView` reads, for callers that can arrive before the
+ *  app has finished booting.
+ *
+ *  BOTH maps matter, and they fail differently. An empty `agents` makes
+ *  `termic agents` answer "No agents configured." with exit 0, a lie a script
+ *  cannot tell from a genuinely empty registry. An empty `detectedClis` is
+ *  worse for `tab`: `visibleCliIds` treats "detection has not run" as "assume
+ *  everything is present" (agents.ts), so every enabled agent reports
+ *  `usable: true, installed: null` and `--agent <uninstalled>` is ACCEPTED,
+ *  failing later when the PTY dies on exec. `refreshClis` normally fires from
+ *  App.tsx, but `termic tab` auto-launches the app and can win that race. */
+async function ensureRegistryHydrated(): Promise<void> {
+  const s = useApp.getState();
+  await Promise.all([
+    s.agents.length === 0 ? s.loadAll() : Promise.resolve(),
+    // Best-effort: a detection failure must not take down the verb. Falling
+    // back to the permissive view is the pre-existing behavior.
+    Object.keys(s.detectedClis).length === 0
+      ? s.refreshClis().catch(() => {})
+      : Promise.resolve(),
+  ]);
+}
+
+async function listAgentsHandler(): Promise<{ agents: RegistryEntry[] }> {
+  await ensureRegistryHydrated();
+  return { agents: registryView() };
+}
+
+// ─────────────────────────── new_tab (GH #138) ───────────────────────
+
+interface NewTabParams {
+  taskId: string;
+  /** "agent" | "terminal" | "shell" | "default" */
+  kind: string;
+  /** Registry id, for the agent and terminal kinds. */
+  id?: string;
+}
+
+/**
+ * Open a tab inside a running task: the "+" menu as an RPC.
+ *
+ * Validation is the part with no GUI equivalent. The menu simply HIDES a
+ * disabled or uninstalled agent (visibleCliIds), but a CLI caller has no menu
+ * to look at, so an unusable id has to come back as an error naming the ids
+ * that would work, rather than a tab whose PTY dies on exec.
+ *
+ * Deliberately does NOT focus the new tab. A shell command should not yank the
+ * user's view mid-work, the same reasoning that keeps `--headless` from
+ * stealing a window; the GUI's "+" focuses because a human just clicked it.
+ */
+// Exported for the store-sequence test: the ordering rules below are
+// invisible in this function's own code (they are properties of addTab /
+// syncDurableTabs), so the test has to drive the REAL handler. A test that
+// re-implements the sequence passes against a copy of the bug.
+export async function newTabHandler(raw: unknown): Promise<{
+  taskId: string; tabId: string; cli: string; title: string;
+}> {
+  const p = raw as NewTabParams;
+  if (typeof p?.taskId !== "string" || !p.taskId) throw new Error("new_tab requires a taskId");
+  const app0 = useApp.getState();
+  if (!app0.tasks.some(t => t.id === p.taskId)) await app0.loadAll();
+  // Same cold-launch race as `agents`, and it decides an ACCEPT/REJECT here
+  // rather than a display value: without detection every enabled agent looks
+  // usable, so an uninstalled --agent slips through and dies at exec.
+  //
+  // Skipped for `shell`, which validates nothing against the registry.
+  // Hydration runs a login-shell PATH probe per agent, so doing it there
+  // would race App.tsx's own refreshClis to no purpose.
+  if (p.kind !== "shell") await ensureRegistryHydrated();
+  const app = useApp.getState();
+  const task = app.tasks.find(t => t.id === p.taskId);
+  if (!task) throw new Error(`unknown task ${p.taskId}`);
+  if (task.archived) throw new Error(`task ${task.name} is archived`);
+
+  const registry = app.agents;
+  let cli: string;
+  // Extra tab fields a kind may need (a custom task's launch command).
+  let extra: Record<string, unknown> = {};
+  switch (p.kind) {
+    case "shell":
+      cli = "shell";
+      break;
+    case "default": {
+      cli = task.cli;
+      // A custom-command task's tab carries its launch command; without it
+      // TerminalPane spawns a bare login shell that STILL gets task_id, i.e.
+      // a caged terminal the user types into. That is the exact shape #32
+      // removed, and the "+" menu cannot produce it because it never offers
+      // `custom`.
+      if (cli === "custom") {
+        const cmd = (task as { custom_command?: string | null }).custom_command;
+        if (!cmd) throw new Error("this task has no launch command to reuse; pass --agent or --shell");
+        extra = { command: cmd };
+        break;
+      }
+      // Validated like an explicit --agent: otherwise `termic tab <task>`
+      // happily opens a disabled or uninstalled agent whose PTY dies on exec,
+      // while `--agent <same id>` refuses it. One verb, two answers.
+      if (cli !== "shell" && !registryView().some(e => e.id === cli && e.usable)) {
+        throw new Error(
+          `the task's agent is not usable: ${cli}. Enable or install it, or pass `
+          + "--agent/--shell (see `termic agents`)",
+        );
+      }
+      break;
+    }
+    case "agent": {
+      if (!p.id) throw new Error("new_tab agent kind requires an id");
+      const view = registryView();
+      if (!view.some(e => e.id === p.id && e.kind === "agent" && e.usable)) {
+        const known = registry.find(a => a.id === p.id);
+        const why = !known ? "unknown agent"
+          : known.disabled ? "agent is disabled in Settings"
+          : isTerminalEntry(known) ? "that is a custom terminal, use --terminal"
+          : "agent is not installed (not found on PATH)";
+        const usable = view.filter(e => e.kind === "agent" && e.usable).map(e => e.id).sort();
+        throw new Error(
+          `${why}: ${p.id}. Available: ${usable.join(", ") || "none"} (see \`termic agents\`)`,
+        );
+      }
+      cli = p.id;
+      break;
+    }
+    case "terminal": {
+      if (!p.id) throw new Error("new_tab terminal kind requires an id");
+      const view = registryView();
+      if (!view.some(e => e.id === p.id && e.kind === "terminal" && e.usable)) {
+        const usable = view.filter(e => e.kind === "terminal" && e.usable).map(e => e.id).sort();
+        throw new Error(
+          `unknown or disabled custom terminal: ${p.id}. Available: ${usable.join(", ") || "none"} (see \`termic agents\`)`,
+        );
+      }
+      cli = p.id;
+      break;
+    }
+    default:
+      throw new Error(`unknown tab kind: ${p.kind}`);
+  }
+
+  // A custom-command task's tab is titled with the TASK NAME, matching the
+  // store's own restore and seed paths (app.ts); agentDisplayName("custom")
+  // would render the generic "Command" instead and drift from the GUI.
+  const title = cli === "shell" ? "Terminal"
+    : cli === "custom" ? (task.name || "Command")
+    : agentDisplayName(cli, registry);
+  const tabId = crypto.randomUUID();
+  const s = useApp.getState();
+  // Mounting a STOPPED task (GH #119 evicts it from mountedTasks but keeps
+  // its tabs) respawns every agent in it. Asking for one tab should not undo
+  // an explicit "stop this task", so say what would happen instead of doing
+  // it. `send --resume` takes the other choice deliberately; there the user
+  // asked to talk to the agent, here they asked for a new tab.
+  //
+  // This MUST be read before the restore below. ensureDefaultTab REPOPULATES
+  // tabs[taskId] from persisted_tabs, so a post-restore read cannot tell a
+  // stopped task from one that was simply never opened this session, and
+  // refuses both. Nothing is mounted until setActiveTask/mountTasks runs, so
+  // that mistake refuses every task on a cold start, which is exactly the
+  // path `termic tab` auto-launches into.
+  const stopped = !s.mountedTasks.has(p.taskId) && (s.tabs[p.taskId]?.length ?? 0) > 0;
+  if (stopped) {
+    throw new Error(
+      `task ${task.name} is stopped; open it in Termic (or \`termic open\`) before adding a tab, `
+      + "so its other agents are not respawned as a side effect",
+    );
+  }
+  // RESTORE THE PERSISTED SET FIRST, exactly as sendPromptHandler does.
+  // addTab runs syncDurableTabs, which treats whatever is in the store as the
+  // live set: on a task that has not been mounted this session (the CLI's
+  // whole use case) that set is EMPTY, so pre-adding would rewrite
+  // persisted_tabs to just the new tab and forget every secondary agent's
+  // session id, permanently. It would also make the new tab the task's first
+  // tab of its cli, i.e. is_default, hijacking what attach/logs/send resolve
+  // to and handing it the main session's cwd-resume.
+  //
+  // Unconditional, like sendPromptHandler. ensureDefaultTab already no-ops
+  // when live main tabs exist, so guarding on persisted_tabs.length buys
+  // nothing and skips the SEED path, which is precisely what a task with an
+  // empty durable set needs (main tab X-ed, or a legacy pre-persistence
+  // record). Skipping it leaves the task holding only this new tab, and
+  // TaskView's mount effect then early-returns because a main tab exists.
+  s.ensureDefaultTab(p.taskId, task.cli);
+  s.mountTasks([p.taskId]);
+  s.addTab(p.taskId, { id: tabId, type: "terminal", title, cli, ...extra }, { focus: false });
+  return { taskId: p.taskId, tabId, cli, title };
+}
+
 // ─────────────────────────── dispatch ────────────────────────────────
 
 const handlers: Record<string, Handler> = {
   open_task: openTaskHandler,
   new_task: newTaskHandler,
+  new_tab: newTabHandler,
+  list_agents: listAgentsHandler,
   send_prompt: sendPromptHandler,
   archive_task: archiveTaskHandler,
   project_add: projectAddHandler,

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -462,7 +462,9 @@ export interface SpawnArgs {
    *  aux shell stays uncaged yet attachable. Omit for setup/run tabs and
    *  ad-hoc shells the CLI cannot address; role-tagged PTYs also retain
    *  an output ring Rust-side for `termic logs`. */
-  role?: { task_id: string; kind: "agent" | "aux"; is_default?: boolean };
+  /** Mirrors Rust's `PtyRole`. `tab_id` is the stable selector `--tab`
+   *  resolves to (index and title both move; the tab uuid does not). */
+  role?: { task_id: string; tab_id?: string; kind: "agent" | "aux"; is_default?: boolean };
 }
 
 /** Sandbox status returned alongside the PTY id - tells the caller

--- a/src/store/cliTab.integration.test.ts
+++ b/src/store/cliTab.integration.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment happy-dom
+//
+// `termic tab` (GH #138) driven through the REAL `newTabHandler` against the
+// REAL store. Both matter:
+//
+//   - Real store, because the rules are properties of `addTab` /
+//     `syncDurableTabs`, not of the handler's own code. `syncDurableTabs`
+//     treats whatever is in the store as the task's LIVE tab set, so on a task
+//     that has not been mounted this session (the CLI's whole use case) that
+//     set is EMPTY and a pre-added tab rewrites `persisted_tabs` to just that
+//     tab, forgetting every other agent's session id permanently, on disk.
+//   - Real handler, because an earlier version of this file re-implemented the
+//     handler's sequence in a local helper and therefore tested a COPY. It
+//     passed while the shipped path refused every unmounted task (the restore
+//     ran before the stopped check, so the check saw the tabs it had just
+//     restored). A test that mirrors the code cannot catch the code.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/ipc", () => ({
+  ptyKill: vi.fn().mockResolvedValue(undefined),
+  taskSetTabs: vi.fn().mockResolvedValue(undefined),
+  taskSetTabSessionId: vi.fn().mockResolvedValue(undefined),
+  taskSetTabPreviousSessionId: vi.fn().mockResolvedValue(undefined),
+  // PATH detection: claude present, codex absent. Drives the cold-launch
+  // case below, where the handler must run this before validating --agent.
+  detectClis: vi.fn().mockResolvedValue([
+    { name: "claude", found: true, path: "/usr/bin/claude" },
+    { name: "codex", found: false, path: null },
+  ]),
+}));
+vi.mock("@/lib/tabFocus", () => ({ focusTerminalTab: vi.fn() }));
+// The handler module pulls in the Tauri event API at import time.
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn().mockResolvedValue(() => {}) }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn().mockResolvedValue(null) }));
+
+import { newTabHandler } from "@/lib/cliRpc";
+import { useApp } from "@/store/app";
+import * as ipc from "@/lib/ipc";
+import type { Task } from "@/lib/types";
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "ws1", project_id: "p1", name: "fix-auth", branch: "main",
+    base_branch: "main", path: "/x/ws1", cli: "claude", port: 1420,
+    created: "2024-01-01", archived: false,
+    // Two durable agents, each with its own session. The second is the one
+    // a naive implementation loses.
+    persisted_tabs: [
+      { id: "main", cli: "claude", title: "claude", is_default: true, session_id: "SESSION-A" },
+      { id: "second", cli: "codex", title: "codex", session_id: "SESSION-B" },
+    ],
+    ...over,
+  } as unknown as Task;
+}
+
+/** An enabled+installed registry so kind validation passes. */
+const AGENTS = [
+  { id: "claude", name: "Claude Code", disabled: false },
+  { id: "codex", name: "Codex", disabled: false },
+];
+
+/** Real `CliInfo` shape. Seeding bare strings here would still let the happy
+ *  paths pass (both readers fall back with `?? true` / `?? null`), which means
+ *  the suite would silently be testing "detection ran but every entry is
+ *  garbage" rather than the case it names. */
+const cliInfo = (name: string, found: boolean) => ({
+  name, found, path: found ? `/usr/bin/${name}` : "", version: found ? "1.0.0" : "",
+});
+
+function seed(over: Partial<Task> = {}) {
+  useApp.setState({
+    tasks: [task(over)],
+    tabs: {},
+    mountedTasks: new Set(),
+    agents: AGENTS,
+    detectedClis: { claude: cliInfo("claude", true), codex: cliInfo("codex", true) },
+  } as never);
+}
+
+// NOTE: live tabs carry `is_default` (snake_case), matching persisted_tabs.
+// Asserting a camelCase `isDefault` silently reads undefined and passes.
+const tabsOf = (id = "ws1") =>
+  useApp.getState().tabs[id] as Array<{
+    id: string; cli: string; sessionId?: string | null; session_id?: string | null;
+    is_default?: boolean;
+  }>;
+
+describe("termic tab: opening a tab on an unmounted task", () => {
+  beforeEach(() => seed());
+
+  it("succeeds on a task the user has not opened this session", async () => {
+    // The cold-start path, and the one `tab` auto-launches into: nothing is
+    // mounted until setActiveTask/mountTasks runs, so a "stopped" check that
+    // fires after the persisted set is restored refuses EVERY task.
+    await expect(newTabHandler({ taskId: "ws1", kind: "shell" })).resolves.toMatchObject({
+      taskId: "ws1",
+      cli: "shell",
+    });
+  });
+
+  it("keeps every persisted agent and its session id", async () => {
+    await newTabHandler({ taskId: "ws1", kind: "agent", id: "claude" });
+
+    const ids = tabsOf().map(t => t.id);
+    expect(ids).toContain("main");
+    expect(ids).toContain("second");
+    // The session ids are the irreplaceable part: losing one means the agent
+    // can never be resumed again.
+    expect(tabsOf().find(t => t.id === "second")?.sessionId).toBe("SESSION-B");
+  });
+
+  it("does not make the new tab the task's default target", async () => {
+    // `is_default` decides what attach/logs/send resolve to. If the persisted
+    // set were dropped, the CLI's tab would be the first of its cli and would
+    // silently inherit that role, plus the main session's cwd-resume.
+    const { tabId } = await newTabHandler({ taskId: "ws1", kind: "agent", id: "claude" });
+    const dflt = tabsOf().find(t => t.is_default);
+    expect(dflt?.id).toBe("main");   // asserted positively: a missing flag must fail
+    expect(dflt?.id).not.toBe(tabId);
+  });
+
+  it("a shell tab does not strand the task without an agent", async () => {
+    // Shell tabs are not durable, so a naive pre-add leaves persisted_tabs
+    // holding only the default and the task wakes with no agent at all.
+    await newTabHandler({ taskId: "ws1", kind: "shell" });
+    const clis = tabsOf().map(t => t.cli);
+    expect(clis).toContain("claude");
+    expect(clis).toContain("codex");
+    expect(clis).toContain("shell");
+  });
+});
+
+describe("termic tab: a task whose durable set is empty", () => {
+  // The main tab X-ed out, or a legacy record from before tab persistence.
+  // `sendPromptHandler` handles this state explicitly; `tab` must too, or the
+  // seed never runs and the task is left with only the CLI's own tab.
+  beforeEach(() => seed({ persisted_tabs: [] }));
+
+  it("still seeds the task's agent alongside a shell tab", async () => {
+    await newTabHandler({ taskId: "ws1", kind: "shell" });
+    const clis = tabsOf().map(t => t.cli);
+    expect(clis).toContain("shell");
+    // Without the seed, TaskView's mount effect early-returns (a main tab now
+    // exists) and the task is agentless with nothing left to seed it.
+    expect(clis).toContain("claude");
+  });
+
+  it("leaves a default target for attach/logs/send", async () => {
+    // A secondary agent differing from task.cli must not become is_default.
+    await newTabHandler({ taskId: "ws1", kind: "agent", id: "codex" });
+    const dflt = tabsOf().find(t => t.is_default);
+    expect(dflt?.cli).toBe("claude");
+  });
+});
+
+describe("termic tab: cold launch, before PATH detection has run", () => {
+  // `termic tab` auto-launches the app, so it can beat App.tsx's refreshClis.
+  // visibleCliIds treats an empty detection map as "assume everything is
+  // present", which would ACCEPT an uninstalled agent and fail later at exec.
+  beforeEach(() => {
+    seed();
+    useApp.setState({ detectedClis: {} } as never);
+  });
+
+  it("detects first, then refuses an agent that is not installed", async () => {
+    await expect(
+      newTabHandler({ taskId: "ws1", kind: "agent", id: "codex" }),
+    ).rejects.toThrow(/not installed/);
+  });
+
+  it("still opens an agent that IS installed", async () => {
+    await expect(
+      newTabHandler({ taskId: "ws1", kind: "agent", id: "claude" }),
+    ).resolves.toMatchObject({ cli: "claude" });
+  });
+
+  it("does not probe PATH for a shell tab, which validates nothing", async () => {
+    // Detection spawns a login shell per agent. Paying that on the one kind
+    // with nothing to validate would race App.tsx's refreshClis for no gain.
+    vi.mocked(ipc.detectClis).mockClear();
+    await newTabHandler({ taskId: "ws1", kind: "shell" });
+    expect(ipc.detectClis).not.toHaveBeenCalled();
+  });
+});
+
+describe("termic tab: a genuinely stopped task", () => {
+  it("is refused rather than respawning every agent in it", async () => {
+    // GH #119 evicts a stopped task from mountedTasks but KEEPS its live tabs.
+    // That live set, not the restored one, is what marks it stopped.
+    seed();
+    useApp.setState({
+      tabs: { ws1: [{ id: "main", type: "terminal", title: "claude", cli: "claude" }] },
+      mountedTasks: new Set(),
+    } as never);
+    await expect(newTabHandler({ taskId: "ws1", kind: "shell" })).rejects.toThrow(/stopped/);
+  });
+});

--- a/termic-cli/src/lib.rs
+++ b/termic-cli/src/lib.rs
@@ -527,6 +527,76 @@ Exit codes: 0 success, 1 unknown or ambiguous task, 4 app not running, \
         project: Option<String>,
     },
 
+    /// List the agents and custom terminals `tab` will accept.
+    #[command(
+        after_help = "Answers \"what can I pass to --agent or --terminal?\". The registry is \
+per-user and editable in Settings, so it cannot live in static help.
+
+`usable` is the field to branch on: enabled in Settings, and found on PATH \
+where detection has an answer. `installed` is blank rather than false when \
+detection has not run, which is not the same as missing. One inherited \
+quirk: if detection resolves and finds NOTHING installed (a stripped GUI \
+PATH), every enabled agent is reported usable rather than stranding you \
+with an empty list, matching what the app's own menus do.
+
+Prints a table on stdout. With --output-format json, one object: \
+{\"agents\": [{\"id\", \"kind\", \"enabled\", \"installed\", \"usable\"}]}.
+
+Exit codes: 0 listed, 1 error, 4 app not running, 5 CLI disabled, \
+6 refused, 8 connection lost."
+    )]
+    Agents,
+    /// Open a tab inside a running task: the "+" tab menu as a command.
+    #[command(
+        after_help = "Opens an agent, custom-terminal or shell tab in a task that is already \
+running, and prints the new tab's id. That id is the stable selector: a \
+tab's index shifts when another closes, and its title is agent-authored and \
+changes mid-turn, so neither is safe for a script to key on.
+
+Kinds are separate flags, not one --kind value, because they differ in \
+SANDBOX behaviour: an agent tab inherits the task's sandbox pin, while \
+terminal and shell tabs are uncaged exactly as the GUI's are. A mistyped \
+kind must not silently downgrade a caged agent into an uncaged shell.
+
+--agent takes a registry id and fails if it is unknown, disabled in \
+Settings, or not installed, listing the ids that would work. The GUI just \
+hides those; a CLI caller has no menu to look at. With no kind flag you get \
+another tab of whatever the task already runs.
+
+The new tab is NOT focused: a shell command should not yank the window you \
+are working in. Sending a prompt into a specific tab lands with --tab \
+targeting (GH #138).
+
+LIMITATION, --shell and --terminal only: those tabs are write-only from the \
+CLI. They open, and you can use them in the window, but `attach` and `logs` \
+cannot reach them and no output history is kept, because only agent tabs \
+carry the PTY role those commands resolve against. That is deliberate: \
+terminal tabs are never sandboxed (so git and ssh work), and putting an \
+uncaged PTY on the control socket where it can be driven remotely is not \
+something to do without a use case.
+
+Prints the tab on stdout. With --output-format json, one object: \
+{\"task_id\", \"tab_id\", \"cli\", \"title\"}.
+
+Exit codes: 0 opened, 1 error (unknown or ambiguous task, unusable agent \
+id), 4 app not running, 5 CLI disabled, 6 refused, 8 connection lost."
+    )]
+    Tab {
+        /// Task name, task id, or qualified project/name.
+        task: Option<String>,
+        /// Project name, to disambiguate.
+        #[arg(long, requires = "task")]
+        project: Option<String>,
+        /// Agent registry id (claude, codex, ...). Must be enabled and installed.
+        #[arg(long, group = "tabkind")]
+        agent: Option<String>,
+        /// Custom terminal registry id (kind: "terminal" entries).
+        #[arg(long, group = "tabkind")]
+        terminal: Option<String>,
+        /// A plain login shell, uncaged like the GUI's.
+        #[arg(long, group = "tabkind")]
+        shell: bool,
+    },
     /// Quit Termic: every running agent dies with it. For the human at the keyboard, not for agents driving Termic.
     ///
     /// The only shell-side teardown for a windowless instance. Asks for
@@ -841,6 +911,38 @@ fn execute(cli: &Cli) -> Result<Output, CliError> {
             };
             let code = w.result.outcome.exit_code();
             Ok(Output { stdout: final_stdout(format, &output::wait_text(&w), &w), code })
+        }
+        Cmd::Agents => {
+            let data = client::request(&mut conn, proto::Command::Agents, &token)?;
+            let proto::ReplyData::Agents(a) = data else {
+                return Err(CliError::new(exit_code::ERROR, "unexpected reply to agents"));
+            };
+            Ok(Output::ok(final_stdout(format, &output::agents_text(&a), &a)))
+        }
+        Cmd::Tab { task, project, agent, terminal, shell } => {
+            let kind = if let Some(id) = agent {
+                proto::TabKind::Agent { id: id.clone() }
+            } else if let Some(id) = terminal {
+                proto::TabKind::Terminal { id: id.clone() }
+            } else if *shell {
+                proto::TabKind::Shell
+            } else {
+                proto::TabKind::Default
+            };
+            let data = client::request(
+                &mut conn,
+                proto::Command::Tab {
+                    task: task.clone(),
+                    project: project.clone(),
+                    kind,
+                    cwd: std::env::current_dir().ok().map(|p| p.display().to_string()),
+                },
+                &token,
+            )?;
+            let proto::ReplyData::Tab(t) = data else {
+                return Err(CliError::new(exit_code::ERROR, "unexpected reply to tab"));
+            };
+            Ok(Output::ok(final_stdout(format, &output::tab_text(&t), &t)))
         }
         Cmd::Quit { yes } => execute_quit(&mut conn, &token, format, *yes, &paths),
         Cmd::Archive { task, project, yes } => {
@@ -1845,7 +1947,8 @@ mod tests {
             v["commands"].as_array().unwrap().iter().map(|c| c["name"].as_str().unwrap()).collect();
         for expected in [
             "list", "status", "open", "new", "send", "attach", "logs", "result", "diff",
-            "apply", "path", "wait", "archive", "quit", "project add", "project list",
+            "apply", "path", "wait", "archive", "tab", "agents", "quit", "project add",
+            "project list",
             "project remove", "help",
         ] {
             assert!(names.contains(&expected), "missing {expected} in {names:?}");

--- a/termic-cli/src/output.rs
+++ b/termic-cli/src/output.rs
@@ -4,9 +4,9 @@
 
 use serde::Serialize;
 use termic_proto::{
-    send_mode, ApplyData, ArchiveData, DiffData, DiffStat, NewData, OpenData, ProjectInfo,
-    ProjectRemoveData, QuitData, ResultData, SendData, StreamEvent, TaskStatus, TaskSummary, WaitData,
-    WaitOutcome, WaitResult,
+    send_mode, AgentsData, ApplyData, ArchiveData, DiffData, DiffStat, NewData, OpenData,
+    ProjectInfo, ProjectRemoveData, QuitData, ResultData, SendData, StreamEvent, TabData,
+    TaskStatus, TaskSummary, WaitData, WaitOutcome, WaitResult,
 };
 
 /// One JSON object, compact, exactly as documented in each verb's help.
@@ -371,9 +371,64 @@ fn plural(n: u32, one: &str, many: &str) -> String {
     format!("{n} {}", if n == 1 { one } else { many })
 }
 
+/// The registry as a table. `usable` is what a caller acts on, so it gets a
+/// column of its own rather than being left implied by the other two: an entry
+/// can be enabled but missing from PATH, and that combination is exactly the
+/// one that produces a confusing `tab` failure.
+pub fn agents_text(a: &AgentsData) -> String {
+    if a.agents.is_empty() {
+        return "No agents configured.".into();
+    }
+    // Registry ids are user-editable (`my-custom-terminal` is 18 chars), and
+    // this table is documented output, so size the column to the data rather
+    // than to a constant that a long id silently breaks. Never narrower than
+    // the header.
+    let idw = a
+        .agents
+        .iter()
+        .map(|e| e.id.chars().count())
+        .max()
+        .unwrap_or(0)
+        .max("ID".len());
+    let mut out = format!("{:<idw$} KIND      ENABLED  INSTALLED  USABLE\n", "ID");
+    for e in &a.agents {
+        let installed = match e.installed {
+            Some(true) => "yes",
+            Some(false) => "no",
+            // Blank, not "no": detection may simply not have run.
+            None => "-",
+        };
+        out.push_str(&format!(
+            "{:<idw$} {:<9} {:<8} {:<10} {}\n",
+            e.id,
+            e.kind,
+            if e.enabled { "yes" } else { "no" },
+            installed,
+            if e.usable { "yes" } else { "no" },
+        ));
+    }
+    out.trim_end().to_string()
+}
+
+/// One line naming the tab and, crucially, its id: that id is the stable
+/// selector, so printing it is what lets a script address the tab it just
+/// made instead of racing an index or an agent-authored title.
+pub fn tab_text(t: &TabData) -> String {
+    // `title` is what the tab shows in the GUI, and it is the only useful
+    // label when it differs from the cli id: a custom-command task's tab is
+    // titled with the TASK NAME, so printing `cli` alone would say "custom".
+    let label = if t.title.is_empty() || t.title.eq_ignore_ascii_case(&t.cli) {
+        t.cli.clone()
+    } else {
+        format!("{} ({})", t.title, t.cli)
+    };
+    format!("Opened {label} tab {} in {}.", t.tab_id, t.task_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use termic_proto::AgentEntry;
 
     fn d(tasks: u32, agents: u32, working: Option<u32>) -> QuitData {
         QuitData { running: true, tasks_with_agents: tasks, live_agents: agents, working_tasks: working, quitting: false }
@@ -404,6 +459,84 @@ mod tests {
         let q = quit_question(&d(2, 5, Some(2)));
         assert!(q.contains("5 agents"), "{q}");
         assert!(q.contains("2 tasks still working"), "{q}");
+    }
+
+    // `installed` must render "-" for unknown, never "no": the two mean
+    // different things and a user reading "no" would go install something
+    // that is already there.
+    #[test]
+    fn agents_table_distinguishes_unknown_from_missing() {
+        let d = AgentsData {
+            agents: vec![
+                AgentEntry { id: "claude".into(), kind: "agent".into(), enabled: true, installed: Some(true), usable: true },
+                AgentEntry { id: "codex".into(), kind: "agent".into(), enabled: true, installed: Some(false), usable: false },
+                AgentEntry { id: "gemini".into(), kind: "agent".into(), enabled: true, installed: None, usable: true },
+            ],
+        };
+        let out = agents_text(&d);
+        assert!(out.contains("claude"), "{out}");
+        // unknown renders as a dash, not "no"
+        let gemini = out.lines().find(|l| l.starts_with("gemini")).unwrap();
+        assert!(gemini.contains(" -  "), "unknown must be a dash: {gemini}");
+        let codex = out.lines().find(|l| l.starts_with("codex")).unwrap();
+        assert!(codex.contains("no"), "{codex}");
+    }
+
+    #[test]
+    fn agents_table_is_not_empty_looking_when_there_are_none() {
+        assert_eq!(agents_text(&AgentsData { agents: vec![] }), "No agents configured.");
+    }
+
+    // Registry ids are user-editable, so the id column cannot be a constant.
+    // Every row's KIND must still start at the same column as the header's.
+    #[test]
+    fn agents_table_stays_aligned_when_an_id_is_longer_than_the_header() {
+        let d = AgentsData {
+            agents: vec![
+                AgentEntry { id: "my-very-long-custom-terminal".into(), kind: "terminal".into(), enabled: true, installed: None, usable: true },
+                AgentEntry { id: "cc".into(), kind: "agent".into(), enabled: true, installed: Some(true), usable: true },
+            ],
+        };
+        let out = agents_text(&d);
+        /// Column where the second field starts: first non-space after the id.
+        fn kind_col(line: &str) -> usize {
+            let id_end = line.find(' ').expect("row has an id");
+            line.len() - line[id_end..].trim_start().len()
+        }
+        let mut lines = out.lines();
+        let header = lines.next().unwrap();
+        let want = header.find("KIND").expect("header has KIND");
+        assert_eq!(kind_col(header), want);
+        for l in lines {
+            assert_eq!(kind_col(l), want, "misaligned row: {l:?}");
+        }
+        // And the long id is not truncated.
+        assert!(out.contains("my-very-long-custom-terminal"), "{out}");
+    }
+
+    // The id is the whole point of the line: it is what a script records.
+    #[test]
+    fn tab_text_prints_the_id() {
+        let t = TabData {
+            task_id: "ws1".into(), tab_id: "abc-123".into(),
+            cli: "claude".into(), title: "claude".into(),
+        };
+        let out = tab_text(&t);
+        assert!(out.contains("abc-123"), "{out}");
+        assert!(out.contains("claude"), "{out}");
+    }
+
+    #[test]
+    fn new_verbs_carry_no_em_dashes() {
+        let a = agents_text(&AgentsData {
+            agents: vec![AgentEntry { id: "claude".into(), kind: "agent".into(), enabled: true, installed: None, usable: true }],
+        });
+        let t = tab_text(&TabData {
+            task_id: "ws1".into(), tab_id: "x".into(), cli: "shell".into(), title: "Terminal".into(),
+        });
+        for s in [a, t] {
+            assert!(!s.contains('\u{2014}'), "em dash in CLI output: {s}");
+        }
     }
 
     // A stale work-state cache is UNKNOWN, not idle. Rendering it as silence

--- a/termic-proto/src/lib.rs
+++ b/termic-proto/src/lib.rs
@@ -31,7 +31,7 @@ use std::io::{self, BufRead, Read, Write};
 /// the bidirectional `attach` session (AttachFrame lines after the
 /// accepted request). Exit codes 10 (apply conflict) and 11 (attach
 /// target closed) become live.
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 
 /// serde default for `QuitData::running`.
 pub(crate) fn default_true() -> bool { true }
@@ -227,6 +227,24 @@ pub enum Command {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cwd: Option<String>,
     },
+    /// List the agent registry: what `--agent` / `--terminal` accept.
+    /// Answers "what can I pass?", which was otherwise only discoverable
+    /// by guessing wrong and reading the error (GH #138).
+    Agents,
+    /// Open a tab INSIDE a running task: the GUI's "+" menu as a verb.
+    /// The KIND is explicit rather than a string, because the kinds differ
+    /// in sandbox, resume and YOLO behaviour and a typo must not land the
+    /// caller in the wrong semantics (docs/plans/cli.md, GH #138).
+    Tab {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project: Option<String>,
+        kind: TabKind,
+        /// The CLI's working directory, for worktree-first resolution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cwd: Option<String>,
+    },
     /// Shut the app down: every PTY, script process group, in-flight grep
     /// and spotlight session goes with it (the same teardown Cmd-Q does).
     /// Authenticated, because it is the most destructive thing the socket
@@ -409,6 +427,28 @@ impl Reply {
     }
 }
 
+/// What `termic tab` opens. Separate variants rather than one string:
+/// an agent tab inherits the task's sandbox pin, while terminal and shell
+/// tabs are uncaged exactly as the GUI's are, so a mistyped kind must not
+/// silently downgrade a caged agent into an uncaged shell.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "tab", rename_all = "snake_case")]
+pub enum TabKind {
+    /// A `kind: "agent"` registry entry. Rejected if unknown, disabled or
+    /// not detected on PATH: the GUI hides those, but a CLI caller has no
+    /// menu to look at and must be told why.
+    Agent { id: String },
+    /// A `kind: "terminal"` custom entry (#27). Never resumes, no YOLO args.
+    Terminal { id: String },
+    /// A plain login shell tab in the task's strip, uncaged like the GUI's.
+    /// NOT the aux terminal: `attach --shell` / `logs --shell` resolve the
+    /// separate aux pane (role kind "aux"), which this does not create.
+    Shell,
+    /// Another tab of whatever the task already runs. What the `+` button
+    /// does before you pick anything.
+    Default,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ReplyData {
@@ -418,6 +458,8 @@ pub enum ReplyData {
     Open(OpenData),
     New(NewData),
     Wait(WaitData),
+    Agents(AgentsData),
+    Tab(TabData),
     Quit(QuitData),
     Archive(ArchiveData),
     ProjectList(ProjectListData),
@@ -485,6 +527,59 @@ pub struct WaitData {
     pub task_id: String,
     #[serde(flatten)]
     pub result: WaitResult,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentsData {
+    pub agents: Vec<AgentEntry>,
+}
+
+/// One registry entry, as the CLI sees it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentEntry {
+    /// What you pass to `--agent` or `--terminal`.
+    pub id: String,
+    /// "agent" or "terminal". Decides WHICH flag takes it, and with it the
+    /// sandbox behaviour, so it is not cosmetic.
+    pub kind: String,
+    /// Enabled in Settings. A disabled entry is rejected by `tab`.
+    pub enabled: bool,
+    /// Found on PATH. `None` when detection has not run yet, which is not
+    /// the same as "not installed" and must not be rendered as such.
+    #[serde(default)]
+    pub installed: Option<bool>,
+    /// Usable RIGHT NOW: enabled, and installed where that is known. The
+    /// single field a caller should branch on, so the enabled/installed
+    /// rule cannot drift between the CLI and the tab validator.
+    pub usable: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TabData {
+    /// The task the tab was opened in.
+    pub task_id: String,
+    /// The tab's stable store id. Printed for every kind so a script can
+    /// record what it made, and it never changes the way an index or an
+    /// agent-authored title does.
+    ///
+    /// Resolution caveat for part 2: only AGENT tabs carry a `PtyRole`
+    /// today, so only those are addressable by the RUST-NATIVE path
+    /// (`find_role_pty`, which `attach` and `logs` use). Anything routed
+    /// through the webview sees every tab, since the store holds them all.
+    /// Giving shell and custom-terminal tabs a role would close that gap
+    /// and is NOT a sandbox change: the cage keys on `pty_spawn`'s separate
+    /// `task_id` argument, not on `role`.
+    pub tab_id: String,
+    /// Resolved cli id ("claude", "shell", a custom terminal's id).
+    pub cli: String,
+    /// Display title the GUI gave it.
+    pub title: String,
+    // NOTE no `prompt_delivered`: `tab -p` lands with `--tab` targeting
+    // (GH #138 part 2). Delivering into a SPECIFIC tab needs the targeting
+    // this verb does not have yet, and `send_prompt`'s confirmed route picks
+    // from a task's sendable agent tabs. Reusing that route is the point;
+    // a second injection recipe would reintroduce the silently-dropped
+    // prompt Phase 1 exists to prevent.
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1146,6 +1241,19 @@ mod tests {
                 cwd: None,
             },
             Command::Wait { task: None, project: None, timeout_ms: None, cwd: Some("/t".into()) },
+            Command::Tab {
+                task: Some("fix-auth".into()),
+                project: None,
+                kind: TabKind::Agent { id: "claude".into() },
+                cwd: None,
+            },
+            Command::Tab {
+                task: None, project: None, kind: TabKind::Shell, cwd: None,
+            },
+            Command::Tab {
+                task: None, project: None, kind: TabKind::Default, cwd: None,
+            },
+            Command::Agents,
             Command::Quit { commit: false },
             Command::Quit { commit: true },
             Command::Archive { task: "fix-auth".into(), project: Some("web".into()) },
@@ -1263,6 +1371,21 @@ mod tests {
             ReplyData::Wait(WaitData {
                 task_id: "w1".into(),
                 result: WaitResult { outcome: WaitOutcome::Timeout, state: None, detail: Some("x".into()) },
+            }),
+            ReplyData::Agents(AgentsData {
+                agents: vec![AgentEntry {
+                    id: "claude".into(),
+                    kind: "agent".into(),
+                    enabled: true,
+                    installed: Some(true),
+                    usable: true,
+                }],
+            }),
+            ReplyData::Tab(TabData {
+                task_id: "w1".into(),
+                tab_id: "3f1c-…".into(),
+                cli: "claude".into(),
+                title: "claude".into(),
             }),
             ReplyData::Quit(QuitData {
                 running: true,


### PR DESCRIPTION
Part 1 of GH #138. Two commits: the verbs, then the plan updated to match.

## Why

The CLI could create tasks but never reach inside one. A task is a strip of tabs, so "open a second claude beside the first" was mouse-only.

```
termic tab <task> --agent claude     another agent beside the first
termic tab <task> --terminal <id>    a custom terminal entry (#27)
termic tab <task> --shell            a plain uncaged shell
termic tab <task>                    another of what the task runs
termic agents                        what those ids can be
```

`agents` exists because otherwise the only way to learn a valid id was to guess wrong and read the error. The registry is per-user and editable, so static `help --json` cannot carry it.

## Decisions

| Decision | Why |
|---|---|
| Tabs get a stable id (`PtyRole.tab_id`) | The webview already minted a uuid per tab; Rust never saw it. An index shifts when another tab closes and a title is agent-authored and changes mid-turn, so neither can be the identity. This is what `--tab` will resolve to in part 2. |
| Kinds are separate flags, not `--kind <string>` | They differ in **sandbox** behaviour: agent tabs inherit the task's pin, terminal and shell tabs are uncaged. A mistyped kind must not silently downgrade a caged agent into an uncaged shell. |
| Every kind is validated, including the no-flag default | Otherwise `termic tab <task>` opens an agent that `--agent <same id>` refuses. One verb, two answers. |
| Restore the persisted tab set **before** adding | `addTab` runs `syncDurableTabs`, which treats the store as the live set. On an unmounted task (the CLI's whole use case) that set is empty, so adding first rewrites `persisted_tabs` to just the new tab and forgets every other agent's session id, permanently. `sendPromptHandler` already guards this; both do now. |
| New tab is not focused; a stopped task is refused | A shell command should not yank the window you are working in, and respawning every agent in a stopped task is a poor side effect of asking for one tab. |

Both verbs go through the webview, sharing one `registryView()`, so `agents` cannot advertise something `tab` refuses. That is also where the cached PATH detection lives; answering from Rust would give a second verdict on "is this usable" that could disagree with the one gating tab creation.

Protocol v5.

## Known limitation

`--shell` and `--terminal` tabs are write-only from the CLI: `attach` and `logs` cannot reach them and no output is retained, because only agent tabs carry a `PtyRole`.

Left that way on purpose. Giving them a role would put an UNCAGED PTY on the control socket, where it could be driven remotely, and terminal tabs are uncaged by design so git and ssh work (#32). Not an escalation today (a caged agent cannot reach the socket at all, and `attach --shell` already drives the uncaged aux terminal), but it widens what the socket can reach for no use case we have. The 256 KiB retained-output ring per shell is the smaller reason.

Documented in `tab --help`.

## Tests

- **Store-level ordering test** pinning the persisted-set rule above. Verified to **fail** against the naive ordering, including the session-id loss.
- **Output goldens** for both formatters, covering `installed` unknown-vs-missing and the no-em-dash rule.
- **Proto round-trips** for all four kinds and both replies.

Verified live: a second agent tab opened beside the first (2 live PTYs), `--agent` with an uninstalled agent exits 1 naming the usable ids, a usable one exits 0, `--project` without a task exits 2.

Green: 290 cargo, 58 cli, 16 proto, 505 vitest, clippy at main's count.

## Plan updates (commit 2)

- #138 split into part 1 (this) and part 2: `--tab` targeting on send/wait/attach/logs, tabs in `status`, and `tab -p`.
- Selector stability moves from open question to settled.
- `tab -p` recorded as waiting on targeting: `send_prompt` is the confirmed delivery route and it picks from a task's sendable agent tabs rather than a named one, so a prompt into a specific new tab needs `--tab` first. A second injection recipe would reintroduce the silently-dropped prompt Phase 1 exists to prevent.
- `events --json` is now **sequenced behind agent hooks** rather than "deferred", which scheduled nothing and read as limbo. An event stream is a versioned public API consumed by scripts with nobody watching, so it should not publish `{"event":"done"}` on a heuristic. Hooks first, then the stream.

With this, every named Phase 3 item is resolved. What trails it are parks, not unfinished work: #138 part 2, the hooks-then-events sequence, and `termic mcp` (still not approved).
