### PR TITLE
fix(diff): keep the gutter aligned with the code

### DIFF
--- a/docs/plans/e2e-coverage.md
+++ b/docs/plans/e2e-coverage.md
@@ -52,6 +52,7 @@ until `make e2e` is green and this file reflects it.
 | ✅ Git stage/unstage/commit | Stage → unstage → re-stage + commit → clean | `git.e2e.ts` |
 | ✅ Task rename/delete | Rename updates store+sidebar; delete removes the task entirely | `task.e2e.ts` |
 | ✅ Git diff | Open a diff tab for a changed file | `git.e2e.ts` |
+| ✅ Inline review comments | Select a diff line → tooltip → compose → save, three times; line numbers stay level with the code throughout (GH #157) | `git.e2e.ts` |
 | ✅ Find in files | ⇧⌘F opens; a repo-present query returns a result row | `files.e2e.ts` |
 | ✅ Markdown preview | Preview view renders the README markdown (h1) | `editor.e2e.ts` |
 | ✅ File tree | Create a folder → expand reveals its child → collapse hides it | `files.e2e.ts` |

--- a/e2e/specs/git.e2e.ts
+++ b/e2e/specs/git.e2e.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { archiveTask, clickByText, openTask, requireTermicApi, snap, waitForAppShell, waitForText, waitForTextGone } from "../helpers";
+import { archiveTask, clickByText, openTask, requireTermicApi, snap, waitForAppShell, waitForText, waitForTextGone, waitGone, waitVisible } from "../helpers";
 
 // Git integration is central to termic (every task is a worktree/checkout).
 // This guards the Git panel: switching to it shows the working-tree status.
@@ -389,5 +389,131 @@ describe("git commit & push", () => {
     ).toString();
     expect(log).toContain("e2e push commit");
     await snap("commit-push.png");
+  });
+});
+
+// GH #157: inline review comments are CodeMirror block widgets, and CodeMirror
+// sizes the line-number gutter from a height map it fills by measuring each
+// widget's border box. Vertical margin on the measured element is space it
+// never counts, so the gutter sheared away from the code, ~12px per comment.
+// Only a real layout engine can see that, so it lives here rather than in
+// reviewCommentsExt.test.ts (happy-dom has no layout).
+describe("review comment alignment", () => {
+  let taskId: string | undefined;
+  after(async () => {
+    if (taskId) await archiveTask(taskId);
+  });
+
+  /**
+   * Vertical offset between each gutter element and the content block beside
+   * it. A constant offset is fine (the columns can share a padding); what #157
+   * produced was a SPREAD, the offset growing line by line down the file.
+   */
+  const gutterDrift = () =>
+    browser.execute(() => {
+      const ed = [...document.querySelectorAll(".cm-editor")]
+        .find((e) => e.getBoundingClientRect().height > 0);
+      if (!ed) return null;
+      const lines = [...(ed.querySelector(".cm-content")?.children ?? [])]
+        .filter((el) => el.classList.contains("cm-line"));
+      // One gutter element per rendered line, in the same order (CodeMirror's
+      // lineNumbers has no widget marker, so block widgets get none) — EXCEPT
+      // the zero-height hidden spacer that sizes the column to the widest
+      // number. Pair by index once that is dropped; the counts matching is the
+      // proof the pairing is real, so report them.
+      const nums = [...ed.querySelectorAll(".cm-lineNumbers .cm-gutterElement")]
+        .filter((el) => getComputedStyle(el).visibility !== "hidden");
+      const drifts = lines.map((line, i) =>
+        (nums[i]?.getBoundingClientRect().top ?? NaN) - line.getBoundingClientRect().top);
+      return {
+        lines: lines.length,
+        nums: nums.length,
+        spread: drifts.length ? Math.max(...drifts) - Math.min(...drifts) : NaN,
+      };
+    });
+
+  /**
+   * Leave a comment the way a user does: select the line, click the tooltip
+   * button that raises, type, save. Selecting is the only step that needs care
+   * — CodeMirror reads the DOM selection inside its content into state (a
+   * read-only editor doesn't even need focus for that), and a non-empty
+   * selection is what makes the "Comment on line N" tooltip appear.
+   */
+  async function addCommentOnLine(lineText: string, body: string) {
+    await browser.execute((text) => {
+      const ed = [...document.querySelectorAll(".cm-editor")]
+        .find((e) => e.getBoundingClientRect().height > 0);
+      const line = [...(ed?.querySelector(".cm-content")?.children ?? [])]
+        .find((el) => el.classList.contains("cm-line") && el.textContent?.trim() === text);
+      if (!line) throw new Error(`no rendered diff line reading: ${text}`);
+      const range = document.createRange();
+      range.selectNodeContents(line);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }, lineText);
+
+    await waitVisible(".tc-add-comment-btn");
+    await browser.execute(() => {
+      // The tooltip button commits on mousedown, so that the editor can't clear
+      // the selection out from under it first. `.click()` alone does nothing.
+      document.querySelector(".tc-add-comment-btn")!
+        .dispatchEvent(new MouseEvent("mousedown", { bubbles: true, cancelable: true }));
+    });
+
+    await waitVisible(".tc-comment-textarea");
+    await browser.execute((text) => {
+      const ta = document.querySelector(".tc-comment-textarea") as HTMLTextAreaElement;
+      ta.value = text;
+      ta.dispatchEvent(new Event("input", { bubbles: true })); // also runs autoGrow
+      (document.querySelector(".tc-comment-composer .tc-btn-primary") as HTMLElement).click();
+    }, body);
+    await waitGone(".tc-comment-textarea");
+  }
+
+  it("keeps the line numbers level with the code across several comments", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+    taskId = await openTask("e2e-comment-align");
+
+    // A diff long enough that drift below the comments is unmistakable. Append
+    // rather than rewrite: an added-only diff keeps @codemirror/merge's own
+    // deleted-chunk widgets out of the measurement.
+    await browser.execute(async (id) => {
+      const t = window.__termic!;
+      const orig = await t.ipc.taskFileRead(id, "README.md");
+      const added = Array.from({ length: 30 }, (_, i) => `align line ${i + 1}`).join("\n");
+      await t.ipc.taskFileWrite(id, "README.md", `${orig}\n${added}\n`);
+      t.useApp.getState().openPreviewTab(id, {
+        type: "diff",
+        path: "README.md",
+        title: "README.md",
+        scope: "unstaged",
+      });
+    }, taskId);
+
+    await browser.waitUntil(async () => ((await gutterDrift())?.lines ?? 0) >= 10, {
+      timeout: 15_000,
+      timeoutMsg: "the diff never rendered enough lines to measure",
+    });
+
+    // Baseline: no comment widgets in the content column yet.
+    const before = (await gutterDrift())!;
+    expect(before.nums).toEqual(before.lines);
+    expect(before.spread).toBeLessThan(2);
+
+    for (const n of [2, 5, 8]) await addCommentOnLine(`align line ${n}`, `comment on ${n}`);
+
+    await browser.waitUntil(
+      () => browser.execute(() => document.querySelectorAll(".tc-comment-card").length === 3),
+      { timeout: 10_000, timeoutMsg: "the three comment cards never mounted" },
+    );
+
+    // The cards push the code down; the numbers have to move with it. Before
+    // the fix this was ~36px by the bottom of the file.
+    const after = (await gutterDrift())!;
+    expect(after.nums).toEqual(after.lines);
+    expect(after.spread).toBeLessThan(2);
+    await snap("comment-alignment.png");
   });
 });

