### PR TITLE
fix(e2e): Fix click "Add to pending" in the comment test. 

### DIFF
--- a/e2e/specs/git.e2e.ts
+++ b/e2e/specs/git.e2e.ts
@@ -478,7 +478,9 @@ describe("review comment alignment", () => {
       const ta = document.querySelector(".tc-comment-textarea") as HTMLTextAreaElement;
       ta.value = text;
       ta.dispatchEvent(new Event("input", { bubbles: true })); // also runs autoGrow
-      (document.querySelector(".tc-comment-composer .tc-btn-primary") as HTMLElement).click();
+      // "Add to pending" queues the comment card; the primary CTA is now Send,
+      // which ships it to the agent instead of mounting a card.
+      (document.querySelector(".tc-comment-composer .tc-btn-queue") as HTMLElement).click();
     }, body);
     await waitGone(".tc-comment-textarea");
   }


### PR DESCRIPTION
The comment composer now has two buttons: "Send" (ships the comment to the agent, now carries `tc-btn-primary`) and "Add to pending" (queues a pending comment card). The alignment spec in `git.e2e.ts` still clicked `.tc-btn-primary`, so it was hitting Send: no cards mounted and the test timed out. This broke the e2e job on main and on every PR branched after 3c610a6. `editor.e2e.ts` was already updated to the new selectors; this spec was missed.

One line: click `.tc-comment-composer .tc-btn-queue` instead, the same selector `editor.e2e.ts` uses. The test's assertion (gutter numbers stay level with the code after cards mount) is unchanged.

Tested: `make e2e` locally, 11/11 spec files pass, including this one.