### PR TITLE
feat(settings): expose the GPU terminal renderer toggle on macOS (#140)

### DIFF
--- a/docs/plans/e2e-coverage.md
+++ b/docs/plans/e2e-coverage.md
@@ -43,6 +43,7 @@ until `make e2e` is green and this file reflects it.
 | ✅ Git clean | Clean working-tree status for the fixture repo | `git.e2e.ts` |
 | ✅ Git dirty | Modify a file → Git panel leaves clean state, git status reports it | `git.e2e.ts` |
 | ✅ Settings | Toggling a preference lands in the prefs store + control reflects it | `settings.e2e.ts` |
+| ✅ GPU renderer toggle | Appearance → Terminal exposes the WebGL toggle on macOS (GH #140); flipping the real switch lands in prefs, both directions | `settings.e2e.ts` |
 | ✅ Tabs | Add a terminal tab via the "+" menu; switch active tab | `tabs-layout.e2e.ts` |
 | ✅ Tab rename | Double-click inline edit commits the new name | `tabs-layout.e2e.ts` |
 | ✅ Theme | Picker switches theme; palette class applied to `<html>` | `tabs-layout.e2e.ts` |

--- a/docs/plans/windows.md
+++ b/docs/plans/windows.md
@@ -54,8 +54,9 @@ deliberate rather than lucky.
   `"Cascadia Mono", Consolas, monospace`, `:138` carries `"Segoe UI"`. Both
   primary faces (JetBrains Mono, Inter Variable) are bundled via `@fontsource`.
 - **`IS_MAC` already exists** (`shortcuts.ts:257`) and ~12 sites branch on it.
-  Terminal copy/paste, the GPU-renderer toggle, the Option-as-Meta setting and
-  completion sounds are already gated off-mac.
+  Terminal copy/paste, the Option-as-Meta setting and completion sounds are
+  already gated off-mac. (The GPU-renderer toggle is shown on every platform
+  since GH #140; only its hint text branches on `IS_MAC`.)
 - **The e2e architecture ports better than standard Tauri.** We use the embedded
   `tauri-plugin-wdio-webdriver` (`wdio.conf.ts:36`, `driverProvider: "embedded"`),
   not `tauri-driver`, so the WebDriver server travels inside the app. Specs drive

--- a/e2e/specs/settings.e2e.ts
+++ b/e2e/specs/settings.e2e.ts
@@ -1,5 +1,20 @@
 import { archiveTask, dismissOverlays, openTask, pointerDrag, requireTermicApi, snap, waitForAppShell, waitForText, waitVisible } from "../helpers";
 
+/** Click the [role="switch"] in the settings row whose label matches exactly.
+ *  Toggle rows are label + switch inside one .justify-between wrapper
+ *  (Controls.tsx / AppearanceSection.tsx, same markup). */
+const clickToggleByLabel = (label: string) =>
+  browser.execute((lbl) => {
+    const labelEl = [...document.querySelectorAll("div")].find(
+      (d) => d.textContent?.trim() === lbl,
+    );
+    const sw = labelEl
+      ?.closest(".justify-between")
+      ?.querySelector('[role="switch"]') as HTMLElement | null;
+    if (!sw) throw new Error("toggle switch not found for: " + lbl);
+    sw.click();
+  }, label);
+
 // Settings/preferences subsystem. Guards that a real toggle in the Settings
 // overlay flips the pref in the prefs store and the control reflects it.
 describe("settings", () => {
@@ -31,16 +46,7 @@ describe("settings", () => {
     );
 
     // Click the actual toggle switch in that setting's row.
-    await browser.execute((lbl) => {
-      const labelEl = [...document.querySelectorAll("div")].find(
-        (d) => d.textContent?.trim() === lbl,
-      );
-      const sw = labelEl
-        ?.closest(".justify-between")
-        ?.querySelector('[role="switch"]') as HTMLElement | null;
-      if (!sw) throw new Error("toggle switch not found for: " + lbl);
-      sw.click();
-    }, LABEL);
+    await clickToggleByLabel(LABEL);
 
     // The prefs store must reflect the flip (poll, don't sleep).
     await browser.waitUntil(
@@ -78,7 +84,20 @@ describe("settings", () => {
 // to a control that lives ONLY there, so a section landing on the wrong rail
 // item fails here instead of in a bug report.
 describe("settings rail", () => {
+  /** Snapshot for the GPU-toggle case below. The case restores in its own
+   *  finally (so the NEXT case in this file never sees a flipped pref: the
+   *  preview case asserts a canvas mounts, and the DOM renderer creates
+   *  none); this after() is the backstop for the shared profile when the
+   *  whole run dies mid-case. Same discipline as the signal-inspector
+   *  snapshot. */
+  let gpuOriginal: boolean | undefined;
+
   after(async () => {
+    if (gpuOriginal !== undefined) {
+      await browser.execute((v) => {
+        window.__termic!.usePrefs.getState().setTerminalGpuEnabled(v);
+      }, gpuOriginal);
+    }
     await browser.execute(() => window.__termic!.useApp.getState().closeSettings());
   });
 
@@ -252,6 +271,51 @@ describe("settings rail", () => {
     const interfacePane = await paneText();
     expect(interfacePane).toContain("Dim inactive split panes");
     expect(interfacePane).not.toContain("Terminal font");
+  });
+
+  // GH #140: the GPU renderer toggle used to be hidden behind !IS_MAC, forcing
+  // Mac users to hand-edit localStorage to reach the DOM renderer (whose whole
+  // point on macOS is cutting the standing WindowServer cost of an idle WebGL
+  // surface). The suite runs on macOS, so asserting the control exists IS the
+  // regression guard for the exposure.
+  it("exposes the GPU renderer toggle on the Terminal tab and it lands in prefs", async () => {
+    // Explicitly select the Terminal sub-tab: a click on the rail item is a
+    // no-op when Appearance is already open, and the previous case leaves it
+    // on Interface.
+    await clickRail("Appearance");
+    await clickAppearanceTab("terminal");
+    await waitForText("GPU (WebGL) terminal renderer");
+
+    const LABEL = "GPU (WebGL) terminal renderer";
+    const original = await browser.execute(
+      () => window.__termic!.usePrefs.getState().terminalGpuEnabled,
+    );
+    gpuOriginal = original;
+    const pref = () =>
+      browser.execute(() => window.__termic!.usePrefs.getState().terminalGpuEnabled);
+
+    // The finally puts the pref back through the setter even when an
+    // assertion between the two clicks throws, so the next case (which needs
+    // the WebGL canvas) never runs with GPU off. Idempotent on success.
+    try {
+      await clickToggleByLabel(LABEL);
+      await browser.waitUntil(async () => (await pref()) === !original, {
+        timeout: 8_000,
+        timeoutMsg: "terminalGpuEnabled never flipped",
+      });
+
+      // Back through the same control, so the off -> on transition is
+      // exercised through the real switch too.
+      await clickToggleByLabel(LABEL);
+      await browser.waitUntil(async () => (await pref()) === original, {
+        timeout: 8_000,
+        timeoutMsg: "terminalGpuEnabled never flipped back",
+      });
+    } finally {
+      await browser.execute((v) => {
+        window.__termic!.usePrefs.getState().setTerminalGpuEnabled(v);
+      }, original);
+    }
   });
 
   it("does not spawn the preview pty until the preview is armed", async () => {

--- a/src/components/settings/AppearanceSection.tsx
+++ b/src/components/settings/AppearanceSection.tsx
@@ -115,7 +115,7 @@ export function AppearanceSection() {
           size="sm"
           disabled={atDefaults}
           onClick={resetAppearance}
-          title="Restore fonts, sizes, zoom, letter spacing, ligatures and font list filtering to their defaults."
+          title="Restore all Appearance settings (fonts, sizes, zoom, spacing, and terminal options) to their defaults."
         >
           Reset to defaults
         </Button>
@@ -191,17 +191,19 @@ export function AppearanceSection() {
         />
       )}
 
-      {/* Linux/Windows only: macOS WKWebView always has a working GPU path,
-          so exposing this there would only let a Mac user accidentally
-          downgrade themselves to the slower DOM renderer. */}
-      {!IS_MAC && (
-        <Toggle
-          label="GPU (WebGL) terminal renderer"
-          hint="On is the fast path. Turn off if typing feels laggy: some Linux/WebKitGTK setups run WebGL on a software rasterizer where the plain renderer is faster. Applies to terminals opened after the change (relaunch to switch every terminal)."
-          value={terminalGpuEnabled}
-          onChange={setTerminalGpuEnabled}
-        />
-      )}
+      {/* All platforms (GH #140). Mac WebGL always works, but each live GL
+          surface carries a standing WindowServer/compositor cost on macOS 26
+          even at zero draw calls — measured ~10pp WindowServer CPU per idle
+          visible terminal. Off trades throughput under heavy output for
+          battery; the default stays on. */}
+      <Toggle
+        label="GPU (WebGL) terminal renderer"
+        hint={IS_MAC
+          ? "Renders terminal text on the GPU, keeping heavy output fast and smooth. Turning it off uses less power while terminals sit idle, which can help battery life. Applies to terminals opened after the change; relaunch to switch the ones already open."
+          : "Renders terminal text on the GPU, keeping heavy output fast and smooth. Turn off if typing feels laggy: some Linux/WebKitGTK setups run WebGL on a software rasterizer, where the plain renderer is faster. Applies to terminals opened after the change; relaunch to switch the ones already open."}
+        value={terminalGpuEnabled}
+        onChange={setTerminalGpuEnabled}
+      />
 
       {/* Live terminal preview — spawns a real shell in $HOME so
           font + size + weight changes are reflected immediately

--- a/src/lib/terminalRenderer.ts
+++ b/src/lib/terminalRenderer.ts
@@ -36,9 +36,11 @@ function dumpRenderer(addon: WebglAddon | null): void {
  *  fire on a half-disposed terminal. If WebGL is unsupported (throw) OR the
  *  user disabled the GPU renderer (the `terminalGpuEnabled` pref — escape
  *  hatch for Linux/WebKitGTK boxes where WebGL runs on a software rasterizer
- *  and typing crawls), the load is skipped and xterm's built-in DOM renderer
- *  remains. Read once at mount; toggling the pref takes effect on the next
- *  terminal spawn (relaunch to switch every open terminal). */
+ *  and typing crawls, and for macOS battery users: on macOS 26 each live GL
+ *  surface costs ~10pp of standing WindowServer CPU even at zero draw calls,
+ *  GH #140), the load is skipped and xterm's built-in DOM renderer remains.
+ *  Read once at mount; toggling the pref takes effect on the next terminal
+ *  spawn (relaunch to switch every open terminal). */
 /** GH #70: the bundled JetBrains Mono is a lazy @font-face; xterm's WebGL atlas
  *  keys glyphs per (char, fg, bg, ext) with no font in the key, so a glyph
  *  rasterized against the fallback stays wrong-height until the cell happens to


### PR DESCRIPTION
Closes #140.

This removes the `!IS_MAC` guard so the existing "GPU (WebGL) terminal renderer" toggle shows up on macOS too. The default is still on for everyone; nothing changes unless you flip it. The hint text now differs per platform (battery on macOS, the software-rasterizer note on Linux/Windows).

I re-ran the issue's measurements before touching anything (macOS 26, M-series, WindowServer cputime deltas over 20s, same method as the report):

| Config (one idle, focused terminal) | WindowServer CPU |
|---|---|
| WebGL, cursor blink on (default) | 22.5% |
| WebGL, cursor blink off | 20.7% |
| DOM renderer, cursor blink on | 11.7% |

So about 10pp of standing WindowServer CPU per idle visible WebGL terminal on my machine (the issue saw 33pp on an M5 Pro). Cursor blink turned out to be irrelevant: with blink accounting for only 35 GL draw calls over 8 seconds and zero texture uploads, WindowServer still sat at ~21%. The cost comes from having a live GL surface in the layer tree at all, not from drawing. That's why exposing the existing pref is the fix here rather than some blink or debounce tweak, and why the old guard's comment ("macOS WKWebView always has a working GPU path") is still true but no longer a good reason to hide the escape hatch.

The DOM renderer is slower under heavy streaming output, which is termic's bread and butter, so the default stays on. Longer term, parking the WebGL addon while a terminal is idle and re-attaching on output would remove the idle cost for everyone without a toggle; happy to file that separately if there's interest.

Testing:

- New case in settings.e2e.ts asserts the toggle renders on Appearance -> Terminal (the suite runs on macOS, so that's the actual regression guard) and flips the pref through the real switch in both directions, restoring the shared profile even if it dies halfway.
- npm test 579/579; e2e suite 9/11 spec files green. git.e2e.ts and projects.e2e.ts fail identically with this change stashed, so those are pre-existing.
- Manually checked the DOM renderer path on macOS: pref off, no canvas in .xterm, .xterm-rows present, terminal fully usable.

Docs: dropped the "gated off-mac" mention in docs/plans/windows.md, added a coverage row in docs/plans/e2e-coverage.md. No changelog entry per repo convention (maintainer authors it at release time).