### PR TITLE
feat(tabs): pin, close others and close to the right tab actions

### DIFF
--- a/docs/plans/e2e-coverage.md
+++ b/docs/plans/e2e-coverage.md
@@ -55,6 +55,9 @@ until `make e2e` is green and this file reflects it.
 | ✅ Default tasks path | The global setting ships a real value (not an empty box); a new project's `tasks_path` starts empty so that setting applies; an absolute default lands worktrees at `<default>/<project>/<task>` and a relative one at `<repo>/<default>/<task>`, both verified on disk; a project's own tasks path overrides it; the project field shows the global-derived path as its placeholder while staying empty; the Settings → Tasks preview flips between the two halves of the rule as it is typed, and emptying the required field blocks the save | `settings.e2e.ts` |
 | ✅ Tabs | Add a terminal tab via the "+" menu; switch active tab | `tabs-layout.e2e.ts` |
 | ✅ Tab rename | Double-click inline edit commits the new name | `tabs-layout.e2e.ts` |
+| ✅ Tab context menu | Right-click a pill: Pin moves the tab to the head of the strip and a second pin appends to the end of that block; Unpin drops back to the first slot after it; Close to the right and Close others spare every pinned tab and the clicked one; both go disabled when they have nothing to close (GH #183) | `tabs-layout.e2e.ts` |
+| ✅ Pinned pill has no close X | A pinned pill offers "Unpin tab" where an unpinned one offers "Close tab", so one stray click cannot kill a live PTY; that control unpins (the tab survives) and the X comes back with it (GH #183) | `tabs-layout.e2e.ts` |
+| ✅ Pinned tabs stay in view | A pinned tab lives outside the strip's scroller: with the strip flooded past overflow and scrolled to its end, the pinned pill has not moved a pixel and is still fully inside the bar (GH #183) | `tabs-layout.e2e.ts` |
 | ✅ Theme | Picker switches theme; palette class applied to `<html>` | `tabs-layout.e2e.ts` |
 | ✅ Editor persist | Single-click = preview tab; double-click persists it | `editor.e2e.ts` |
 | ✅ Split panes | Unsplit start; split-right → 2 leaves; split-below → 3 | `tabs-layout.e2e.ts` |

--- a/e2e/specs/tabs-layout.e2e.ts
+++ b/e2e/specs/tabs-layout.e2e.ts
@@ -636,3 +636,335 @@ describe("split restore", () => {
     await snap("split-restore-collapsed.png");
   });
 });
+
+// Tab context menu (GH #183): Pin / Unpin plus the two bulk closes. Pinning is
+// an ORDERING operation, not just a flag — the pin appends to the pinned block
+// at the head of the strip and the unpin drops back to the first slot after it,
+// so the cases assert tab order, and that both bulk closes spare pinned tabs.
+describe("tab context menu", () => {
+  let taskId: string | undefined;
+  after(async () => {
+    if (taskId) await archiveTask(taskId);
+  });
+
+  // Main-strip tab ids, in display order.
+  const strip = () =>
+    browser.execute(
+      (id) =>
+        (window.__termic!.useApp.getState().tabs[id] ?? [])
+          .filter((t: any) => !t.paneId)
+          .map((t: any) => t.id as string),
+      taskId,
+    );
+
+  // Shell tabs on purpose: closing one is silent, so the bulk-close cases
+  // assert the close itself instead of racing a confirm dialog.
+  const addShells = (prefix: string, n: number) =>
+    browser.execute(
+      (id, p, count) => {
+        const app = window.__termic!.useApp.getState();
+        const ids: string[] = [];
+        for (let i = 0; i < count; i++) {
+          const tabId = `${p}-${i}`;
+          ids.push(tabId);
+          app.addTab(id, { id: tabId, type: "terminal", cli: "shell", title: tabId } as any);
+        }
+        return ids;
+      },
+      taskId, prefix, n,
+    );
+
+  // Dispatched, not gestured: a WebDriver right-click does not reach Radix's
+  // onContextMenu in this WKWebView (same gap as its double-click, see
+  // files.e2e.ts). The MouseEvent goes through the real trigger, so everything
+  // from the menu opening downwards is genuinely exercised.
+  const openTabMenu = async (tabId: string) => {
+    await browser.execute((id) => {
+      const el = document.querySelector(`[data-tab-id="${id}"]`) as HTMLElement;
+      if (!el) throw new Error(`no tab pill ${id}`);
+      const r = el.getBoundingClientRect();
+      el.dispatchEvent(new MouseEvent("contextmenu", {
+        bubbles: true, cancelable: true, button: 2,
+        clientX: r.left + 10, clientY: r.top + 10,
+      }));
+    }, tabId);
+    await browser.waitUntil(async () => (await menuItems()).length > 0, {
+      timeout: 8_000,
+      timeoutMsg: `the tab context menu never opened for ${tabId}`,
+    });
+  };
+
+  // Scoped to the menu holding the tab items, never a bare [role="menu"]:
+  // menus stack and a closing one can linger (see the e2e skill). Items are the
+  // content div's direct children; ContextMenuItem passes role={undefined} for
+  // plain items, so an ARIA selector would match nothing.
+  const menuItems = () =>
+    browser.execute(() => {
+      const menu = [...document.querySelectorAll('[role="menu"]')].find((m) =>
+        (m as HTMLElement).innerText.includes("Close others"),
+      ) as HTMLElement | undefined;
+      if (!menu) return [] as { label: string; disabled: boolean }[];
+      return [...menu.children]
+        .map((el) => ({
+          label: (el as HTMLElement).innerText?.trim() ?? "",
+          disabled: el.hasAttribute("data-disabled"),
+        }))
+        .filter((i) => i.label.length > 0);
+    });
+
+  const clickTabMenuItem = (label: string) =>
+    browser.execute((text) => {
+      const menu = [...document.querySelectorAll('[role="menu"]')].find((m) =>
+        (m as HTMLElement).innerText.includes("Close others"),
+      ) as HTMLElement | undefined;
+      if (!menu) throw new Error("the tab context menu is not open");
+      const item = [...menu.children].find(
+        (i) => (i as HTMLElement).innerText?.trim() === text,
+      ) as HTMLElement | undefined;
+      if (!item) throw new Error(`no menu item "${text}"`);
+      item.click();
+    }, label);
+
+  const isPinned = (tabId: string) =>
+    browser.execute(
+      (id) => !!document.querySelector(`[data-tab-id="${id}"][data-pinned]`),
+      tabId,
+    );
+
+  // Titles of the pill's own action buttons, which is what the user can click.
+  // Run-tab controls (Restart / Stop / Run) would show up here too; these
+  // fixtures are plain shells and an agent, so the trailing slot is all there is.
+  const pillButtons = (tabId: string) =>
+    browser.execute(
+      (id) =>
+        [...document.querySelectorAll(`[data-tab-id="${id}"] button`)].map(
+          (b) => b.getAttribute("title") ?? "",
+        ),
+      tabId,
+    );
+
+  it("pins a tab to the head of the strip", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+    taskId = await openTask("e2e-tabmenu");
+    await browser.waitUntil(async () => (await strip()).length === 1, {
+      timeout: 20_000,
+      timeoutMsg: "agent tab never appeared",
+    });
+    await ensureActiveTask(taskId);
+    await dismissOverlays();
+
+    const [agent] = await strip();
+    const [s0, s1, s2] = await addShells("e2e-pin", 3);
+    await browser.waitUntil(async () => (await strip()).length === 4, {
+      timeout: 8_000, timeoutMsg: "shell tabs never rendered",
+    });
+
+    await openTabMenu(s2);
+    await clickTabMenuItem("Pin");
+    await browser.waitUntil(async () => (await strip())[0] === s2, {
+      timeout: 5_000, timeoutMsg: "the pinned tab never moved to the head",
+    });
+    expect(await strip()).toEqual([s2, agent, s0, s1]);
+    expect(await isPinned(s2)).toBe(true);
+    await snap("tab-menu-pinned.png");
+  });
+
+  it("trades the close X for an unpin control on a pinned pill", async () => {
+    const [s2, agent] = await strip(); // [s2*, agent, s0, s1]
+    // A pinned tab must not be one stray click from a dead PTY: the pill
+    // offers "Unpin tab" where an unpinned one offers "Close tab".
+    expect(await pillButtons(s2)).toEqual(["Unpin tab"]);
+    expect(await pillButtons(agent)).toEqual(["Close tab"]);
+
+    // And that control unpins rather than closing: the tab survives, it just
+    // leaves the pinned block.
+    await browser.execute((id) => {
+      const btn = document.querySelector(
+        `[data-tab-id="${id}"] button[title="Unpin tab"]`,
+      ) as HTMLElement;
+      btn.click();
+    }, s2);
+    await browser.waitUntil(async () => !(await isPinned(s2)), {
+      timeout: 5_000, timeoutMsg: "the pin control never unpinned the tab",
+    });
+    expect(await strip()).toHaveLength(4);
+    expect(await pillButtons(s2)).toEqual(["Close tab"]);
+
+    // Put it back so the ordering cases below start where they expect.
+    await openTabMenu(s2);
+    await clickTabMenuItem("Pin");
+    await browser.waitUntil(async () => (await strip())[0] === s2, {
+      timeout: 5_000, timeoutMsg: "the tab never went back to the pinned block",
+    });
+  });
+
+  it("a second pin appends to the END of the pinned block", async () => {
+    const [, , s0] = await strip(); // [s2*, agent, s0, s1]
+    await openTabMenu(s0);
+    await clickTabMenuItem("Pin");
+    await browser.waitUntil(async () => (await strip())[1] === s0, {
+      timeout: 5_000, timeoutMsg: "the second pin did not land after the first",
+    });
+  });
+
+  it("unpin drops the tab to the first slot after the pinned block", async () => {
+    const [s2, s0] = await strip(); // [s2*, s0*, agent, s1]
+    await openTabMenu(s2);
+    await clickTabMenuItem("Unpin");
+    await browser.waitUntil(async () => (await strip())[0] === s0, {
+      timeout: 5_000, timeoutMsg: "the unpinned tab never left the pinned block",
+    });
+    expect((await strip())[1]).toBe(s2);
+    expect(await isPinned(s2)).toBe(false);
+  });
+
+  it("close to the right spares pinned tabs", async () => {
+    // Pin the agent tab too, so no bulk close can reach it (closing an agent
+    // tab would raise a confirm dialog; shells close silently).
+    const before = await strip(); // [s0*, s2, agent, s1]
+    const agent = before[2];
+    await openTabMenu(agent);
+    await clickTabMenuItem("Pin");
+    await browser.waitUntil(async () => (await strip())[1] === agent, {
+      timeout: 5_000, timeoutMsg: "the agent tab never joined the pinned block",
+    });
+
+    const [pinnedShell] = await strip(); // [s0*, agent*, s2, s1]
+    await openTabMenu(pinnedShell);
+    await clickTabMenuItem("Close to the right");
+    await browser.waitUntil(async () => (await strip()).length === 2, {
+      timeout: 8_000, timeoutMsg: "close to the right never closed the tabs",
+    });
+    expect(await strip()).toEqual([pinnedShell, agent]);
+  });
+
+  it("close others keeps the clicked tab and every pinned tab", async () => {
+    const [pinnedShell, agent] = await strip();
+    const [keep] = await addShells("e2e-others", 2);
+    await browser.waitUntil(async () => (await strip()).length === 4, {
+      timeout: 8_000, timeoutMsg: "shell tabs never rendered",
+    });
+
+    await openTabMenu(keep);
+    await clickTabMenuItem("Close others");
+    await browser.waitUntil(async () => (await strip()).length === 3, {
+      timeout: 8_000, timeoutMsg: "close others never closed the sibling",
+    });
+    expect(await strip()).toEqual([pinnedShell, agent, keep]);
+  });
+
+  it("disables a bulk close that has nothing to close", async () => {
+    const strips = await strip(); // [pinned shell*, agent*, keep]
+    await openTabMenu(strips[strips.length - 1]);
+    const items = await menuItems();
+    const byLabel = (l: string) => items.find((i) => i.label === l);
+    // Nothing to its right, and every other tab is pinned.
+    expect(byLabel("Close to the right")?.disabled).toBe(true);
+    expect(byLabel("Close others")?.disabled).toBe(true);
+    expect(byLabel("Close")?.disabled).toBe(false);
+    await browser.keys(["Escape"]);
+  });
+});
+
+// The reason pinning exists (GH #183): a pinned tab must stay in reach when the
+// strip overflows. Reordering it to the head is not enough on its own — it has
+// to sit OUTSIDE the scroller, so this drives the strip to a real overflow and
+// scrolls it to the end.
+describe("pinned tabs do not scroll away", () => {
+  let taskId: string | undefined;
+  after(async () => {
+    if (taskId) await archiveTask(taskId);
+  });
+
+  // Scoped to THIS task's strip: every visited task stays mounted, so a bare
+  // [data-main-strip] can return a hidden copy whose geometry is all zeroes
+  // (see the e2e skill) — which reads as "never overflows" forever.
+  const geometry = (tabId: string) =>
+    browser.execute((wid, id) => {
+      const strip = document.querySelector(
+        `[data-task-id="${wid}"] [data-main-strip]`,
+      ) as HTMLElement | null;
+      const scroller = strip?.querySelector("[data-scroll-strip]") as HTMLElement | null;
+      const pill = strip?.querySelector(`[data-tab-id="${id}"]`) as HTMLElement | null;
+      if (!strip || !scroller || !pill) {
+        return { found: false, pillLeft: 0, visible: false, overflowing: false, scrollLeft: 0, scrollWidth: 0, clientWidth: 0 };
+      }
+      const s = strip.getBoundingClientRect();
+      const p = pill.getBoundingClientRect();
+      return {
+        found: true,
+        pillLeft: Math.round(p.left),
+        // Fully inside the strip's box = the user can see and click it.
+        visible: p.left >= s.left - 1 && p.right <= s.right + 1,
+        overflowing: scroller.scrollWidth > scroller.clientWidth + 1,
+        scrollLeft: Math.round(scroller.scrollLeft),
+        scrollWidth: Math.round(scroller.scrollWidth),
+        clientWidth: Math.round(scroller.clientWidth),
+      };
+    }, taskId, tabId);
+
+  it("keeps a pinned tab in view after the strip is scrolled to the end", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+    taskId = await openTask("e2e-pinscroll");
+    await browser.waitUntil(
+      () => browser.execute(
+        (id) => (window.__termic!.useApp.getState().tabs[id] ?? []).length === 1,
+        taskId,
+      ),
+      { timeout: 20_000, timeoutMsg: "agent tab never appeared" },
+    );
+    await ensureActiveTask(taskId);
+    await dismissOverlays();
+
+    // Pin the agent tab, then flood the strip until it genuinely overflows.
+    const agent = await browser.execute(
+      (id) => window.__termic!.useApp.getState().tabs[id][0].id as string,
+      taskId,
+    );
+    await browser.execute((id, tab) => {
+      window.__termic!.useApp.getState().pinTab(id, tab);
+    }, taskId, agent);
+
+    // Size the flood to the real strip: a pill shrinks to min-w 140px, so it
+    // takes ceil(width / 140) of them to overflow. A fixed count would silently
+    // stop overflowing on a wider window and make the case vacuous.
+    const need = Math.ceil((await geometry(agent)).clientWidth / 140) + 3;
+    await browser.execute((id, n) => {
+      const app = window.__termic!.useApp.getState();
+      for (let i = 0; i < n; i++) {
+        app.addTab(id, { id: `e2e-flood-${i}`, type: "terminal", cli: "shell", title: `flood ${i}` } as any);
+      }
+    }, taskId, need);
+
+    // A strip that does not overflow would make every assertion below vacuous,
+    // so fail loudly WITH the measurements rather than passing on nothing.
+    let g = await geometry(agent);
+    try {
+      await browser.waitUntil(async () => (g = await geometry(agent)).overflowing, { timeout: 10_000 });
+    } catch {
+      throw new Error(`the tab strip never overflowed: ${JSON.stringify(g)}`);
+    }
+
+    const before = await geometry(agent);
+    expect(before.visible).toBe(true);
+
+    // Scroll the unpinned remainder all the way to its end.
+    await browser.execute((wid) => {
+      const scroller = document.querySelector(
+        `[data-task-id="${wid}"] [data-main-strip] [data-scroll-strip]`,
+      ) as HTMLElement;
+      scroller.scrollLeft = scroller.scrollWidth;
+    }, taskId);
+    await browser.waitUntil(async () => (await geometry(agent)).scrollLeft > 0, {
+      timeout: 5_000, timeoutMsg: "the strip never scrolled",
+    });
+
+    // The pinned pill has not moved a pixel and is still fully in the bar.
+    const after = await geometry(agent);
+    expect(after.visible).toBe(true);
+    expect(after.pillLeft).toBe(before.pillLeft);
+    await snap("tab-pinned-stays-visible.png");
+  });
+});

