### PR TITLE
feat(app): Fall back to the command when a run command has no label

### DIFF
--- a/e2e/specs/run.e2e.ts
+++ b/e2e/specs/run.e2e.ts
@@ -7,7 +7,7 @@ import { archiveTask, ensureActiveTask, openTask, requireTermicApi, snap, waitFo
 // command. (No .termic.yaml needed, so the fixture repo stays clean.)
 describe("run tabs", () => {
   let taskId: string | undefined;
-  const MEMBER = "cmd:e2e-run";
+  const MEMBER = "label:e2e-run";
   after(async () => {
     if (taskId) await archiveTask(taskId);
   });
@@ -46,8 +46,9 @@ describe("run tabs", () => {
   });
 
   // An unlabeled command falls back to the command itself for both its tab
-  // identity (`cmd:<command>`, so two unlabeled commands never share a tab)
-  // and its visible title, clipped at 40 chars.
+  // identity (`cmd:<command>`, a namespace apart from a labeled command's
+  // `label:<label>`, so neither can collide with the other) and its visible
+  // title, clipped at 40 chars.
   it("titles an unlabeled command with its (clipped) command", async () => {
     const command = "echo unlabeled-run-command-with-a-very-long-tail";
     await browser.execute((id, cmd) => {
@@ -89,7 +90,7 @@ describe("run tabs", () => {
 // its PTY (what the Stop button does) and assert the run tab stops.
 describe("run stop", () => {
   let taskId: string | undefined;
-  const MEMBER = "cmd:e2e-stop";
+  const MEMBER = "label:e2e-stop";
   after(async () => {
     if (taskId) await archiveTask(taskId);
   });

--- a/e2e/specs/run.e2e.ts
+++ b/e2e/specs/run.e2e.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import path from "node:path";
-import { archiveTask, openTask, requireTermicApi, snap, waitForAppShell } from "../helpers";
+import { archiveTask, ensureActiveTask, openTask, requireTermicApi, snap, waitForAppShell } from "../helpers";
 
 // P0: the Run feature (#54/#124) launches commands in dedicated run tabs.
 // Guards a custom run: it opens a run tab whose PTY actually executes the
@@ -43,6 +43,45 @@ describe("run tabs", () => {
     // The launch wiring (a run tab created for the command) is the regression
     // surface here; PTY spawn + execution is covered by task-spawn's agent PTY.
     await snap("run.png");
+  });
+
+  // An unlabeled command falls back to the command itself for both its tab
+  // identity (`cmd:<command>`, so two unlabeled commands never share a tab)
+  // and its visible title, clipped at 40 chars.
+  it("titles an unlabeled command with its (clipped) command", async () => {
+    const command = "echo unlabeled-run-command-with-a-very-long-tail";
+    await browser.execute((id, cmd) => {
+      window.__termic!.runTabs.launchCustomRun(id, { label: "", command: cmd });
+    }, taskId, command);
+
+    const tabId = await browser.waitUntil(
+      async () =>
+        (await browser.execute(
+          (id, member) =>
+            (window.__termic!.useApp.getState().tabs[id] ?? []).find(
+              (t: any) => t.runTab?.member === member,
+            )?.id,
+          taskId,
+          `cmd:${command}`,
+        )) as string | undefined,
+      { timeout: 15_000, timeoutMsg: "unlabeled run tab was not keyed by its command" },
+    );
+
+    await ensureActiveTask(taskId!);
+    // The tab strip shows the command, clipped to 40 chars with an ellipsis.
+    await browser.waitUntil(
+      async () =>
+        (await browser.execute(
+          (id, tab) =>
+            document
+              .querySelector(`[data-task-id="${id}"] [data-tab-id="${tab}"]`)
+              ?.textContent?.includes("echo unlabeled-run-command-with-a-very-…") ?? false,
+          taskId,
+          tabId,
+        )) === true,
+      { timeout: 10_000, timeoutMsg: "unlabeled run tab did not show the clipped command" },
+    );
+    await snap("run-unlabeled.png");
   });
 });
 

--- a/src/components/settings/RunCommandsEditor.tsx
+++ b/src/components/settings/RunCommandsEditor.tsx
@@ -1,9 +1,11 @@
 // Editor for a list of extra Run commands (GH #124). Each row is a
-// label + command pair; an empty label falls back to the command at launch.
+// label + command pair; an empty label falls back to the command at launch
+// (`runCommandLabel`), which the Label placeholder previews.
 // Shared by the Settings "Run commands" surface and the Run Commands manager
 // dialog. Persistence is the caller's job (via `onChange`) so the same editor
 // backs both the personal (projects.json) and committed (.termic.yaml) lists.
 
+import { runCommandLabel } from "@/lib/runCommands";
 import type { RunCommand } from "@/lib/types";
 import { Trash2, Plus } from "lucide-react";
 
@@ -29,7 +31,7 @@ export function RunCommandsEditor({ value, onChange }: {
               <input
                 value={cmd.label}
                 onChange={(e) => update(i, { label: e.target.value })}
-                placeholder="Label"
+                placeholder={cmd.command.trim() ? runCommandLabel(cmd) : "Label"}
                 autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck={false}
                 className="w-40 shrink-0 rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-2 py-1 text-[12.5px] text-[var(--color-fg)] outline-none focus:border-[var(--color-accent)]"
               />

--- a/src/components/task/RunControls.tsx
+++ b/src/components/task/RunControls.tsx
@@ -21,8 +21,8 @@ import {
   DropdownLabel, DropdownSeparator,
 } from "@/components/ui/Dropdown";
 import { ptyKill, openPath } from "@/lib/ipc";
-import { launchRunTabs, launchSetupTab, launchCustomRun, customRunMember, resolveRunTargets, runsAtRepoRoot, type RunTarget } from "@/lib/runTabs";
-import { resolveCustomCommands, runCommandKey, runCommandLabel, type ResolvedCommand } from "@/lib/runCommands";
+import { launchRunTabs, launchSetupTab, launchCustomRun, customRunMember, isCustomRunMember, resolveRunTargets, runsAtRepoRoot, type RunTarget } from "@/lib/runTabs";
+import { resolveCustomCommands, runCommandLabel, type ResolvedCommand } from "@/lib/runCommands";
 import { Play, Square, ChevronDown, Wrench, Globe, Settings, SlidersHorizontal } from "lucide-react";
 
 export function RunControls({ task }: { task: Task }) {
@@ -38,10 +38,10 @@ export function RunControls({ task }: { task: Task }) {
   const isMultiRepo = (task.composition?.length ?? 0) > 0;
   const [targets, setTargets] = useState<RunTarget[]>([]);
   // Custom run commands (GH #124), personal + committed. Ad-hoc, keyed by
-  // `cmd:<label>` run tabs, so they're kept OUT of the primary Run/Stop
-  // button below and get their own dropdown section instead.
+  // their own run-tab members (see `customRunMember`), so they're kept OUT of
+  // the primary Run/Stop button below and get their own dropdown section.
   const [customCmds, setCustomCmds] = useState<ResolvedCommand[]>([]);
-  const primaryRunTabs = runTabs.filter(t => !(t.runTab?.member ?? "").startsWith("cmd:"));
+  const primaryRunTabs = runTabs.filter(t => !isCustomRunMember(t.runTab?.member));
   const runLabel = isMultiRepo ? "Run all" : "Run";
   const stopLabel = isMultiRepo ? "Stop all" : "Stop";
   const stopTip = isMultiRepo ? "Stop all running scripts" : "Stop the running scripts";
@@ -169,13 +169,13 @@ export function RunControls({ task }: { task: Task }) {
             </>
           )}
           {/* Custom run commands (GH #124) — the curated per-repo list,
-              personal + committed. Each toggles its own `cmd:<label>` run
-              tab; independent of the primary Run button above. */}
+              personal + committed. Each toggles its own run tab, keyed by
+              `customRunMember`; independent of the primary Run button above. */}
           {customCmds.length > 0 && (
             <>
               <DropdownLabel>Run commands</DropdownLabel>
               {customCmds.map((cmd, i) => {
-                const tab = runTabs.find(t => t.runTab?.member === customRunMember(runCommandKey(cmd)));
+                const tab = runTabs.find(t => t.runTab?.member === customRunMember(cmd));
                 const runningCmd = !!tab?.ptyId;
                 return (
                   <DropdownItem

--- a/src/components/task/RunControls.tsx
+++ b/src/components/task/RunControls.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/Dropdown";
 import { ptyKill, openPath } from "@/lib/ipc";
 import { launchRunTabs, launchSetupTab, launchCustomRun, customRunMember, resolveRunTargets, runsAtRepoRoot, type RunTarget } from "@/lib/runTabs";
-import { resolveCustomCommands, type ResolvedCommand } from "@/lib/runCommands";
+import { resolveCustomCommands, runCommandKey, runCommandLabel, type ResolvedCommand } from "@/lib/runCommands";
 import { Play, Square, ChevronDown, Wrench, Globe, Settings, SlidersHorizontal } from "lucide-react";
 
 export function RunControls({ task }: { task: Task }) {
@@ -175,7 +175,7 @@ export function RunControls({ task }: { task: Task }) {
             <>
               <DropdownLabel>Run commands</DropdownLabel>
               {customCmds.map((cmd, i) => {
-                const tab = runTabs.find(t => t.runTab?.member === customRunMember(cmd.label));
+                const tab = runTabs.find(t => t.runTab?.member === customRunMember(runCommandKey(cmd)));
                 const runningCmd = !!tab?.ptyId;
                 return (
                   <DropdownItem
@@ -188,7 +188,7 @@ export function RunControls({ task }: { task: Task }) {
                     {runningCmd
                       ? <Square className="h-4 w-4 text-[var(--color-err)]" fill="currentColor" />
                       : <Play className="h-4 w-4" />}
-                    <span className="min-w-0 flex-1 truncate">{cmd.label}</span>
+                    <span className="min-w-0 flex-1 truncate">{runCommandLabel(cmd)}</span>
                   </DropdownItem>
                 );
               })}

--- a/src/lib/runCommands.test.ts
+++ b/src/lib/runCommands.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+
+// runCommands.ts pulls in the store + IPC at import time; neither matters for
+// the pure label helpers under test.
+vi.mock("@/lib/ipc", () => ({
+  projectUpdate: vi.fn(),
+  repoConfigLoad: vi.fn(),
+  repoConfigSave: vi.fn(),
+}));
+vi.mock("@/store/app", () => ({ useApp: { getState: () => ({ projects: [] }) } }));
+
+import { runCommandKey, runCommandLabel, RUN_COMMAND_LABEL_MAX } from "@/lib/runCommands";
+
+describe("runCommandKey", () => {
+  it("uses the label when one is set", () => {
+    expect(runCommandKey({ label: "Check", command: "make check-all" })).toBe("Check");
+  });
+
+  it("falls back to the command when the label is blank", () => {
+    expect(runCommandKey({ label: "", command: "make check-all" })).toBe("make check-all");
+    expect(runCommandKey({ label: "   ", command: "make check-all" })).toBe("make check-all");
+  });
+
+  it("keeps long commands intact so two commands never share a run tab", () => {
+    const a = { label: "", command: "npm run build -- --mode production --target one" };
+    const b = { label: "", command: "npm run build -- --mode production --target two" };
+    expect(runCommandKey(a)).not.toBe(runCommandKey(b));
+    expect(runCommandKey(a)).toBe(a.command);
+  });
+});
+
+describe("runCommandLabel", () => {
+  it("shows the command when no label is given", () => {
+    expect(runCommandLabel({ label: "", command: "make check-all" })).toBe("make check-all");
+  });
+
+  it("prefers the label over the command", () => {
+    expect(runCommandLabel({ label: "Check", command: "make check-all" })).toBe("Check");
+  });
+
+  it("clips overlong text with an ellipsis", () => {
+    const command = "npm run build -- --mode production --target everything";
+    const out = runCommandLabel({ label: "", command });
+    expect(out.length).toBe(RUN_COMMAND_LABEL_MAX);
+    expect(out.endsWith("…")).toBe(true);
+    expect(command.startsWith(out.slice(0, -1))).toBe(true);
+  });
+
+  it("clips overlong labels the same way", () => {
+    const label = "A very long label that nobody would ever want to read in a menu";
+    expect(runCommandLabel({ label, command: "x" })).toBe(label.slice(0, RUN_COMMAND_LABEL_MAX - 1).trimEnd() + "…");
+  });
+
+  it("leaves text at the limit alone", () => {
+    const command = "x".repeat(RUN_COMMAND_LABEL_MAX);
+    expect(runCommandLabel({ label: "", command })).toBe(command);
+  });
+});

--- a/src/lib/runCommands.test.ts
+++ b/src/lib/runCommands.test.ts
@@ -9,25 +9,7 @@ vi.mock("@/lib/ipc", () => ({
 }));
 vi.mock("@/store/app", () => ({ useApp: { getState: () => ({ projects: [] }) } }));
 
-import { runCommandKey, runCommandLabel, RUN_COMMAND_LABEL_MAX } from "@/lib/runCommands";
-
-describe("runCommandKey", () => {
-  it("uses the label when one is set", () => {
-    expect(runCommandKey({ label: "Check", command: "make check-all" })).toBe("Check");
-  });
-
-  it("falls back to the command when the label is blank", () => {
-    expect(runCommandKey({ label: "", command: "make check-all" })).toBe("make check-all");
-    expect(runCommandKey({ label: "   ", command: "make check-all" })).toBe("make check-all");
-  });
-
-  it("keeps long commands intact so two commands never share a run tab", () => {
-    const a = { label: "", command: "npm run build -- --mode production --target one" };
-    const b = { label: "", command: "npm run build -- --mode production --target two" };
-    expect(runCommandKey(a)).not.toBe(runCommandKey(b));
-    expect(runCommandKey(a)).toBe(a.command);
-  });
-});
+import { runCommandLabel, RUN_COMMAND_LABEL_MAX } from "@/lib/runCommands";
 
 describe("runCommandLabel", () => {
   it("shows the command when no label is given", () => {

--- a/src/lib/runCommands.ts
+++ b/src/lib/runCommands.ts
@@ -31,21 +31,14 @@ export function defaultCommandFor(rel: string): string {
  *  run tab) to the width of a full shell line. */
 export const RUN_COMMAND_LABEL_MAX = 40;
 
-/** The identity of a run command: its label, or the command itself when the
- *  label is blank. Keys the `cmd:<key>` run-tab member, so it stays untrimmed
- *  of content — two different commands must never collapse onto one tab. */
-export function runCommandKey(cmd: RunCommand): string {
-  return cmd.label.trim() || cmd.command.trim();
-}
-
 /** What the Run dropdown and the run tab show for a command: the label, or
  *  the command when no label was given, clipped with an ellipsis past
  *  `RUN_COMMAND_LABEL_MAX`. */
 export function runCommandLabel(cmd: RunCommand): string {
-  const key = runCommandKey(cmd);
-  return key.length > RUN_COMMAND_LABEL_MAX
-    ? key.slice(0, RUN_COMMAND_LABEL_MAX - 1).trimEnd() + "…"
-    : key;
+  const text = cmd.label.trim() || cmd.command.trim();
+  return text.length > RUN_COMMAND_LABEL_MAX
+    ? text.slice(0, RUN_COMMAND_LABEL_MAX - 1).trimEnd() + "…"
+    : text;
 }
 
 /** An empty `.termic.yaml` shape, used when a repo has none yet. Mirrors the

--- a/src/lib/runCommands.ts
+++ b/src/lib/runCommands.ts
@@ -26,6 +26,28 @@ export function defaultCommandFor(rel: string): string {
   return `./${rel}`;
 }
 
+/** Longest display label before it gets clipped. Sized so a command still
+ *  reads as a command in the Run dropdown without stretching the menu (or the
+ *  run tab) to the width of a full shell line. */
+export const RUN_COMMAND_LABEL_MAX = 40;
+
+/** The identity of a run command: its label, or the command itself when the
+ *  label is blank. Keys the `cmd:<key>` run-tab member, so it stays untrimmed
+ *  of content — two different commands must never collapse onto one tab. */
+export function runCommandKey(cmd: RunCommand): string {
+  return cmd.label.trim() || cmd.command.trim();
+}
+
+/** What the Run dropdown and the run tab show for a command: the label, or
+ *  the command when no label was given, clipped with an ellipsis past
+ *  `RUN_COMMAND_LABEL_MAX`. */
+export function runCommandLabel(cmd: RunCommand): string {
+  const key = runCommandKey(cmd);
+  return key.length > RUN_COMMAND_LABEL_MAX
+    ? key.slice(0, RUN_COMMAND_LABEL_MAX - 1).trimEnd() + "…"
+    : key;
+}
+
 /** An empty `.termic.yaml` shape, used when a repo has none yet. Mirrors the
  *  default RepositorySection builds. */
 function emptyRepoConfig(): RepoConfig {

--- a/src/lib/runTabs.test.ts
+++ b/src/lib/runTabs.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+
+// runTabs.ts pulls in the stores + IPC at import time; the member helpers under
+// test are pure.
+vi.mock("@/lib/ipc", () => ({
+  repoConfigLoad: vi.fn(),
+  repoConfigLoadAt: vi.fn(),
+  repoConfigSave: vi.fn(),
+  projectUpdate: vi.fn(),
+}));
+vi.mock("@/store/app", () => ({ useApp: { getState: () => ({ projects: [], tabs: {} }) } }));
+vi.mock("@/store/ui", () => ({ useUI: { getState: () => ({}) } }));
+
+import { customRunMember, isCustomRunMember } from "@/lib/runTabs";
+
+describe("customRunMember", () => {
+  it("keys a labeled command off its label", () => {
+    expect(customRunMember({ label: "Check", command: "make check-all" })).toBe("label:Check");
+  });
+
+  it("keys an unlabeled command off its command", () => {
+    expect(customRunMember({ label: "", command: "make check-all" })).toBe("cmd:make check-all");
+    expect(customRunMember({ label: "  ", command: "make check-all" })).toBe("cmd:make check-all");
+  });
+
+  it("never lets a label collide with another command's raw text", () => {
+    const labeled = { label: "make check-all", command: "echo something-else" };
+    const unlabeled = { label: "", command: "make check-all" };
+    expect(customRunMember(labeled)).not.toBe(customRunMember(unlabeled));
+  });
+
+  it("keeps long commands intact so two commands never share a run tab", () => {
+    const a = { label: "", command: "npm run build -- --mode production --target one" };
+    const b = { label: "", command: "npm run build -- --mode production --target two" };
+    expect(customRunMember(a)).not.toBe(customRunMember(b));
+  });
+});
+
+describe("isCustomRunMember", () => {
+  it("claims both custom prefixes", () => {
+    expect(isCustomRunMember(customRunMember({ label: "Check", command: "x" }))).toBe(true);
+    expect(isCustomRunMember(customRunMember({ label: "", command: "make check-all" }))).toBe(true);
+  });
+
+  // The primary Run/Stop button drives everything this rejects, so a custom
+  // member leaking through here would hand the main button someone's ad-hoc run.
+  it("leaves the primary host and composition members alone", () => {
+    expect(isCustomRunMember("")).toBe(false);
+    expect(isCustomRunMember("api")).toBe(false);
+    expect(isCustomRunMember(undefined)).toBe(false);
+    expect(isCustomRunMember(null)).toBe(false);
+  });
+});

--- a/src/lib/runTabs.ts
+++ b/src/lib/runTabs.ts
@@ -12,7 +12,8 @@
 import { useApp } from "@/store/app";
 import { useUI } from "@/store/ui";
 import { repoConfigLoad, repoConfigLoadAt } from "@/lib/ipc";
-import type { Project, Task, TerminalTab } from "@/lib/types";
+import { runCommandKey, runCommandLabel } from "@/lib/runCommands";
+import type { Project, RunCommand, Task, TerminalTab } from "@/lib/types";
 
 export interface RunTarget {
   /** "" = host project; otherwise composition dir_name. */
@@ -164,13 +165,14 @@ export function customRunMember(label: string): string {
 
 /** Launch (or restart) a run tab for a user-configured custom command
  *  (GH #124). Behaves exactly like a Run tab (RunPane, pill controls,
- *  persistence) but is keyed by its label so it never collides with the
+ *  persistence) but is keyed by its label (or, unlabeled, by the command
+ *  itself, per `runCommandKey`) so it never collides with the
  *  primary host run (`member: ""`) or a composition member. `customTitle`
  *  is set so the label survives a persistence round-trip (restore otherwise
  *  rebuilds run-tab titles from `member`). Runs in the task's worktree — the
  *  PTY's spawn cwd; no spotlight repo-root redirect (that's host-only). */
-export function launchCustomRun(taskId: string, cmd: { label: string; command: string }): void {
-  const member = customRunMember(cmd.label);
+export function launchCustomRun(taskId: string, cmd: RunCommand): void {
+  const member = customRunMember(runCommandKey(cmd));
   const existing = (useApp.getState().tabs[taskId] ?? []).find(
     (t): t is TerminalTab => t.type === "terminal" && (t as TerminalTab).runTab?.member === member,
   );
@@ -181,7 +183,7 @@ export function launchCustomRun(taskId: string, cmd: { label: string; command: s
   useApp.getState().addTabToActivePane(taskId, {
     id: crypto.randomUUID(),
     type: "terminal",
-    title: cmd.label,
+    title: runCommandLabel(cmd),
     customTitle: true,
     cli: "custom",
     command: cmd.command,

--- a/src/lib/runTabs.ts
+++ b/src/lib/runTabs.ts
@@ -12,7 +12,7 @@
 import { useApp } from "@/store/app";
 import { useUI } from "@/store/ui";
 import { repoConfigLoad, repoConfigLoadAt } from "@/lib/ipc";
-import { runCommandKey, runCommandLabel } from "@/lib/runCommands";
+import { runCommandLabel } from "@/lib/runCommands";
 import type { Project, RunCommand, Task, TerminalTab } from "@/lib/types";
 
 export interface RunTarget {
@@ -158,21 +158,33 @@ export async function launchSetupTab(taskId: string, opts?: { focus?: boolean })
 
 /** The `runTab.member` value for an ad-hoc custom run command (GH #124).
  *  Prefixed so RunControls can tell these apart from the primary host/member
- *  run tabs — the primary Run/Stop button ignores anything `cmd:*`. */
-export function customRunMember(label: string): string {
-  return `cmd:${label}`;
+ *  run tabs — the primary Run/Stop button ignores custom members entirely.
+ *  Labeled commands key off the label (`label:*`), unlabeled ones off the
+ *  command (`cmd:*`); the two prefixes keep a label from colliding with
+ *  another command's raw text. Takes the whole command, not a bare string,
+ *  so no caller can pick the wrong field. */
+export function customRunMember(cmd: RunCommand): string {
+  const label = cmd.label.trim();
+  return label ? `label:${label}` : `cmd:${cmd.command.trim()}`;
+}
+
+/** Whether a `runTab.member` belongs to a custom run command rather than the
+ *  primary host/composition run. Both custom prefixes live here so a new one
+ *  can never be missed at a call site. */
+export function isCustomRunMember(member: string | undefined | null): boolean {
+  return !!member && (member.startsWith("cmd:") || member.startsWith("label:"));
 }
 
 /** Launch (or restart) a run tab for a user-configured custom command
  *  (GH #124). Behaves exactly like a Run tab (RunPane, pill controls,
- *  persistence) but is keyed by its label (or, unlabeled, by the command
- *  itself, per `runCommandKey`) so it never collides with the
- *  primary host run (`member: ""`) or a composition member. `customTitle`
- *  is set so the label survives a persistence round-trip (restore otherwise
- *  rebuilds run-tab titles from `member`). Runs in the task's worktree — the
- *  PTY's spawn cwd; no spotlight repo-root redirect (that's host-only). */
+ *  persistence) but is keyed by `customRunMember` so it never collides with
+ *  another custom command, the primary host run (`member: ""`), or a
+ *  composition member. `customTitle` is set so the label survives a
+ *  persistence round-trip (restore otherwise rebuilds run-tab titles from
+ *  `member`). Runs in the task's worktree — the PTY's spawn cwd; no
+ *  spotlight repo-root redirect (that's host-only). */
 export function launchCustomRun(taskId: string, cmd: RunCommand): void {
-  const member = customRunMember(runCommandKey(cmd));
+  const member = customRunMember(cmd);
   const existing = (useApp.getState().tabs[taskId] ?? []).find(
     (t): t is TerminalTab => t.type === "terminal" && (t as TerminalTab).runTab?.member === member,
   );


### PR DESCRIPTION
Hello! This is my first contribution here. First of all, thanks for doing this great work!

I've tried many "ADE" in the market (Paseo, Orca, Conductor, and even terminal multiplexer like cmux) but there is always something missing or too much of it. Then I found this project, tried it and really love it! That's why even if I'm not familar with the tech stack here, I'd still want to contribute this project somehow.

Most of the code change came from Claude honestly but I tried to review and supervise it as much as possible, so if there is any suggestion or feedback please feel free to let me know and sorry in advance if there is any "AI slop" in the change due to my unfamiliar with the language.

This PR also written by human still.

## Problem

When a run command doesn't have a label, in the run menu the application show empty string instead of brief information about the command since the label is already optional (as it should be).

<img width="577" height="134" alt="image" src="https://github.com/user-attachments/assets/0887315d-3844-42d7-8fde-8a86a7c10862" />  
<img width="240" height="105" alt="image" src="https://github.com/user-attachments/assets/3f502e3c-e334-4e95-8244-0bc295c11cc7" />

## Changes

This PR did change on how a run command is showing in the top bar menu. When a run command label is not specified, the command will be show in the run menu instead. Also if the command is very long, it will be truncated and show ellipsis (...), default at 40 chars (see `RUN_COMMAND_LABEL_MAX`).

<img width="589" height="146" alt="Snapzy_2026-08-11_15-01-25_711" src="https://github.com/user-attachments/assets/f94e2933-c068-4fe1-a962-d41aa7575e31" />  
<img width="187" height="97" alt="Snapzy_2026-08-11_15-02-14_486" src="https://github.com/user-attachments/assets/b4762c0f-8b57-408c-94ec-0b36bc736293" />  
<img width="294" height="111" alt="image" src="https://github.com/user-attachments/assets/6e46dde5-c1d1-4604-97ac-7bbe483f432e" />


This PR also added one E2E test (`titles an unlabeled command with its (clipped) command`) and two unit tests (`runCommandKey` and `runCommandLabel`) which corresponding to two new helper functions on the calculation of run label and command.

## Tests

- [x] `make check-all`
- [x] E2E passed