### PR TITLE
test(cli): pin new_tab's default arm; the shell guard is live, not dead

### DIFF
--- a/src/lib/cliRpc.ts
+++ b/src/lib/cliRpc.ts
@@ -706,6 +706,11 @@ export async function newTabHandler(raw: unknown): Promise<{
       // Validated like an explicit --agent: otherwise `termic tab <task>`
       // happily opens a disabled or uninstalled agent whose PTY dies on exec,
       // while `--agent <same id>` refuses it. One verb, two answers.
+      //
+      // The shell short-circuit is live, not defensive: shell TASKS exist
+      // (NewTaskDialog's no-agent "Terminal" fallback persists cli="shell"),
+      // and the registry has no shell entry, so validating it like an agent
+      // would refuse every shell task's default tab as "not usable".
       if (cli !== "shell" && !registryView().some(e => e.id === cli && e.usable)) {
         throw new Error(
           `the task's agent is not usable: ${cli}. Enable or install it, or pass `

--- a/src/store/cliTab.integration.test.ts
+++ b/src/store/cliTab.integration.test.ts
@@ -153,6 +153,42 @@ describe("termic tab: a task whose durable set is empty", () => {
   });
 });
 
+describe("termic tab: the default kind (`termic tab <task>` with no flags)", () => {
+  it("reuses the task's agent", async () => {
+    seed();
+    await expect(newTabHandler({ taskId: "ws1", kind: "default" })).resolves.toMatchObject({
+      cli: "claude",
+    });
+  });
+
+  it("opens a shell task's tab instead of validating \"shell\" as an agent", async () => {
+    // task.cli = "shell" is a real persisted shape (NewTaskDialog's no-agent
+    // "Terminal" fallback), and the registry has no shell entry. Guards the
+    // `cli !== "shell"` short-circuit in the default arm: without it every
+    // shell task's `termic tab` would be refused as an unusable agent.
+    seed({ cli: "shell", persisted_tabs: [] });
+    await expect(newTabHandler({ taskId: "ws1", kind: "default" })).resolves.toMatchObject({
+      cli: "shell",
+      title: "Terminal",
+    });
+  });
+
+  it("refuses a task whose agent is not installed, like --agent would", async () => {
+    seed({ cli: "codex" });
+    useApp.setState({
+      detectedClis: { claude: cliInfo("claude", true), codex: cliInfo("codex", false) },
+    } as never);
+    await expect(newTabHandler({ taskId: "ws1", kind: "default" })).rejects.toThrow(/not usable/);
+  });
+
+  it("refuses a custom task with no launch command to reuse", async () => {
+    seed({ cli: "custom", persisted_tabs: [] });
+    await expect(newTabHandler({ taskId: "ws1", kind: "default" })).rejects.toThrow(
+      /no launch command/,
+    );
+  });
+});
+
 describe("termic tab: cold launch, before PATH detection has run", () => {
   // `termic tab` auto-launches the app, so it can beat App.tsx's refreshClis.
   // visibleCliIds treats an empty detection map as "assume everything is


### PR DESCRIPTION
Follow-up to the #154 review nit on `newTabHandler`'s default arm, which read the `cli !== "shell"` short-circuit as a dead condition ("drop it or add a comment").

The guard is live. Tasks with `cli = "shell"` are a real persisted shape (NewTaskDialog's no-agent "Terminal" fallback), and the registry never contains a shell entry, so dropping the guard would make `termic tab` on a shell task fail with "the task's agent is not usable: shell". The existing comment only explained agent validation, which is exactly why the condition read as dead; the new comment states the shell exemption directly.

Also gives the default kind its first specs, mutation-verified (each fails if the behavior it pins is broken):

- reuses the task's agent
- opens a shell task's tab instead of validating "shell" against the registry
- refuses a task whose agent is not installed, matching `--agent`
- refuses a custom task with no launch command to reuse

Related: #138 (this branch will carry the part 2 work).