--- a/e2e/specs/tabs-layout.e2e.ts
+++ b/e2e/specs/tabs-layout.e2e.ts
@@ -731,6 +731,22 @@ describe("tab context menu", () => {
       tabId,
     );
 
+  const pillWidth = (tabId: string) =>
+    browser.execute((wid, id) => {
+      const pill = document.querySelector(
+        `[data-task-id="${wid}"] [data-tab-id="${id}"]`,
+      ) as HTMLElement | null;
+      return pill ? Math.round(pill.getBoundingClientRect().width) : -1;
+    }, taskId, tabId);
+
+  const tabLiveTitle = (tabId: string) =>
+    browser.execute((wid, id) => {
+      const tab = (window.__termic!.useApp.getState().tabs[wid] ?? []).find(
+        (t: any) => t.id === id,
+      );
+      return (tab?.liveTitle as string) ?? "";
+    }, taskId, tabId);
+
   // Titles of the pill's own action buttons, which is what the user can click.
   // Run-tab controls (Restart / Stop / Run) would show up here too; these
   // fixtures are plain shells and an agent, so the trailing slot is all there is.
@@ -768,6 +784,27 @@ describe("tab context menu", () => {
     expect(await strip()).toEqual([s2, agent, s0, s1]);
     expect(await isPinned(s2)).toBe(true);
     await snap("tab-menu-pinned.png");
+  });
+
+  it("holds a pinned pill's width steady while its live title changes", async () => {
+    const [s2, , s0] = await strip(); // [s2*, agent, s0, s1]
+    // A pinned pill sits in the strip's shrink-to-fit region, so a
+    // content-sized one would re-measure on every OSC title the agent emits and
+    // shove the whole scrolling remainder sideways with it.
+    const before = await pillWidth(s2);
+    // Same width as an unpinned neighbour when the row is not crowded.
+    expect(before).toBe(await pillWidth(s0));
+
+    for (const title of ["x", "a considerably longer live title than before", "y"]) {
+      await browser.execute((wid, id, t) => {
+        window.__termic!.useApp.getState().setTabLiveTitle(wid, id, t);
+      }, taskId, s2, title);
+      await browser.waitUntil(
+        async () => (await tabLiveTitle(s2)) === title,
+        { timeout: 5_000, timeoutMsg: `live title never became "${title}"` },
+      );
+      expect(await pillWidth(s2)).toBe(before);
+    }
   });
 
   it("trades the close X for an unpin control on a pinned pill", async () => {

--- a/src-tauri/src/cli_server.rs
+++ b/src-tauri/src/cli_server.rs
@@ -6900,6 +6900,7 @@ mod tests {
             previous_session_id: None,
             pane_leaf_id: None,
             run_member: run.map(str::to_string),
+            pinned: false,
         };
         let mut host = host;
         host.tasks.iter_mut().find(|t| t.id == "w3").unwrap().persisted_tabs = vec![
@@ -6937,6 +6938,7 @@ mod tests {
             previous_session_id: None,
             pane_leaf_id: None,
             run_member: None,
+            pinned: false,
         };
         let mut host = host;
         host.tasks.iter_mut().find(|t| t.id == "w3").unwrap().persisted_tabs =
@@ -7045,6 +7047,7 @@ mod tests {
                 previous_session_id: None,
                 pane_leaf_id: None,
                 run_member: None,
+                pinned: false,
             },
             crate::PersistedTab {
                 id: "tab-x".into(),
@@ -7057,6 +7060,7 @@ mod tests {
                 previous_session_id: None,
                 pane_leaf_id: None,
                 run_member: None,
+                pinned: false,
             },
             crate::PersistedTab {
                 id: "tab-sh".into(),
@@ -7069,6 +7073,7 @@ mod tests {
                 previous_session_id: None,
                 pane_leaf_id: None,
                 run_member: None,
+                pinned: false,
             },
         ];
         assert_eq!(resolve_tab_selector(&host, &t, "tab-a").unwrap().id, "tab-a");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -417,6 +417,10 @@ pub struct PersistedTab {
     /// the run script ("" = host project). Restores the RunPane in its pane.
     #[serde(default)]
     pub run_member: Option<String>,
+    /// Pinned tabs sort before the others in their strip. Persisted so a
+    /// pinned tab comes back pinned and leftmost.
+    #[serde(default)]
+    pub pinned: bool,
 }
 
 /// Frontend payload for `task_set_tabs`. `session_id` is only honored
@@ -444,6 +448,8 @@ pub struct PersistedTabInput {
     pub pane_leaf_id: Option<String>,
     #[serde(default)]
     pub run_member: Option<String>,
+    #[serde(default)]
+    pub pinned: bool,
 }
 
 impl Task {
@@ -4316,6 +4322,7 @@ fn task_set_tabs(id: String, tabs: Vec<PersistedTabInput>) -> Result<(), String>
                 command: t.command,
                 pane_leaf_id: t.pane_leaf_id,
                 run_member: t.run_member,
+                pinned: t.pinned,
             }
         })
         .collect();
@@ -4334,6 +4341,7 @@ fn task_set_tabs(id: String, tabs: Vec<PersistedTabInput>) -> Result<(), String>
                 && a.previous_session_id == b.previous_session_id
                 && a.pane_leaf_id == b.pane_leaf_id
                 && a.run_member == b.run_member
+                && a.pinned == b.pinned
         });
     if same {
         return Ok(());
@@ -4431,6 +4439,7 @@ fn task_set_right_tabs(id: String, tabs: Vec<PersistedTabInput>) -> Result<(), S
                 command: t.command,
                 pane_leaf_id: None,
                 run_member: None,
+                pinned: t.pinned,
             }
         })
         .collect();