--- a/src/components/task/reviewCommentsExt.test.ts
+++ b/src/components/task/reviewCommentsExt.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+//
+// GH #157: the gutter drifted out of step with the code, ~12px per review
+// comment, cumulative. CodeMirror fills its height map from each block widget's
+// BORDER BOX, so vertical margin on the element `toDOM` returns is space it
+// never counts, and a widget that grows after being measured goes stale.
+//
+// No layout engine here, so these pin the structure that makes the geometry
+// correct, not the geometry: the measured element keeps the card's spacing
+// inside itself, and a growing composer re-syncs the height map. Real pixel
+// alignment is the "review comment alignment" case in e2e/specs/git.e2e.ts.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EditorView } from "@codemirror/view";
+import { reviewCommentsExtension, dispatchFileComment } from "./reviewCommentsExt";
+import { useReviewComments } from "@/store/reviewComments";
+
+const TASK = "task-157";
+const FILE = "src/thing.ts";
+const DOC = "one\ntwo\nthree\nfour\nfive\n";
+
+let views: EditorView[] = [];
+
+function mount() {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  const view = new EditorView({
+    parent,
+    doc: DOC,
+    extensions: [reviewCommentsExtension(TASK, FILE)],
+  });
+  views.push(view);
+  return view;
+}
+
+/** storeSyncPlugin seeds on a microtask, and widgets mount on the next tick. */
+const settle = () => new Promise(r => setTimeout(r, 0));
+
+function addComment(line: number, body: string) {
+  return useReviewComments.getState().add({
+    taskId: TASK, file: FILE, startLine: line, endLine: line, quote: "x", body,
+  });
+}
+
+/** The element CodeMirror measures for a widget: the shell we mounted it in. */
+const measuredBox = (inner: Element) => inner.parentElement!;
+
+/** happy-dom leaves unset lengths as "", which is 0 for our purposes. */
+const px = (v: string) => parseFloat(v) || 0;
+
+/**
+ * Does this element hold a child's vertical margin inside its border box? We
+ * use `flow-root`, but padding or any other block formatting context works too,
+ * so assert the property rather than the implementation.
+ */
+function containsChildMargins(el: Element): boolean {
+  const s = getComputedStyle(el);
+  return ["flow-root", "flex", "grid", "table", "inline-block"].includes(s.display)
+    || (s.overflow !== "" && s.overflow !== "visible")
+    || px(s.paddingTop) > 0;
+}
+
+/** The invariant the gutter depends on, asserted on the element CM measures. */
+function expectMeasuredBox(inner: Element, view: EditorView) {
+  const box = measuredBox(inner);
+  expect(box, "widget is not wrapped in a shell").not.toBe(view.contentDOM);
+  expect(containsChildMargins(box), `${box.firstElementChild?.className} shell is not a BFC`).toBe(true);
+  expect({ top: px(getComputedStyle(box).marginTop), bottom: px(getComputedStyle(box).marginBottom) })
+    .toEqual({ top: 0, bottom: 0 });
+}
+
+beforeEach(() => {
+  useReviewComments.getState().clear(TASK);
+});
+
+afterEach(() => {
+  for (const v of views) v.destroy();
+  views = [];
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("review comment block widgets", () => {
+  it("mounts a comment card in a measured box that owns its spacing", async () => {
+    addComment(2, "look at this");
+    const view = mount();
+    await settle();
+
+    const card = view.contentDOM.querySelector(".tc-comment-card");
+    expect(card).toBeTruthy();
+    expectMeasuredBox(card!, view);
+
+    // Guards against passing vacuously: if the spacing were simply deleted, a
+    // zero-margin measured box would prove nothing. The margin must still exist,
+    // just contained.
+    const s = getComputedStyle(card!);
+    expect(px(s.marginTop)).toBeGreaterThan(0);
+    expect(px(s.marginBottom)).toBeGreaterThan(0);
+  });
+
+  it("mounts the composer the same way", async () => {
+    const view = mount();
+    await settle();
+    dispatchFileComment(view);
+    await settle();
+
+    const composer = view.contentDOM.querySelector(".tc-comment-composer");
+    expect(composer).toBeTruthy();
+    expectMeasuredBox(composer!, view);
+  });
+
+  it("holds for every block widget once several comments stack up", async () => {
+    // The reported case: drift was invisible at one comment and obvious at
+    // three, so assert the invariant across all of them at once.
+    addComment(1, "a");
+    addComment(3, "b");
+    addComment(5, "c");
+    const view = mount();
+    await settle();
+    dispatchFileComment(view);
+    await settle();
+
+    expect(view.contentDOM.querySelectorAll(".tc-comment-card")).toHaveLength(3);
+
+    // Anything in the content column that is not a line is a block widget, so
+    // this also catches a NEW widget added later without a shell.
+    const blocks = Array.from(view.contentDOM.children).filter(el => !el.classList.contains("cm-line"));
+    expect(blocks.length).toBeGreaterThanOrEqual(4);
+    for (const b of blocks) expectMeasuredBox(b.firstElementChild!, view);
+  });
+
+  it("re-measures when the composer's textarea grows", async () => {
+    // The other half of the fix: the textarea auto-grows past the height
+    // CodeMirror measured on mount, which leaves a stale height in the map.
+    const view = mount();
+    await settle();
+    dispatchFileComment(view);
+    await settle(); // mount's own autoGrow has run by here
+
+    const ta = view.contentDOM.querySelector<HTMLTextAreaElement>(".tc-comment-textarea")!;
+    const requestMeasure = vi.spyOn(view, "requestMeasure");
+
+    ta.value = "one\ntwo\nthree";
+    ta.dispatchEvent(new Event("input"));
+
+    expect(requestMeasure).toHaveBeenCalled();
+  });
+});

--- a/src/components/task/reviewCommentsExt.ts
+++ b/src/components/task/reviewCommentsExt.ts
@@ -87,6 +87,21 @@ function locLabel(start: number | null, end: number | null, file: string): strin
   return `${base} · line ${start}`;
 }
 
+// CodeMirror fills its height map (and so lays out the gutter) from each block
+// widget's BORDER BOX, so vertical margin on the element `toDOM` returns is
+// space it never counts and the gutter drifts further out of step with the code
+// on every widget (GH #157). A widget that resizes after being measured goes
+// stale the same way, hence the `requestMeasure` in the composer's `autoGrow`.
+/** Wrap a block widget so its measured box always equals the space it occupies. */
+function blockShell(inner: HTMLElement): HTMLElement {
+  const shell = document.createElement("div");
+  // flow-root, not block: a block formatting context is what keeps the card's
+  // own margins inside the box CodeMirror measures instead of collapsing out.
+  shell.style.display = "flow-root";
+  shell.appendChild(inner);
+  return shell;
+}
+
 // ── Widgets ───────────────────────────────────────────────────────────────
 
 class ComposerWidget extends WidgetType {
@@ -114,16 +129,22 @@ class ComposerWidget extends WidgetType {
     ta.className = "tc-comment-textarea";
     ta.placeholder = "Leave a comment for the agent…";
     ta.value = this.c.initialBody;
-    ta.rows = 1;
+    // Rough starting height (no layout yet, so `scrollHeight` is 0 here) to
+    // keep an edit composer from mounting at one line and popping open a frame
+    // later; `autoGrow` corrects for wrapping once it is in the document.
+    ta.rows = Math.min(this.c.initialBody.split("\n").length, 8);
     ta.spellcheck = false;
     ta.autocapitalize = "off";
     ta.setAttribute("autocorrect", "off");
     wrap.appendChild(ta);
 
-    // Start at one line, grow with content (Shift+Enter newlines) up to a cap.
+    // Grow with content (Shift+Enter newlines) up to a cap. The grow happens
+    // after CodeMirror measured the widget, so re-sync the height map or the
+    // gutter drifts (see `blockShell`); CodeMirror coalesces these per frame.
     const autoGrow = () => {
       ta.style.height = "auto";
       ta.style.height = `${Math.min(ta.scrollHeight, 220)}px`;
+      view.requestMeasure();
     };
     ta.addEventListener("input", autoGrow);
 
@@ -193,7 +214,7 @@ class ComposerWidget extends WidgetType {
       ta.setSelectionRange(ta.value.length, ta.value.length);
       autoGrow();
     }, 0);
-    return wrap;
+    return blockShell(wrap);
   }
 
   ignoreEvent() { return true; }
@@ -259,7 +280,7 @@ class CommentCardWidget extends WidgetType {
       useReviewComments.getState().remove(this.ctx.taskId, this.comment.id);
     });
 