@@ -11800,6 +11809,22 @@ mod tests {
         assert!(apply_cli_default_migration(&mut s));
         assert!(s.cli_enabled);
         assert!(s.cli_default_migrated);
+    }
+
+    // Pinned tabs (GH #183). Task JSON has no migration step: `#[serde(default)]`
+    // IS the compatibility story, so a task file written before pinning existed
+    // must still load, and a pinned one must survive a save/load round trip.
+    #[test]
+    fn a_task_file_without_pinned_loads_with_it_off() {
+        let t: PersistedTab = serde_json::from_str(r#"{"id":"t1","cli":"claude"}"#).unwrap();
+        assert!(!t.pinned);
+    }
+
+    #[test]
+    fn pinned_survives_a_round_trip() {
+        let t = PersistedTab { id: "t1".into(), cli: "claude".into(), pinned: true, ..Default::default() };
+        let back: PersistedTab = serde_json::from_str(&serde_json::to_string(&t).unwrap()).unwrap();
+        assert!(back.pinned);
     }
 
     fn role(kind: &str, task: &str) -> PtyRole {

--- a/src/components/task/PaneHeader.tsx
+++ b/src/components/task/PaneHeader.tsx
@@ -22,7 +22,8 @@ import { Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { visibleCliIds, isTerminalEntry } from "@/lib/agents";
 import { focusPaneTab } from "@/lib/tabFocus";
-import { requestClosePaneTab } from "@/lib/closeTab";
+import { requestClosePaneTab, requestClosePaneTabs } from "@/lib/closeTab";
+import { TabContextMenu } from "./TabContextMenu";
 import { showDragGhost, moveDragGhost, hideDragGhost } from "@/lib/dragGhost";
 import { detectDropZone, setDropHighlight, clearDropHighlight, type DropZone } from "@/lib/dropZones";
 
@@ -48,6 +49,8 @@ export function PaneHeader({ leaf, task, onClose }: PaneHeaderProps) {
   const moveTabToPane    = useApp(s => s.moveTabToPane);
   const moveTabToMain    = useApp(s => s.moveTabToMain);
   const moveTabToSplit   = useApp(s => s.moveTabToSplit);
+  const pinTab           = useApp(s => s.pinTab);
+  const unpinTab         = useApp(s => s.unpinTab);
 
   // Cross-pane drag: lets tabs be dragged to other panes' headers or back to
   // the main tab strip.
@@ -208,51 +211,84 @@ export function PaneHeader({ leaf, task, onClose }: PaneHeaderProps) {
     setOpen(false);
   }
 
+  // Closing the pane's last tab collapses the pane, matching ⌘W
+  // (useShortcuts). Without this the X leaves an empty "New pane" behind while
+  // ⌘W removes it. Capture wasLastTab before the async confirm, and only
+  // collapse if the close actually went through (onClose === closePane for
+  // this leaf).
+  function closePaneTabAt(tabId: string) {
+    const wasLastTab = (leaf.tabIds?.length ?? 1) <= 1;
+    void requestClosePaneTab(task.id, paneId, tabId).then(closed => {
+      if (closed && wasLastTab) onClose();
+    });
+  }
+
+  // Pinned tabs sit outside the scroller so they stay in reach (issue #183).
+  // The store keeps them at the head of the leaf, so this split preserves order.
+  const pinnedTabs = paneTabs.filter(t => t.pinned);
+  const looseTabs = paneTabs.filter(t => !t.pinned);
+
+  const renderPill = (tab: Tab) => (
+    <TabContextMenu
+      key={tab.id}
+      tabs={paneTabs}
+      tabId={tab.id}
+      pinned={!!tab.pinned}
+      onPin={() => pinTab(task.id, tab.id)}
+      onUnpin={() => unpinTab(task.id, tab.id)}
+      onClose={() => closePaneTabAt(tab.id)}
+      onCloseMany={(ids) => requestClosePaneTabs(task.id, paneId, ids)}
+    >
+      <TabPill
+        task={task}
+        tab={tab}
+        active={tab.id === activeTabId}
+        paneFocused={isPaneFocused}
+        compact
+        // focusPaneTab: keyboard focus must follow the click so ⌘W (which
+        // derives the pane from DOM focus) targets THIS pane afterwards.
+        onSelect={() => { setPaneActiveTab(task.id, paneId, tab.id); focusPaneTab(tab.id); }}
+        onClose={() => closePaneTabAt(tab.id)}
+        onUnpin={() => unpinTab(task.id, tab.id)}
+        renaming={null}
+        onStartRename={() => {}}
+        onChangeRename={() => {}}
+        onCommitRename={() => {}}
+        onCancelRename={() => {}}
+        dragging={dragTabId === tab.id}
+        dragTx={0}
+        onStartDrag={(e) => startTabDrag(tab.id, e)}
+      />
+    </TabContextMenu>
+  );
+
   return (
     <div
       data-pane-header=""
       data-pane-id={paneId}
       className="termic-tabstrip flex h-9 shrink-0 items-stretch border-b border-[var(--color-border-soft)] bg-[var(--color-bg-1)] select-none"
     >
-      {/* Scrollable tab pills — same geometry as main TabBar. */}
-      <div className="flex min-w-0 flex-1 items-stretch overflow-x-auto no-scrollbar pl-2">
+      {/* Tab pills — same geometry as the main TabBar, including its fixed
+          pinned region + scrolling remainder. */}
+      <div className="flex min-w-0 flex-1 items-stretch pl-2">
         {paneTabs.length === 0 ? (
           <span className="flex items-center px-2 text-[12.5px] italic text-[var(--color-fg-faint)]">
             New pane
           </span>
         ) : (
-          paneTabs.map(tab => (
-            <TabPill
-              key={tab.id}
-              task={task}
-              tab={tab}
-              active={tab.id === activeTabId}
-              paneFocused={isPaneFocused}
-              compact
-              // focusPaneTab: keyboard focus must follow the click so ⌘W (which
-              // derives the pane from DOM focus) targets THIS pane afterwards.
-              onSelect={() => { setPaneActiveTab(task.id, paneId, tab.id); focusPaneTab(tab.id); }}
-              // Closing the pane's last tab collapses the pane, matching ⌘W
-              // (useShortcuts). Without this the X leaves an empty "New pane"
-              // behind while ⌘W removes it. Capture wasLastTab before the
-              // async confirm, and only collapse if the close actually went
-              // through (onClose === closePane for this leaf).
-              onClose={() => {
-                const wasLastTab = (leaf.tabIds?.length ?? 1) <= 1;
-                void requestClosePaneTab(task.id, paneId, tab.id).then(closed => {
-                  if (closed && wasLastTab) onClose();
-                });
-              }}
-              renaming={null}
-              onStartRename={() => {}}
-              onChangeRename={() => {}}
-              onCommitRename={() => {}}
-              onCancelRename={() => {}}
-              dragging={dragTabId === tab.id}
-              dragTx={0}
-              onStartDrag={(e) => startTabDrag(tab.id, e)}
-            />
-          ))
+          <>
+            {pinnedTabs.length > 0 && (
+              <>
+                <div data-pinned-strip="" className="flex shrink-0 items-stretch overflow-x-auto no-scrollbar max-w-[55%]">
+                  {pinnedTabs.map(renderPill)}
+                </div>
+                <div className="mx-1 h-5 w-px shrink-0 self-center bg-[var(--color-border-soft)]" />
+              </>
+            )}
+            <div data-scroll-strip="" className="flex min-w-0 flex-1 items-stretch overflow-x-auto no-scrollbar">
+              {looseTabs.map(renderPill)}
+            </div>
+          </>
         )}
       </div>
 

--- a/src/components/task/TabBar.tsx
+++ b/src/components/task/TabBar.tsx
@@ -489,11 +489,18 @@ export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onC
       // always sized to comfortably fit 3 tabs; min-w floors
       // readability, max-w caps a lone tab on a very wide bar.
       style={{
-        // Main strip sizes tabs to fit ~three; the right strip sizes to
-        // content. A PINNED pill sizes to content too: it lives in the strip's
-        // fixed (non-scrolling) region, which is shrink-to-fit, so a percentage
-        // basis there has nothing definite to resolve against.
-        ...(compact || tab.pinned ? null : { flex: "0 1 calc((100% - 5rem) / 3)" }),
+        // Main strip sizes tabs to fit ~three; the right strip sizes to content.
+        // A PINNED pill gets an outright FIXED width instead. It lives in the
+        // strip's shrink-to-fit region, so a content-sized one re-measures on
+        // every OSC title the agent emits, resizing itself and shoving the whole
+        // scrolling remainder sideways. A flex-basis is not enough here: the
+        // region is a scroll container, whose intrinsic width does not track a
+        // shrinkable item's basis, so the pill collapsed to its min-w. The value
+        // equals max-w below, so an uncrowded pinned tab is exactly as wide as
+        // its unpinned neighbours; past the region's cap it scrolls.
+        ...(tab.pinned
+          ? { flex: "0 0 auto", width: compact ? 220 : 260 }
+          : compact ? null : { flex: "0 1 calc((100% - 5rem) / 3)" }),
         // While dragging this pill rides the cursor via translateX and
         // floats above its neighbours. z-index needs the inline value so
         // it beats sibling stacking contexts. pointer-events: none lets

--- a/src/components/task/TabBar.tsx
+++ b/src/components/task/TabBar.tsx
@@ -8,13 +8,14 @@ import { useTabStripDrag } from "./useTabStripDrag";
 import { Button } from "@/components/ui/Button";
 import { DropdownRoot, DropdownTrigger, DropdownMenu, DropdownItem, DropdownLabel, DropdownSeparator } from "@/components/ui/Dropdown";
 import { CliIcon, CLI_BRAND_COLOR, CLI_LABEL, resolveIconId } from "@/icons/cli";
-import { Plus, X, GitCompare, FileText, SquareSplitVertical, SquareSplitHorizontal, TerminalSquare, Bell, Megaphone, Repeat, RotateCw, Square, Play, AlertTriangle } from "lucide-react";
+import { Plus, X, GitCompare, FileText, SquareSplitVertical, SquareSplitHorizontal, TerminalSquare, Bell, Megaphone, Pin, Repeat, RotateCw, Square, Play, AlertTriangle } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { ptyKill } from "@/lib/ipc";
 import { usePrefs } from "@/store/prefs";
 import { Tip } from "@/components/ui/Tooltip";
 import { useUI } from "@/store/ui";
-import { requestCloseTab } from "@/lib/closeTab";
+import { requestCloseTab, requestCloseTabs } from "@/lib/closeTab";
+import { TabContextMenu } from "./TabContextMenu";
 import { focusMainTab } from "@/lib/tabFocus";
 import { visibleCliIds, agentDisplayName, isTerminalEntry } from "@/lib/agents";
 import { cn } from "@/lib/utils";
@@ -108,6 +109,8 @@ export function TabBar({ task }: { task: Task }) {
   const addTab = useApp(s => s.addTab);
   const reorderTab = useApp(s => s.reorderTab);
   const renameTab = useApp(s => s.renameTab);
+  const pinTab = useApp(s => s.pinTab);
+  const unpinTab = useApp(s => s.unpinTab);
   const stripRef = useRef<HTMLDivElement>(null);
 
   // Hide disabled / not-installed agents from the + (new agent) menu.
@@ -203,6 +206,40 @@ export function TabBar({ task }: { task: Task }) {
     });
   }
 
+  // The store keeps pinned tabs at the head of the strip, so splitting here
+  // preserves the display order (and therefore the DOM order the drag code
+  // reads back out of `stripRef`).
+  const pinnedTabs = tabs.filter(t => t.pinned);
+  const looseTabs = tabs.filter(t => !t.pinned);
+
+  const renderPill = (t: Tab) => (
+    <TabContextMenu
+      key={t.id} tabs={tabs} tabId={t.id} pinned={!!t.pinned}
+      onPin={() => pinTab(task.id, t.id)}
+      onUnpin={() => unpinTab(task.id, t.id)}
+      onClose={() => requestCloseTab(task.id, t.id)}
+      onCloseMany={(ids) => requestCloseTabs(task.id, ids)}
+    >
+      <TabPill
+        task={task} tab={t} active={t.id === activeId} paneFocused={mainFocused}
+        // focusMainTab: keyboard focus must follow the click into the tab's
+        // content (terminal / editor) — otherwise the previously focused
+        // pane keeps DOM focus and ⌘W acts on the wrong pane.
+        onSelect={() => { if (suppressClickRef.current) return; setActive(task.id, t.id); focusMainTab(t.id); }}
+        onClose={() => requestCloseTab(task.id, t.id)}
+        onUnpin={() => unpinTab(task.id, t.id)}
+        renaming={renaming?.id === t.id ? renaming.value : null}
+        onStartRename={() => setRenaming({ id: t.id, value: t.title })}
+        onChangeRename={(v) => setRenaming(r => r ? { ...r, value: v } : r)}
+        onCommitRename={commitRename}
+        onCancelRename={() => setRenaming(null)}
+        dragging={dragId === t.id}
+        dragTx={dragId === t.id ? dragTx : 0}
+        onStartDrag={(e) => startDrag(t.id, e)}
+      />
+    </TabContextMenu>
+  );
+
   return (
     <div className="termic-tabstrip flex h-9 shrink-0 border-b border-[var(--color-border-soft)] bg-[var(--color-bg-1)]">
       {/* Left portion: scrollable tab pills + a fixed control cluster (new-tab,
@@ -216,32 +253,43 @@ export function TabBar({ task }: { task: Task }) {
         ref={stripRef}
         data-main-strip=""
         className={cn(
-          "flex min-w-0 flex-1 items-stretch gap-0 pl-2 no-scrollbar",
-          // While dragging, let the pill escape the strip's clip and lift the
-          // whole strip above the right strip (a later DOM sibling that would
-          // otherwise paint over the pill) so the tab stays visible as it
-          // crosses into the other pane.
-          dragId ? "relative z-30 overflow-visible" : "overflow-x-auto overflow-y-hidden",
+          "flex min-w-0 flex-1 items-stretch gap-0 pl-2",
+          // While dragging, lift the whole strip above the right strip (a later
+          // DOM sibling that would otherwise paint over the pill) so the tab
+          // stays visible as it crosses into the other pane.
+          dragId && "relative z-30",
         )}
       >
-        {tabs.map(t => (
-          <TabPill
-            key={t.id} task={task} tab={t} active={t.id === activeId} paneFocused={mainFocused}
-            // focusMainTab: keyboard focus must follow the click into the tab's
-            // content (terminal / editor) — otherwise the previously focused
-            // pane keeps DOM focus and ⌘W acts on the wrong pane.
-            onSelect={() => { if (suppressClickRef.current) return; setActive(task.id, t.id); focusMainTab(t.id); }}
-            onClose={() => requestCloseTab(task.id, t.id)}
-            renaming={renaming?.id === t.id ? renaming.value : null}
-            onStartRename={() => setRenaming({ id: t.id, value: t.title })}
-            onChangeRename={(v) => setRenaming(r => r ? { ...r, value: v } : r)}
-            onCommitRename={commitRename}
-            onCancelRename={() => setRenaming(null)}
-            dragging={dragId === t.id}
-            dragTx={dragId === t.id ? dragTx : 0}
-            onStartDrag={(e) => startDrag(t.id, e)}
-          />
-        ))}
+        {/* Pinned region — OUTSIDE the scroller, which is the whole point of
+            pinning (issue #183): a pinned tab must stay in reach no matter how
+            far the rest of the strip is scrolled. Capped so that many pinned
+            tabs cannot eat the bar and strand the "+" button; past the cap this
+            region scrolls on its own. */}
+        {pinnedTabs.length > 0 && (
+          <>
+            <div
+              data-pinned-strip=""
+              className={cn(
+                "flex shrink-0 items-stretch no-scrollbar max-w-[55%]",
+                dragId ? "overflow-visible" : "overflow-x-auto",
+              )}
+            >
+              {pinnedTabs.map(renderPill)}
+            </div>
+            <div className="mx-1 h-5 w-px shrink-0 self-center bg-[var(--color-border-soft)]" />
+          </>
+        )}
+
+        <div
+          data-scroll-strip=""
+          className={cn(
+            "flex min-w-0 flex-1 items-stretch gap-0 no-scrollbar",
+            // The dragged pill escapes this clip so it stays visible while it
+            // crosses into the other pane.
+            dragId ? "overflow-visible" : "overflow-x-auto overflow-y-hidden",
+          )}
+        >
+        {looseTabs.map(renderPill)}
 
         {/* New tab button — right after the last tab. When scrolling lands,
             move this back to the sticky right cluster. */}
@@ -276,6 +324,7 @@ export function TabBar({ task }: { task: Task }) {
             )}
           </DropdownMenu>
         </DropdownRoot>
+        </div>
       </div>
 
       {/* Fixed control cluster — never scrolls; always reachable on the right. */}
@@ -329,7 +378,7 @@ function SplitBelowToggle({ taskId }: { taskId: string }) {
   );
 }
 
-export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onClose, renaming, onStartRename, onChangeRename, onCommitRename, onCancelRename, dragging, dragTx, onStartDrag }: {
+export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onClose, onUnpin, renaming, onStartRename, onChangeRename, onCommitRename, onCancelRename, dragging, dragTx, onStartDrag }: {
   task: Task; tab: Tab; active: boolean;
   /** True when this pill's pane is the focused one. The active tab keeps its
    *  bg highlight regardless, but only shows the accent underline when its
@@ -339,6 +388,10 @@ export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onC
    *  fit-three-tabs flex basis. */
   compact?: boolean;
   onSelect: () => void; onClose: () => void;
+  /** A PINNED pill trades its close × for a pin that unpins on click, so the
+   *  tab the user marked as important is never one stray click from a dead
+   *  PTY. ⌘W and the context menu's Close stay as the ways out. */
+  onUnpin: () => void;
   renaming: string | null;  // current draft value while renaming, else null
   onStartRename: () => void;
   onChangeRename: (v: string) => void;
@@ -370,6 +423,9 @@ export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onC
   const showBell    = !showFailed && reason === "attention";
   const showDone    = !showFailed && !showBell && workState === "done";
   const showWorking = workingIndicator && !showFailed && !showBell && !showDone && workState === "working";
+  // Something already occupies the trailing slot at rest, so the action button
+  // (close ×, or the pin on a pinned tab) waits for hover.
+  const slotTaken = showFailed || showBell || showDone || showWorking || !!tab.dirty;
   const iconId = tab.type === "terminal" ? resolveIconId(tab.cli, agents) : "";
   const color = tab.type === "terminal" ? CLI_BRAND_COLOR[iconId] : "text-[var(--color-fg-dim)]";
   const isRenaming = renaming !== null;
@@ -407,6 +463,7 @@ export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onC
     <div
       ref={pillRef}
       data-tab-id={tab.id}
+      {...(tab.pinned ? { "data-pinned": "" } : null)}
       // Start a pointer-drag for reordering, except while renaming (so the
       // inline input handles text selection / caret normally).
       onPointerDown={(e) => { if (!isRenaming) onStartDrag(e); }}
@@ -432,8 +489,11 @@ export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onC
       // always sized to comfortably fit 3 tabs; min-w floors
       // readability, max-w caps a lone tab on a very wide bar.
       style={{
-        // Main strip sizes tabs to fit ~three; the right strip sizes to content.
-        ...(compact ? null : { flex: "0 1 calc((100% - 5rem) / 3)" }),
+        // Main strip sizes tabs to fit ~three; the right strip sizes to
+        // content. A PINNED pill sizes to content too: it lives in the strip's
+        // fixed (non-scrolling) region, which is shrink-to-fit, so a percentage
+        // basis there has nothing definite to resolve against.
+        ...(compact || tab.pinned ? null : { flex: "0 1 calc((100% - 5rem) / 3)" }),
         // While dragging this pill rides the cursor via translateX and
         // floats above its neighbours. z-index needs the inline value so
         // it beats sibling stacking contexts. pointer-events: none lets
@@ -541,9 +601,10 @@ export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onC
           </span>
         );
       })()}
-      {/* Trailing slot — iTerm2 convention: status badge / dirty dot
-          by default; close × on hover. Fixed cell so the pill never
-          jiggles. Priority: failed > attention > done > dirty > none. */}
+      {/* Trailing slot — iTerm2 convention: status badge / dirty dot by
+          default; the action button (close ×, or the unpin pin on a pinned
+          tab) on hover. Fixed cell so the pill never jiggles.
+          Priority: failed > attention > done > dirty > none. */}
       {!isRenaming && (
         <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
           {(showFailed || showBell || showDone || showWorking) ? (
@@ -589,14 +650,30 @@ export function TabPill({ task, tab, active, paneFocused, compact, onSelect, onC
               className="absolute h-[7px] w-[7px] rounded-full bg-[var(--color-fg-dim)] transition-opacity group-hover:opacity-0"
             />
           )}
-          <button
-            title="Close tab"
-            className={cn(
-              "absolute inset-0 flex items-center justify-center rounded p-0.5 text-[var(--color-fg-faint)] transition-opacity hover:bg-[var(--color-bg-3)] hover:text-[var(--color-fg)]",
-              (!active || tab.dirty || showFailed || showBell || showDone || showWorking) && "opacity-0 group-hover:opacity-100",
-            )}
-            onClick={(e) => { e.stopPropagation(); onClose(); }}
-          ><X className="h-3 w-3" /></button>
+          {tab.pinned ? (
+            // No close × on a pinned tab: the affordance would contradict the
+            // intent, and one stray click would kill a live PTY (a secondary
+            // agent tab is forgotten for good, see closeTab.ts). The pin is
+            // always on show when nothing outranks it, so pinned state can
+            // never hide behind a status badge.
+            <button
+              title="Unpin tab"
+              className={cn(
+                "absolute inset-0 flex items-center justify-center rounded p-0.5 text-[var(--color-fg-faint)] transition-opacity hover:bg-[var(--color-bg-3)] hover:text-[var(--color-fg)]",
+                slotTaken && "opacity-0 group-hover:opacity-100",
+              )}
+              onClick={(e) => { e.stopPropagation(); onUnpin(); }}
+            ><Pin className="h-3 w-3" /></button>
+          ) : (
+            <button
+              title="Close tab"
+              className={cn(
+                "absolute inset-0 flex items-center justify-center rounded p-0.5 text-[var(--color-fg-faint)] transition-opacity hover:bg-[var(--color-bg-3)] hover:text-[var(--color-fg)]",
+                (!active || slotTaken) && "opacity-0 group-hover:opacity-100",
+              )}
+              onClick={(e) => { e.stopPropagation(); onClose(); }}
+            ><X className="h-3 w-3" /></button>
+          )}
         </span>
       )}
     </div>

--- a/src/components/task/TabContextMenu.tsx
+++ b/src/components/task/TabContextMenu.tsx
@@ -1,0 +1,51 @@
+// Right-click menu on a tab pill (issue #183). Shared by all three strips: the
+// main TabBar, a split pane's PaneHeader, and TaskView's bottom scratch shells.
+// Each host supplies its own strip and its own close/pin wiring; the item set
+// and the "which siblings does this close" rules live here.
+
+import type { ReactNode } from "react";
+import { Pin, PinOff, X } from "lucide-react";
+import {
+  ContextMenuRoot, ContextMenuTrigger, ContextMenuContent,
+  ContextMenuItem, ContextMenuSeparator,
+} from "@/components/ui/ContextMenu";
+import { closableSiblings, type StripTab } from "@/lib/tabActions";
+
+export function TabContextMenu({ tabs, tabId, pinned, onPin, onUnpin, onClose, onCloseMany, children }: {
+  /** This strip's tabs, in display order. */
+  tabs: StripTab[];
+  tabId: string;
+  pinned: boolean;
+  onPin: () => void;
+  onUnpin: () => void;
+  onClose: () => void;
+  onCloseMany: (tabIds: string[]) => void;
+  children: ReactNode;
+}) {
+  const others = closableSiblings(tabs, tabId, "others");
+  const right = closableSiblings(tabs, tabId, "right");
+  return (
+    <ContextMenuRoot>
+      {/* `contents` rather than asChild: TabPill neither forwards a ref nor
+          spreads unknown props, so Radix's Slot would drop them. A
+          display:contents span generates no box, so the pill stays the strip's
+          flex item and the contextmenu event still bubbles through. */}
+      <ContextMenuTrigger className="contents">{children}</ContextMenuTrigger>
+      <ContextMenuContent>
+        {pinned ? (
+          <ContextMenuItem onSelect={onUnpin}><PinOff /> Unpin</ContextMenuItem>
+        ) : (
+          <ContextMenuItem onSelect={onPin}><Pin /> Pin</ContextMenuItem>
+        )}
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onClose}><X /> Close</ContextMenuItem>
+        <ContextMenuItem disabled={!others.length} onSelect={() => onCloseMany(others)}>
+          Close others
+        </ContextMenuItem>
+        <ContextMenuItem disabled={!right.length} onSelect={() => onCloseMany(right)}>
+          Close to the right
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenuRoot>
+  );
+}

--- a/src/components/task/TaskView.tsx
+++ b/src/components/task/TaskView.tsx
@@ -21,6 +21,7 @@ import type { Task, Tab, TerminalTab } from "@/lib/types";
 import { useApp, useTaskTabs, useActiveTabId } from "@/store/app";
 import { usePrefs, currentTerminalTheme } from "@/store/prefs";
 import { TabBar, TabPill } from "./TabBar";
+import { TabContextMenu } from "./TabContextMenu";
 import { TerminalPane, FooterBar } from "./TerminalPane";
 import { RunPane } from "./RunPane";
 import { SplitNodeView } from "./SplitView";
@@ -137,6 +138,8 @@ export function TaskView({ task }: { task: Task }) {
   const addBottomTab = useApp(s => s.addBottomTab);
   const closeBottomTab = useApp(s => s.closeBottomTab);
   const setActiveBottom = useApp(s => s.setActiveBottomTab);
+  const pinBottomTab = useApp(s => s.pinBottomTab);
+  const unpinBottomTab = useApp(s => s.unpinBottomTab);
   const setBottomLiveTitle = useApp(s => s.setBottomTabLiveTitle);
 
   // Subscribe to themeMode (and the custom-theme edit counter) so the
@@ -252,6 +255,42 @@ export function TaskView({ task }: { task: Task }) {
       height: `calc(${r.h * 100}% - ${chromePx}px)`,
     };
   };
+
+  // Scratch shells live in a separate `bottomTabs` array, but render through
+  // the SAME TabPill as agent tabs (via a synthetic shell Tab) so every strip
+  // looks identical.
+  const renderBottomPill = (t: NonNullable<typeof bottomTabs>[number]) => (
+    <TabContextMenu
+      key={t.id}
+      tabs={bottomTabs || []}
+      tabId={t.id}
+      pinned={!!t.pinned}
+      onPin={() => pinBottomTab(task.id, t.id)}
+      onUnpin={() => unpinBottomTab(task.id, t.id)}
+      onClose={() => closeBottomTab(task.id, t.id)}
+      // Plain shells: nothing to confirm, nothing to resume.
+      onCloseMany={(ids) => ids.forEach(id => closeBottomTab(task.id, id))}
+    >
+      <TabPill
+        task={task}
+        tab={{ id: t.id, type: "terminal", cli: "shell", title: t.title, liveTitle: t.liveTitle, pinned: t.pinned } as TerminalTab}
+        active={t.id === activeBottom}
+        paneFocused
+        compact
+        onSelect={() => setActiveBottom(task.id, t.id)}
+        onClose={() => closeBottomTab(task.id, t.id)}
+        onUnpin={() => unpinBottomTab(task.id, t.id)}
+        renaming={null}
+        onStartRename={() => {}}
+        onChangeRename={() => {}}
+        onCommitRename={() => {}}
+        onCancelRename={() => {}}
+        dragging={false}
+        dragTx={0}
+        onStartDrag={() => {}}
+      />
+    </TabContextMenu>
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -452,30 +491,18 @@ export function TaskView({ task }: { task: Task }) {
                 {/* Tabs + New scroll horizontally (no scrollbar) so the queue
                     button on the left and the collapse toggle on the right stay
                     fixed and reachable no matter how many shells are open. */}
-                <div className="flex min-w-0 flex-1 items-stretch gap-0 overflow-x-auto no-scrollbar">
-                  {(bottomTabs || []).map(t => (
-                    // Scratch shells live in a separate `bottomTabs` array, but
-                    // render through the SAME TabPill as agent tabs (via a
-                    // synthetic shell Tab) so every strip looks identical.
-                    <TabPill
-                      key={t.id}
-                      task={task}
-                      tab={{ id: t.id, type: "terminal", cli: "shell", title: t.title, liveTitle: t.liveTitle } as TerminalTab}
-                      active={t.id === activeBottom}
-                      paneFocused
-                      compact
-                      onSelect={() => setActiveBottom(task.id, t.id)}
-                      onClose={() => closeBottomTab(task.id, t.id)}
-                      renaming={null}
-                      onStartRename={() => {}}
-                      onChangeRename={() => {}}
-                      onCommitRename={() => {}}
-                      onCancelRename={() => {}}
-                      dragging={false}
-                      dragTx={0}
-                      onStartDrag={() => {}}
-                    />
-                  ))}
+                {/* Pinned shells sit outside the scroller so they stay in
+                    reach, same as the main strip (issue #183). */}
+                {(bottomTabs || []).some(t => t.pinned) && (
+                  <>
+                    <div data-pinned-strip="" className="flex shrink-0 items-stretch gap-0 overflow-x-auto no-scrollbar max-w-[55%]">
+                      {(bottomTabs || []).filter(t => t.pinned).map(renderBottomPill)}
+                    </div>
+                    <div className="mx-1 h-5 w-px shrink-0 self-center bg-[var(--color-border-soft)]" />
+                  </>
+                )}
+                <div data-scroll-strip="" className="flex min-w-0 flex-1 items-stretch gap-0 overflow-x-auto no-scrollbar">
+                  {(bottomTabs || []).filter(t => !t.pinned).map(renderBottomPill)}
                   <button
                     title="New shell tab"
                     onClick={() => addBottomTab(task.id)}

--- a/src/components/task/useTabStripDrag.ts
+++ b/src/components/task/useTabStripDrag.ts
@@ -122,8 +122,13 @@ export function useTabStripDrag(opts: {
     }
     const stripT = stripTabsRef.current; const allT = allTabsRef.current;
     const cur = stripT.findIndex(t => t.id === d.id);
-    if (target === cur) return;
     const filteredWithout = stripT.filter(t => t.id !== d.id);
+    // Pinned tabs own the head of the strip, so a drag can only reorder WITHIN
+    // its own group: a pinned pill stops at the boundary, an unpinned one can't
+    // cross above it (issue #183).
+    const boundary = filteredWithout.filter(t => t.pinned).length;
+    target = stripT[cur]?.pinned ? Math.min(target, boundary) : Math.max(target, boundary);
+    if (target === cur) return;
     const fullWithout = allT.filter(t => t.id !== d.id);
     let fullTarget: number;
     if (target >= filteredWithout.length) {

--- a/src/lib/closeTab.ts
+++ b/src/lib/closeTab.ts
@@ -74,6 +74,34 @@ async function confirmTabClose(tab: Tab | undefined, paneTab: boolean): Promise<
   return true;
 }
 
+/** One confirm for a whole set (the context menu's "Close others" / "Close to
+ *  the right"). A per-tab confirm would stack five modals on one gesture, so
+ *  this dialog counts the losses and asks once. */
+async function confirmBulkClose(tabs: Tab[]): Promise<boolean> {
+  const agents = useApp.getState().agents;
+  const dirty = tabs.filter(t => t.type === "edit" && t.dirty);
+  // Same rule as confirmTabClose: an already-exited terminal-like tab has
+  // neither a process to stop nor a session to lose.
+  const live = tabs.filter(t =>
+    t.type === "terminal" && t.cli !== "shell"
+    && !(isTerminalCli(t.cli, agents) && !t.ptyId));
+  if (!dirty.length && (!live.length || !usePrefs.getState().confirmBeforeCloseAgentTab)) return true;
+  const parts: string[] = [];
+  if (dirty.length) {
+    parts.push(`termic discards the unsaved changes in ${dirty.length} ${dirty.length === 1 ? "file" : "files"}.`);
+  }
+  if (live.length) {
+    parts.push(`termic ends ${live.length} agent ${live.length === 1 ? "session" : "sessions"}.`);
+  }
+  const ok = await useUI.getState().askConfirm({
+    title: `Close ${tabs.length} ${tabs.length === 1 ? "tab" : "tabs"}?`,
+    message: parts.join(" "),
+    confirmLabel: "Close tabs",
+    destructive: true,
+  });
+  return ok === true;
+}
+
 /** After a fast-path close (confirm skipped, see above), tell the user
  *  where the tab went. Secondary tabs snapshot into `closedTabs` on close
  *  (see app.ts's closeTab) so the toast's action can reopen the exact one
@@ -133,4 +161,23 @@ export async function requestClosePaneTab(taskId: string, paneId: string, tabId:
   useApp.getState().closePaneTab(taskId, paneId, tabId);
   if (fastClose && tab) toastClosedTab(taskId, tab, true);
   return true;
+}
+
+/** Close a set of main-pane tabs behind ONE confirm. Secondary agent tabs still
+ *  snapshot into `closedTabs`, so the "+" menu's Resume section can bring any of
+ *  them back. */
+export async function requestCloseTabs(taskId: string, tabIds: string[]) {
+  const tabs = (useApp.getState().tabs[taskId] ?? []).filter(t => tabIds.includes(t.id));
+  if (!tabs.length) return;
+  if (!(await confirmBulkClose(tabs))) return;
+  for (const t of tabs) useApp.getState().closeTab(taskId, t.id);
+}
+
+/** Close a set of split-pane tabs behind ONE confirm. The clicked tab always
+ *  survives both menu actions, so the pane can never end up empty here. */
+export async function requestClosePaneTabs(taskId: string, paneId: string, tabIds: string[]) {
+  const tabs = (useApp.getState().tabs[taskId] ?? []).filter(t => tabIds.includes(t.id));
+  if (!tabs.length) return;
+  if (!(await confirmBulkClose(tabs))) return;
+  for (const t of tabs) useApp.getState().closePaneTab(taskId, paneId, t.id);
 }

--- a/src/lib/splitTree.ts
+++ b/src/lib/splitTree.ts
@@ -111,6 +111,16 @@ export function addLeafTab(tree: SplitTree, leafId: string, tabId: string): Spli
   return { ...tree, a: addLeafTab(tree.a, leafId, tabId), b: addLeafTab(tree.b, leafId, tabId) };
 }
 
+/** Replace a leaf's tabIds wholesale (reorder). The caller passes the same set,
+ *  so activeTabId stays valid. */
+export function setLeafTabs(tree: SplitTree, leafId: string, tabIds: string[]): SplitTree {
+  if (tree.type === 'pane') {
+    if (tree.id !== leafId) return tree;
+    return { ...tree, tabIds };
+  }
+  return { ...tree, a: setLeafTabs(tree.a, leafId, tabIds), b: setLeafTabs(tree.b, leafId, tabIds) };
+}
+
 /** Remove a tab from a leaf's tabIds; updates activeTabId to the neighbour. */
 export function removeLeafTab(tree: SplitTree, leafId: string, tabId: string): SplitTree {
   if (tree.type === 'pane') {

--- a/src/lib/tabActions.test.ts
+++ b/src/lib/tabActions.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { pinBoundary, closableSiblings, type StripTab } from "./tabActions";
+
+const strip = (...spec: string[]): StripTab[] =>
+  spec.map(s => (s.endsWith("*") ? { id: s.slice(0, -1), pinned: true } : { id: s }));
+
+describe("pinBoundary", () => {
+  it("is 0 when nothing is pinned", () => {
+    expect(pinBoundary(strip("a", "b", "c"), "c")).toBe(0);
+  });
+
+  it("counts the pinned block", () => {
+    expect(pinBoundary(strip("a*", "b*", "c", "d"), "d")).toBe(2);
+  });
+
+  it("ignores the moving tab's own pinned flag", () => {
+    // Unpinning "b" must land it right after "a", not after itself.
+    expect(pinBoundary(strip("a*", "b*", "c"), "b")).toBe(1);
+    // Pinning "c" appends it to the block, which is still 2 long without it.
+    expect(pinBoundary(strip("a*", "b*", "c"), "c")).toBe(2);
+  });
+
+  it("is the whole length when every other tab is pinned", () => {
+    expect(pinBoundary(strip("a*", "b*", "c"), "c")).toBe(2);
+  });
+});
+
+describe("closableSiblings", () => {
+  it("others: every unpinned tab but the clicked one", () => {
+    expect(closableSiblings(strip("a", "b", "c"), "b", "others")).toEqual(["a", "c"]);
+  });
+
+  it("others: skips pinned tabs", () => {
+    expect(closableSiblings(strip("a*", "b", "c", "d*"), "b", "others")).toEqual(["c"]);
+  });
+
+  it("right: only the tabs after the clicked one", () => {
+    expect(closableSiblings(strip("a", "b", "c", "d"), "b", "right")).toEqual(["c", "d"]);
+  });
+
+  it("right: skips pinned tabs after the clicked one", () => {
+    expect(closableSiblings(strip("a", "b", "c*", "d"), "b", "right")).toEqual(["d"]);
+  });
+
+  it("right: empty on the last tab", () => {
+    expect(closableSiblings(strip("a", "b"), "b", "right")).toEqual([]);
+  });
+
+  it("others: empty when the clicked tab is the only unpinned one", () => {
+    expect(closableSiblings(strip("a*", "b"), "b", "others")).toEqual([]);
+  });
+
+  it("never closes the clicked tab, even when it is pinned", () => {
+    expect(closableSiblings(strip("a*", "b", "c"), "a", "others")).toEqual(["b", "c"]);
+    expect(closableSiblings(strip("a*", "b", "c"), "a", "right")).toEqual(["b", "c"]);
+  });
+
+  it("is empty for an unknown tab id", () => {
+    expect(closableSiblings(strip("a", "b"), "zz", "others")).toEqual([]);
+    expect(closableSiblings(strip("a", "b"), "zz", "right")).toEqual([]);
+  });
+});

--- a/src/lib/tabActions.ts
+++ b/src/lib/tabActions.ts
@@ -1,0 +1,26 @@
+// Ordering + selection rules behind the tab context menu (issue #183).
+//
+// Typed on the smallest shape a tab strip has in common, so the main strip
+// (`Tab[]`), a split pane's strip (`Tab[]`) and the bottom scratch shells
+// (their own `{ id, title }` records) all share one implementation.
+
+export interface StripTab {
+  id: string;
+  pinned?: boolean;
+}
+
+/** Where the pinned block ends, ignoring `tabId` itself. Chrome semantics: this
+ *  is the destination for BOTH pin (append to the block) and unpin (first slot
+ *  after it). */
+export function pinBoundary(strip: StripTab[], tabId: string): number {
+  return strip.filter(t => t.id !== tabId && t.pinned).length;
+}
+
+/** Tabs "Close others" / "Close to the right" should close. Pinned tabs and the
+ *  clicked tab itself always survive. Empty when the clicked tab is unknown. */
+export function closableSiblings(strip: StripTab[], tabId: string, mode: "others" | "right"): string[] {
+  const idx = strip.findIndex(t => t.id === tabId);
+  if (idx < 0) return [];
+  const candidates = mode === "right" ? strip.slice(idx + 1) : strip;
+  return candidates.filter(t => t.id !== tabId && !t.pinned).map(t => t.id);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -269,6 +269,8 @@ export interface PersistedTab {
   /** Run pop-out tab marker (GH #54): the member dir ("" = host project)
    *  when this tab hosts the run script. Restores as a RunPane. */
   run_member?: string | null;
+  /** Pinned state, so a pinned tab comes back pinned and leftmost. */
+  pinned?: boolean;
 }
 
 /** Per-member input for `task_create_multi`. `root_path` matches a
@@ -707,6 +709,10 @@ export interface BaseTab {
    *  main pane tab (shown in the task tab bar). Split-pane tabs are
    *  ephemeral — they are not persisted across launches. */
   paneId?: string;
+  /** Pinned tabs sort before every unpinned tab in their strip, and
+   *  "Close others" / "Close to the right" skip them. `pinTab` / `unpinTab`
+   *  own both the flag and the move that keeps that order true. */
+  pinned?: boolean;
 }
 
 export interface TerminalTab extends BaseTab {

--- a/src/store/app.test.ts
+++ b/src/store/app.test.ts
@@ -32,7 +32,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { isUserWatching, useApp } from "@/store/app";
 import * as ipc from "@/lib/ipc";
 import { markUnattendedSpawn, takeUnattendedSpawn } from "@/lib/unattendedSpawns";
-import type { QueueItem, Tab, TerminalTab, PersistedTab } from "@/lib/types";
+import type { QueueItem, PaneLeaf, Tab, TerminalTab, PersistedTab } from "@/lib/types";
 import { useUI } from "@/store/ui";
 // Store interactor — the ONE place that knows the store's shape. Cases below
 // say what they mean ("what work state is that tab in?") instead of spelling
@@ -653,6 +653,105 @@ describe("reorderTab", () => {
   });
 });
 
+// ── pin / unpin (issue #183) ──────────────────────────────────────────
+
+describe("pinTab / unpinTab", () => {
+  const ids = getTabIds;
+  const pinnedOf = (taskId: string, tabId: string) =>
+    !!getTabs(taskId).find(t => t.id === tabId)?.pinned;
+
+  function seed(taskId: string, n: number) {
+    for (let i = 0; i < n; i++) addTab(taskId, makeTermTab({ id: `t${i}` }));
+  }
+
+  it("pin moves the tab to the front when nothing else is pinned", () => {
+    seed("ws1", 3); // t0 t1 t2
+    useApp.getState().pinTab("ws1", "t2");
+    expect(ids("ws1")).toEqual(["t2", "t0", "t1"]);
+    expect(pinnedOf("ws1", "t2")).toBe(true);
+  });
+
+  it("pin appends to the END of the pinned block, not the front", () => {
+    seed("ws1", 4); // t0 t1 t2 t3
+    useApp.getState().pinTab("ws1", "t3");
+    useApp.getState().pinTab("ws1", "t2");
+    expect(ids("ws1")).toEqual(["t3", "t2", "t0", "t1"]);
+  });
+
+  it("unpin drops the tab to the first slot after the pinned block", () => {
+    seed("ws1", 4); // t0 t1 t2 t3
+    useApp.getState().pinTab("ws1", "t2");
+    useApp.getState().pinTab("ws1", "t3"); // t2 t3 t0 t1
+    useApp.getState().unpinTab("ws1", "t2");
+    expect(ids("ws1")).toEqual(["t3", "t2", "t0", "t1"]);
+    expect(pinnedOf("ws1", "t2")).toBe(false);
+  });
+
+  it("pinning an already-pinned tab at the boundary leaves the order alone", () => {
+    seed("ws1", 3);
+    useApp.getState().pinTab("ws1", "t0");
+    const before = ids("ws1");
+    useApp.getState().pinTab("ws1", "t0");
+    expect(ids("ws1")).toEqual(before);
+  });
+
+  it("ignores an unknown tab id", () => {
+    seed("ws1", 2);
+    const before = ids("ws1");
+    useApp.getState().pinTab("ws1", "nope");
+    expect(ids("ws1")).toEqual(before);
+  });
+
+  it("persists the pinned flag and the new order", () => {
+    useApp.setState({ tasks: [makeTask()] });
+    useApp.getState().addTab("ws1", makeTermTab({ id: "a", cli: "claude" }));
+    useApp.getState().addTab("ws1", makeTermTab({ id: "b", cli: "codex" }));
+
+    useApp.getState().pinTab("ws1", "b");
+
+    const task = useApp.getState().tasks.find(w => w.id === "ws1")!;
+    expect(task.persisted_tabs!.map(t => t.id)).toEqual(["b", "a"]);
+    expect(task.persisted_tabs!.map(t => t.pinned)).toEqual([true, false]);
+  });
+
+  it("persists an unpin even when the order does not change", () => {
+    useApp.setState({ tasks: [makeTask()] });
+    useApp.getState().addTab("ws1", makeTermTab({ id: "a", cli: "claude" }));
+    useApp.getState().addTab("ws1", makeTermTab({ id: "b", cli: "codex" }));
+    useApp.getState().pinTab("ws1", "a"); // already first — no move
+
+    useApp.getState().unpinTab("ws1", "a"); // still first — no move either
+
+    const task = useApp.getState().tasks.find(w => w.id === "ws1")!;
+    expect(task.persisted_tabs!.map(t => t.id)).toEqual(["a", "b"]);
+    expect(task.persisted_tabs![0].pinned).toBe(false);
+  });
+
+  it("a main tab's pin ignores split-pane tabs interleaved in the array", () => {
+    addTab("ws1", makeTermTab({ id: "p0", paneId: "leaf-1" }));
+    addTab("ws1", makeTermTab({ id: "t0" }));
+    addTab("ws1", makeTermTab({ id: "t1" }));
+    useApp.getState().pinTab("ws1", "t1");
+    // t1 lands before t0 (the first MAIN tab), not at array index 0.
+    expect(ids("ws1")).toEqual(["p0", "t1", "t0"]);
+  });
+
+  it("a pane tab's pin reorders its leaf's tabIds", () => {
+    addTab("ws1", makeTermTab({ id: "p0", paneId: "leaf-1" }));
+    addTab("ws1", makeTermTab({ id: "p1", paneId: "leaf-1" }));
+    useApp.setState({
+      splitTree: {
+        ws1: { type: "pane", id: "leaf-1", tabIds: ["p0", "p1"], activeTabId: "p0" },
+      },
+    } as never);
+
+    useApp.getState().pinTab("ws1", "p1");
+
+    const leaf = useApp.getState().splitTree["ws1"] as PaneLeaf;
+    expect(leaf.tabIds).toEqual(["p1", "p0"]);
+  });
+});
+
 // ── persist + restore agent tabs (issue #23) ──────────────────────────
 
 describe("ensureDefaultTab — seed / restore / migrate", () => {
@@ -689,6 +788,18 @@ describe("ensureDefaultTab — seed / restore / migrate", () => {
     expect(useApp.getState().activeTab["ws1"]).toBe("t1");
     // Restore reads existing on-disk state — it must NOT re-persist.
     expect(ipc.taskSetTabs).not.toHaveBeenCalled();
+  });
+
+  it("restores the pinned flag (issue #183)", () => {
+    const persisted: PersistedTab[] = [
+      { id: "t1", cli: "claude", is_default: true, pinned: true },
+      { id: "t2", cli: "codex", pinned: false },
+    ];
+    useApp.setState({ tasks: [makeTask({ persisted_tabs: persisted })] });
+    useApp.getState().ensureDefaultTab("ws1", "claude");
+
+    const tabs = useApp.getState().tabs["ws1"];
+    expect(tabs.map(t => !!t.pinned)).toEqual([true, false]);
   });
 
   it("re-derives the title for tabs the user never renamed", () => {

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -6,9 +6,10 @@ import { useUI } from "@/store/ui";
 import type { Project, Task, Tab, TerminalTab, PersistedTab, SplitTree, PaneLeaf, SplitDir } from "@/lib/types";
 import {
   findLeaf, getAllLeaves, countLeaves, replaceNode, removeLeaf,
-  addLeafTab, removeLeafTab, setLeafActiveTabId, pruneLeafTabs, dropEmptyLeaves,
+  addLeafTab, removeLeafTab, setLeafTabs, setLeafActiveTabId, pruneLeafTabs, dropEmptyLeaves,
   updateSplitRatio, findAdjacentPane, equalizeSplitsOnAxis,
 } from "@/lib/splitTree";
+import { pinBoundary } from "@/lib/tabActions";
 import * as ipc from "@/lib/ipc";
 import { groupOf } from "@/lib/projectGroups";
 import { useRace } from "@/store/race";
@@ -88,7 +89,7 @@ export interface AppState {
   terminalSplitCollapsed: Record<string, boolean>;
   /** Per-task: bottom-terminal tab IDs (each = its own scratch shell).
    *  Lives in memory only — like the main terminal tabs, PTYs die with the app. */
-  bottomTabs: Record<string, { id: string; title: string; liveTitle?: string; autoFocus?: boolean }[]>;
+  bottomTabs: Record<string, { id: string; title: string; liveTitle?: string; autoFocus?: boolean; pinned?: boolean }[]>;
   /** Per-task: id of the active bottom-terminal tab. */
   activeBottomTab: Record<string, string>;
   /** Per-task: the iTerm-like split-pane tree for the main content area.
@@ -205,6 +206,10 @@ export interface AppState {
   addBottomTab: (taskId: string, opts?: { focus?: boolean }) => string;
   closeBottomTab: (taskId: string, tabId: string) => void;
   setActiveBottomTab: (taskId: string, tabId: string) => void;
+  /** `pinTab` / `unpinTab` for the bottom scratch shells. Those live in their
+   *  own array and are never persisted, so their pin lasts the session only. */
+  pinBottomTab: (taskId: string, tabId: string) => void;
+  unpinBottomTab: (taskId: string, tabId: string) => void;
   /** Update a bottom-shell tab's live OSC 0/2 title (what the shell emits,
    *  e.g. the running command or cwd). Falls back to the base "shell N" when
    *  empty. Idempotent. */
@@ -287,6 +292,11 @@ export interface AppState {
    *  tab is pulled out (i.e. an index into the other tabs, 0..length-1).
    *  No-op if the order is unchanged. */
   reorderTab: (taskId: string, tabId: string, toIndex: number) => void;
+  /** Pin a tab: flag it and append it to its strip's pinned block. Unpin: clear
+   *  the flag and drop it to the first slot after that block (Chrome
+   *  semantics). Works for both main-strip and split-pane tabs. */
+  pinTab: (taskId: string, tabId: string) => void;
+  unpinTab: (taskId: string, tabId: string) => void;
   closeTab: (taskId: string, tabId: string) => void;
   /** Reopen a `closedTabs` entry as a fresh tab, forcing its original
    *  `sessionId` so the agent resumes via `--resume <uuid>` (see
@@ -423,9 +433,67 @@ function durablePersistedTabs(tabs: Tab[] | undefined): PersistedTab[] {
       // Run pop-out tabs persist WITH their marker so the RunPane comes back
       // in its pane on relaunch (the run script re-fires, like custom tabs).
       run_member: t.runTab ? t.runTab.member : null,
+      pinned: !!t.pinned,
     }));
 }
 
+/**
+ * Move `tabId` to its strip's pin boundary and persist. Shared by `pinTab` and
+ * `unpinTab`: both send the tab to the SAME index, so this reads the flag that
+ * was just written rather than being told which way it went.
+ */
+function reseatAtPinBoundary(
+  set: (partial: Partial<AppState>) => void,
+  get: () => AppState,
+  taskId: string,
+  tabId: string,
+) {
+  const s = get();
+  const list = s.tabs[taskId] ?? [];
+  const tab = list.find(t => t.id === tabId);
+  if (!tab) return;
+  const paneId = (tab as TerminalTab).paneId;
+  if (paneId) {
+    const tree = s.splitTree[taskId];
+    if (!tree) return;
+    const leaf = findLeaf(tree, paneId);
+    if (!leaf) return;
+    const strip = leaf.tabIds.map(id => list.find(t => t.id === id)).filter(Boolean) as Tab[];
+    const without = leaf.tabIds.filter(id => id !== tabId);
+    without.splice(pinBoundary(strip, tabId), 0, tabId);
+    set({ splitTree: { ...s.splitTree, [taskId]: setLeafTabs(tree, paneId, without) } });
+    get().saveSplitLayout(taskId);
+  } else {
+    // reorderTab indexes into the FULL per-task array, which interleaves
+    // split-pane tabs — so anchor on the main tab that must follow this one
+    // (the same mapping useTabStripDrag does).
+    const main = list.filter(t => !(t as TerminalTab).paneId);
+    const mainWithout = main.filter(t => t.id !== tabId);
+    const anchor = mainWithout[pinBoundary(main, tabId)];
+    const fullWithout = list.filter(t => t.id !== tabId);
+    get().reorderTab(taskId, tabId, anchor
+      ? fullWithout.findIndex(t => t.id === anchor.id)
+      : fullWithout.length);
+  }
+  // reorderTab bails when the order is already right (a tab pinned while it
+  // sits at the boundary), but the flag itself still has to reach disk.
+  get().syncDurableTabs(taskId);
+}
+
+/** `reseatAtPinBoundary` for the bottom scratch shells (own array, no disk). */
+function reseatBottomAtPinBoundary(
+  set: (partial: Partial<AppState>) => void,
+  get: () => AppState,
+  taskId: string,
+  tabId: string,
+) {
+  const list = get().bottomTabs[taskId] ?? [];
+  const tab = list.find(t => t.id === tabId);
+  if (!tab) return;
+  const next = list.filter(t => t.id !== tabId);
+  next.splice(pinBoundary(list, tabId), 0, tab);
+  set({ bottomTabs: { ...get().bottomTabs, [taskId]: next } });
+}
 
 /**
  * True when the user can actually SEE this tab, and therefore does not need a
@@ -927,6 +995,24 @@ export const useApp = create<AppState>((set, get) => ({
   setActiveBottomTab: (taskId, tabId) => set(s => ({
     activeBottomTab: { ...s.activeBottomTab, [taskId]: tabId },
   })),
+  pinBottomTab: (taskId, tabId) => {
+    set(s => ({
+      bottomTabs: {
+        ...s.bottomTabs,
+        [taskId]: (s.bottomTabs[taskId] ?? []).map(t => t.id === tabId ? { ...t, pinned: true } : t),
+      },
+    }));
+    reseatBottomAtPinBoundary(set, get, taskId, tabId);
+  },
+  unpinBottomTab: (taskId, tabId) => {
+    set(s => ({
+      bottomTabs: {
+        ...s.bottomTabs,
+        [taskId]: (s.bottomTabs[taskId] ?? []).map(t => t.id === tabId ? { ...t, pinned: false } : t),
+      },
+    }));
+    reseatBottomAtPinBoundary(set, get, taskId, tabId);
+  },
   setBottomTabLiveTitle: (taskId, tabId, liveTitle) => set(s => {
     const list = s.bottomTabs[taskId];
     if (!list) return s;
@@ -1442,6 +1528,7 @@ export const useApp = create<AppState>((set, get) => ({
         ...(pt.session_id ? { sessionId: pt.session_id } : {}),
         ...(pt.previous_session_id ? { previousSessionId: pt.previous_session_id } : {}),
         ...(unattendedRestore && pt.is_default ? { unattended: true } : {}),
+        ...(pt.pinned ? { pinned: true } : {}),
         // idle: restored run tabs keep their spot but never auto-fire the
         // script — the user presses play (RunPane placeholder / pill).
         ...(pt.run_member != null ? { runTab: { member: pt.run_member, previewUrl: null, idle: true } } : {}),
@@ -1484,6 +1571,7 @@ export const useApp = create<AppState>((set, get) => ({
                 : agentDisplayName(pt.cli, s.agents),
               customTitle: !!pt.custom_title,
               paneId: pt.pane_leaf_id!,
+              ...(pt.pinned ? { pinned: true } : {}),
               ...(pt.command ? { command: pt.command } : {}),
               ...(pt.session_id ? { sessionId: pt.session_id } : {}),
               ...(pt.previous_session_id ? { previousSessionId: pt.previous_session_id } : {}),
@@ -1758,6 +1846,16 @@ export const useApp = create<AppState>((set, get) => ({
     });
     // Persist the new order so restore preserves it.
     if (changed) get().syncDurableTabs(taskId);
+  },
+
+  pinTab: (taskId, tabId) => {
+    get().patchTab(taskId, tabId, { pinned: true });
+    reseatAtPinBoundary(set, get, taskId, tabId);
+  },
+
+  unpinTab: (taskId, tabId) => {
+    get().patchTab(taskId, tabId, { pinned: false });
+    reseatAtPinBoundary(set, get, taskId, tabId);
   },
 
   closeTab: (taskId, tabId) => {


### PR DESCRIPTION
Closes #183.

Adds the three core tab actions from the issue discussion: **Pin / Unpin**, **Close others**, **Close to the right**. The optional split actions (Split Right / Split Down / Move to Split) are out of scope here.

## From Author

I decided to go with a smaller change for now - only add the core pin/close actions without the split pane ops - to simplify the solution. Not sure I'll have enough time to test the "optional" part of that initial ticket.

There are now two "areas" for tabs - pinned section and "free" (scrollable) one.

**This is draft** - testing shows that having the "as small as possible" pinned tab makes the sizing jump all the time (when some process changes the tab title continuously). Will try to make it so that all tabs have the equal width, disregarding the "area" they are in.

<img width="1311" height="566" alt="image" src="https://github.com/user-attachments/assets/92371fdb-1566-411c-8024-5db5063e08ac" />


## What you get

Right-click any tab pill:

```
Pin                     (or Unpin)
────────────────────────
Close
Close others            disabled when there is nothing to close
Close to the right      disabled when there is nothing to close
```

All three strips have it: the main `TabBar`, a split pane's `PaneHeader`, and the bottom scratch shells.

## Pin behaviour

**Pinning is an ordering operation, not just a flag.** Chrome semantics: the strip carries a pinned block on the left, pin appends to the end of it, unpin drops the tab into the first slot after it. Both land on the same index, so one flag-free helper does the move.

```
                pinned block │ rest
start:   [ Claude 📌 ][ Gemini 📌 ]│[ shell ][ Codex ][ diff ]

pin Codex:      [ Claude 📌 ][ Gemini 📌 ][ Codex 📌 ]│[ shell ][ diff ]
unpin Gemini:   [ Claude 📌 ]│[ Gemini ][ shell ][ Codex ][ diff ]
```

**The pinned block lives outside the strip's scroller.** This is the actual point of the issue — reordering a tab to the head does nothing for you once the strip overflows and scrolls it away. The block is capped at 55% width with its own scroll, so pinning a pile of tabs cannot eat the bar and strand the `+` button.

**Drag-to-reorder clamps to the pin boundary,** so a drag cannot put an unpinned tab above a pinned one or vice versa.

**A pinned pill has no close ×.** It shows a pin there instead, which unpins on click. Closing a secondary agent tab is destructive (the session is forgotten for good, see `closeTab.ts`), and `confirmBeforeCloseAgentTab` has a "Don't ask again" checkbox, so leaving the × would put a one-click PTY kill on the tab the user explicitly marked as important. ⌘W and the menu's Close still close it, so nobody gets trapped. Chrome, Firefox and VS Code all drop the affordance on pinned tabs for the same reason.

**The pin persists.** `PersistedTab` carries it with a serde default, so old task files load unchanged and a pinned agent tab comes back pinned and leftmost.

## Bulk closes

Both bulk actions skip pinned tabs and the clicked tab. They ask **once** for the whole set rather than stacking one modal per tab:

> **Close 4 tabs?**
> termic discards the unsaved changes in 1 file. termic ends 2 agent sessions.

The dialog is skipped entirely when there is nothing to lose (plain shells, already-exited terminals) or when the user has turned agent-close confirms off. Neither action can empty a pane, since the clicked tab always survives.

## Notable implementation points

- `src/lib/tabActions.ts` — `pinBoundary` / `closableSiblings`, typed on the smallest shape (`{ id, pinned? }`) all three strips share.
- `src/components/task/TabContextMenu.tsx` — wraps each pill via `ContextMenuTrigger className="contents"`. `TabPill` forwards no ref and spreads no unknown props, so Radix's `asChild` would drop them; this is the same escape hatch `Sidebar.tsx` already uses.
- `stripRef` / `data-main-strip` stay on the shared outer container after the pinned/scrolling split, so drag-to-reorder and cross-pane drop hit-testing are untouched: `querySelectorAll("[data-tab-id]")` still returns pinned-then-loose, matching store order.
- A pinned pill sizes to content rather than the main strip's one-third flex basis, because the fixed region is shrink-to-fit and a percentage basis has nothing definite to resolve against.
- `task_set_tabs`'s idempotence check gained `a.pinned == b.pinned` — without it the equality bail would silently swallow a pin-only change.

## Testing

| Gate | Result |
|---|---|
| `make e2e` | 11/11 spec files, 0 failures |
| `npm test` | 738 passed |
| `cargo test` | 393 passed |
| `npm run build` | clean |

8 new cases in `e2e/specs/tabs-layout.e2e.ts` cover pin ordering, unpin, the missing ×, both bulk closes sparing pinned tabs, the disabled states, and that a pinned tab survives the strip being scrolled to its end. Unit tests cover the ordering helpers, the store actions (including split-pane leaves and persistence) and the serde round trip.

The scroll case sizes its tab flood from the measured strip width and asserts the strip really overflows before it asserts anything else, so it cannot pass vacuously. I also confirmed it fails when the pinned region is removed.

## Notes for review

- **Bottom scratch shells get a session-only pin.** They have no persistence at all today, so unlike agent tabs their pin does not survive a relaunch. Deliberate, but it is an inconsistency worth a look.
- No `CHANGELOG.md` entry, per the maintainer-only release rule in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GoZH3bGG7R5xnm5BmKbhB