-    return wrap;
+    return blockShell(wrap);
   }
 
   ignoreEvent() { return true; }
@@ -559,7 +580,8 @@ const baseTheme = EditorView.baseTheme({
   ".tc-add-comment-btn:hover": { background: "var(--color-accent-deep)", color: "#fff" },
   // Inline thread cards: an accent left rail ties them to the commented-line
   // stripe, a flat fill (no popover shadow) so they read as part of the diff,
-  // not floating over it.
+  // not floating over it. Vertical spacing belongs HERE, inside `blockShell`,
+  // never on the shell itself (GH #157).
   ".tc-comment-card, .tc-comment-composer": {
     margin: "3px 14px 9px 14px",
     padding: "8px 11px 9px",


### PR DESCRIPTION
Fixes #157.

The line-number gutter drifted below the code once a diff had inline review comments, ~12px per comment and cumulative, so three comments put the numbers a couple of lines out. Block widgets now mount inside a `flow-root` shell: the card's margin lands inside the element CodeMirror measures, and it stays there whatever the card CSS grows into later.

After the fix (see the issue for before):

<img width="238" height="619" alt="Screenshot 2026-08-03 at 4 52 23 PM" src="https://github.com/user-attachments/assets/0f633d65-d863-4d0e-abe5-6eaf3d64b71d" />
