### PR TITLE
enhance(settings): Migrate `fs::write` to write-then-rename method for settings, projects, and tasks JSON files (GH #195)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -766,16 +766,29 @@ fn project_tasks_root(default_path: &str, p: &Project) -> Result<PathBuf, String
     Ok(root)
 }
 
-/// Crash-safe replacement of a file: write a sibling temp file, fsync it, then
+/// Crash-safe replacement of a file: write a sibling temp file, sync it, then
 /// atomically `rename()` it over the destination, so a reader never sees a
-/// partial file. Durability is deliberately plain `fsync(2)`, not `F_FULLFSYNC`:
-/// a hard power cut can lose the last write but never the previous intact file,
-/// and per-toggle `F_FULLFSYNC` stalls aren't worth more.
-fn write_atomic(dest: &Path, bytes: &[u8]) -> std::io::Result<()> {
+/// partial file. Durability is `sync_data` (`F_BARRIERFSYNC` on macOS), NOT
+/// `sync_all`, which is the full-device-flush `F_FULLFSYNC` there (measured
+/// ~2.6ms vs ~0.09ms) and would stall the synchronous command path: a hard
+/// power cut can lose the last write but never the previous intact file.
+pub(crate) fn write_atomic(dest: &Path, bytes: &[u8]) -> std::io::Result<()> {
     static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     // Resolve symlinks: rename would replace the link itself with a regular
-    // file; we must write through to its target.
-    let resolved = fs::canonicalize(dest).unwrap_or_else(|_| dest.to_path_buf());
+    // file; we must write through to its target. canonicalize fails on a
+    // DANGLING link (dotfiles target not created yet), so follow links by
+    // hand in that case rather than clobbering the link.
+    let resolved = fs::canonicalize(dest).unwrap_or_else(|_| {
+        let mut cur = dest.to_path_buf();
+        for _ in 0..8 {
+            match fs::read_link(&cur) {
+                Ok(t) if t.is_absolute() => cur = t,
+                Ok(t) => cur = cur.parent().unwrap_or_else(|| Path::new(".")).join(t),
+                Err(_) => break,
+            }
+        }
+        cur
+    });
     let dest = resolved.as_path();
     let dir = dest.parent().unwrap_or_else(|| Path::new("."));
     let stem = dest.file_name().and_then(|n| n.to_str()).unwrap_or("out");
@@ -787,13 +800,16 @@ fn write_atomic(dest: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let write = || -> std::io::Result<()> {
         let mut f = fs::File::create(&tmp)?;
         // A fresh temp inode gets default perms; carry the old mode so a
-        // tightened (e.g. chmod 600) file stays tightened.
+        // tightened (e.g. chmod 600) file stays tightened. Log, don't fail:
+        // some mounts (FUSE/SMB) reject chmod but the write itself is fine.
         if let Ok(meta) = fs::metadata(dest) {
-            let _ = f.set_permissions(meta.permissions());
+            if let Err(e) = f.set_permissions(meta.permissions()) {
+                eprintln!("[write_atomic] could not carry mode onto {}: {e}", dest.display());
+            }
         }
         f.write_all(bytes)?;
-        // Bytes must be durable before the rename is visible.
-        f.sync_all()?;
+        // Bytes must be ordered before the rename is visible.
+        f.sync_data()?;
         drop(f);
         fs::rename(&tmp, dest)
     };
@@ -1151,7 +1167,8 @@ fn ensure_git_excluded(repo: &Path, name: &str) {
     }
     body.push_str(name);
     body.push('\n');
-    let _ = fs::write(&exclude, body);
+    // Atomic: a torn rewrite here would eat the user's own exclude entries.
+    let _ = write_atomic(&exclude, body.as_bytes());
 }
 
 /// Write `schema_version = TASKS_SCHEMA_VERSION` into settings.json directly
@@ -4202,7 +4219,8 @@ fn ensure_multirepo_gitignore(wrapper: &Path, member_dirs: &[String]) -> std::io
         next.push('\n');
     }
     next.push_str(END); next.push('\n');
-    fs::write(&path, next)
+    // Atomic: the file carries the user's own rules outside the managed block.
+    write_atomic(&path, next.as_bytes())
 }
 
 /// Persist the sidebar order of ONE project's tasks. `ids` is that
@@ -7093,7 +7111,9 @@ fn task_file_write(id: String, path: String, content: String) -> Result<(), Stri
     let w = load_tasks().into_iter().find(|w| w.id == id).ok_or("no task")?;
     let (cwd, rel) = resolve_task_git_path(&w, &path)?;
     let abs = safe_task_path(&cwd, &rel)?;
-    fs::write(&abs, content).map_err(|e| format!("write failed: {e}"))
+    // Atomic: uncommitted source is unrecoverable if a truncate-write tears.
+    // Tradeoff accepted: the swap installs a new inode (breaks hardlinks).
+    write_atomic(&abs, content.as_bytes()).map_err(|e| format!("write failed: {e}"))
 }
 
 /// Rename a file or directory in the task (file-tree context menu).
@@ -13803,6 +13823,21 @@ mod tests {
         assert!(fs::symlink_metadata(&link).unwrap().file_type().is_symlink(),
             "the link itself must survive");
         assert_eq!(fs::read_to_string(&target).unwrap(), "new", "target must receive the write");
+    }
+
+    // Dangling link (dotfiles target not created yet): canonicalize fails, so
+    // the manual read_link fallback must still write the target, not clobber
+    // the link with a regular file.
+    #[test]
+    fn write_atomic_creates_the_target_of_a_dangling_symlink() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("dotfiles-settings.json");
+        let link = dir.path().join("settings.json");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        write_atomic(&link, b"new").unwrap();
+        assert!(fs::symlink_metadata(&link).unwrap().file_type().is_symlink(),
+            "the link itself must survive");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new", "target must be created");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -768,10 +768,8 @@ fn project_tasks_root(default_path: &str, p: &Project) -> Result<PathBuf, String
 
 /// Crash-safe replacement of a file: write a sibling temp file, sync it, then
 /// atomically `rename()` it over the destination, so a reader never sees a
-/// partial file. Durability is `sync_data` (`F_BARRIERFSYNC` on macOS), NOT
-/// `sync_all`, which is the full-device-flush `F_FULLFSYNC` there (measured
-/// ~2.6ms vs ~0.09ms) and would stall the synchronous command path: a hard
-/// power cut can lose the last write but never the previous intact file.
+/// partial file. The parent dir is deliberately not fsynced: a hard power cut
+/// can lose the last write, but the file always reads as an intact version.
 pub(crate) fn write_atomic(dest: &Path, bytes: &[u8]) -> std::io::Result<()> {
     static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     // Resolve symlinks: rename would replace the link itself with a regular
@@ -808,7 +806,7 @@ pub(crate) fn write_atomic(dest: &Path, bytes: &[u8]) -> std::io::Result<()> {
             }
         }
         f.write_all(bytes)?;
-        // Bytes must be ordered before the rename is visible.
+        // Bytes must be durable before the rename is visible.
         f.sync_data()?;
         drop(f);
         fs::rename(&tmp, dest)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -766,6 +766,44 @@ fn project_tasks_root(default_path: &str, p: &Project) -> Result<PathBuf, String
     Ok(root)
 }
 
+/// Crash-safe replacement of a file: write a sibling temp file, fsync it, then
+/// atomically `rename()` it over the destination, so a reader never sees a
+/// partial file. Durability is deliberately plain `fsync(2)`, not `F_FULLFSYNC`:
+/// a hard power cut can lose the last write but never the previous intact file,
+/// and per-toggle `F_FULLFSYNC` stalls aren't worth more.
+fn write_atomic(dest: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    // Resolve symlinks: rename would replace the link itself with a regular
+    // file; we must write through to its target.
+    let resolved = fs::canonicalize(dest).unwrap_or_else(|_| dest.to_path_buf());
+    let dest = resolved.as_path();
+    let dir = dest.parent().unwrap_or_else(|| Path::new("."));
+    let stem = dest.file_name().and_then(|n| n.to_str()).unwrap_or("out");
+    let tmp = dir.join(format!(
+        ".{stem}.tmp.{}.{}",
+        std::process::id(),
+        SEQ.fetch_add(1, Ordering::Relaxed),
+    ));
+    let write = || -> std::io::Result<()> {
+        let mut f = fs::File::create(&tmp)?;
+        // A fresh temp inode gets default perms; carry the old mode so a
+        // tightened (e.g. chmod 600) file stays tightened.
+        if let Ok(meta) = fs::metadata(dest) {
+            let _ = f.set_permissions(meta.permissions());
+        }
+        f.write_all(bytes)?;
+        // Bytes must be durable before the rename is visible.
+        f.sync_all()?;
+        drop(f);
+        fs::rename(&tmp, dest)
+    };
+    let res = write();
+    if res.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    res
+}
+
 // ───────────────────────────── projects IO ─────────────────────────────
 
 fn load_projects() -> Vec<Project> {
@@ -934,7 +972,8 @@ fn normalize_member(mut m: ProjectMember) -> Result<ProjectMember, String> {
     Ok(m)
 }
 fn save_projects(list: &[Project]) -> Result<()> {
-    fs::write(projects_file()?, serde_json::to_string_pretty(list)?)?;
+    let json = serde_json::to_string_pretty(list)?;
+    write_atomic(&projects_file()?, json.as_bytes())?;
     Ok(())
 }
 
@@ -946,7 +985,10 @@ fn load_tasks() -> Vec<Task> {
     let mut out = Vec::new();
     if let Ok(rd) = fs::read_dir(&dir) {
         for entry in rd.flatten() {
-            if let Ok(s) = fs::read_to_string(entry.path()) {
+            let path = entry.path();
+            // Only real task records: skip write_atomic staging files, .DS_Store, etc.
+            if path.extension().and_then(|e| e.to_str()) != Some("json") { continue; }
+            if let Ok(s) = fs::read_to_string(&path) {
                 if let Ok(w) = serde_json::from_str::<Task>(&s) {
                     out.push(w);
                 }
@@ -971,7 +1013,8 @@ fn sort_tasks(list: &mut [Task]) {
 }
 fn save_task(w: &Task) -> Result<()> {
     let f = tasks_dir()?.join(format!("{}.json", w.id));
-    fs::write(&f, serde_json::to_string_pretty(w)?)?;
+    let json = serde_json::to_string_pretty(w)?;
+    write_atomic(&f, json.as_bytes())?;
     Ok(())
 }
 fn delete_task_file(id: &str) -> Result<()> {
@@ -1117,11 +1160,7 @@ fn ensure_git_excluded(repo: &Path, name: &str) {
 fn stamp_schema_version() {
     let mut s = settings_load();
     s.schema_version = TASKS_SCHEMA_VERSION;
-    if let Ok(f) = settings_file() {
-        if let Ok(txt) = serde_json::to_string_pretty(&s) {
-            let _ = fs::write(f, txt);
-        }
-    }
+    let _ = save_settings_inner(&s);
 }
 
 /// One-time flip of `cli_enabled` to true for profiles that predate the CLI
@@ -4647,9 +4686,7 @@ fn agent_sandbox_add_allowed_path(agent_id: String, path: String) -> Result<(), 
     if !a.sandbox_allowed_paths.iter().any(|p| p == &stored) {
         a.sandbox_allowed_paths.push(stored);
     }
-    let f = settings_file().map_err(|e| e.to_string())?;
-    fs::write(f, serde_json::to_string_pretty(&s).map_err(|e| e.to_string())?).map_err(|e| e.to_string())?;
-    Ok(())
+    save_settings_inner(&s)
 }
 
 #[tauri::command]
@@ -4661,9 +4698,7 @@ fn agent_sandbox_add_allowed_host(agent_id: String, host: String) -> Result<(), 
     if !a.sandbox_allowed_hosts.iter().any(|h| h == &host) {
         a.sandbox_allowed_hosts.push(host);
     }
-    let f = settings_file().map_err(|e| e.to_string())?;
-    fs::write(f, serde_json::to_string_pretty(&s).map_err(|e| e.to_string())?).map_err(|e| e.to_string())?;
-    Ok(())
+    save_settings_inner(&s)
 }
 
 /// Append a host to the task's `sandbox_allowed_hosts` list and
@@ -9977,11 +10012,7 @@ pub(crate) fn load_settings_inner() -> Settings {
     // a read-only filesystem or transient I/O error shouldn't fail the
     // load (in-memory state is still correct).
     if migrated {
-        if let Ok(f) = settings_file() {
-            if let Ok(serialized) = serde_json::to_string_pretty(&s) {
-                let _ = fs::write(f, serialized);
-            }
-        }
+        let _ = save_settings_inner(&s);
     }
     s
 }
@@ -10037,8 +10068,8 @@ fn settings_save(app: AppHandle, s: Settings) -> Result<(), String> {
 /// Settings UI does, instead of growing a second encoder that could drift.
 pub(crate) fn save_settings_inner(s: &Settings) -> Result<(), String> {
     let f = settings_file().map_err(|e| e.to_string())?;
-    fs::write(f, serde_json::to_string_pretty(s).map_err(|e| e.to_string())?)
-        .map_err(|e| e.to_string())
+    let json = serde_json::to_string_pretty(s).map_err(|e| e.to_string())?;
+    write_atomic(&f, json.as_bytes()).map_err(|e| e.to_string())
 }
 
 /// Hide (`dismissed = true`) or restore (`false`) a discovered repo from the
@@ -10075,9 +10106,7 @@ fn agents_save(agents: Vec<Agent>) -> Result<(), String> {
     // lookups). If duplicates, keep the first occurrence.
     let mut seen = std::collections::HashSet::new();
     s.agents = agents.into_iter().filter(|a| seen.insert(a.id.clone())).collect();
-    let f = settings_file().map_err(|e| e.to_string())?;
-    fs::write(f, serde_json::to_string_pretty(&s).map_err(|e| e.to_string())?)
-        .map_err(|e| e.to_string())
+    save_settings_inner(&s)
 }
 
 // ───────────────────────────── custom themes ─────────────────────────────
@@ -13687,5 +13716,111 @@ mod tests {
                        "created":"2026-01-01T00:00:00Z","archived":false}"#;
         let t: Task = serde_json::from_str(json).expect("legacy task file still parses");
         assert_eq!(t.order, None);
+    }
+
+    // ── write_atomic (the settings.json / projects.json / task writer) ──
+
+    #[test]
+    fn write_atomic_replaces_the_whole_file_with_no_stale_tail() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("settings.json");
+        write_atomic(&f, b"{\"a\":1,\"padding\":\"xxxxxxxxxxxxxxxxxxxx\"}").unwrap();
+        // A shorter payload over a longer one: proof it's a replace, not an
+        // in-place overwrite that could leave the old bytes past the new end.
+        write_atomic(&f, b"{\"a\":2}").unwrap();
+        assert_eq!(fs::read_to_string(&f).unwrap(), "{\"a\":2}");
+    }
+
+    #[test]
+    fn write_atomic_leaves_no_temp_files_behind() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("settings.json");
+        write_atomic(&f, b"one").unwrap();
+        write_atomic(&f, b"two").unwrap();
+        let names: Vec<String> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, ["settings.json"], "staging files must be renamed away, not accumulate");
+    }
+
+    #[test]
+    fn write_atomic_never_exposes_a_partial_file_to_a_concurrent_reader() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("settings.json");
+        let small = "s".repeat(64);
+        let big = "b".repeat(256 * 1024);
+        write_atomic(&f, small.as_bytes()).unwrap();
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let reader = {
+            let (f, stop) = (f.clone(), stop.clone());
+            thread::spawn(move || {
+                let mut seen_partial = None;
+                while !stop.load(Ordering::Relaxed) {
+                    let got = fs::read_to_string(&f).expect("path is never absent mid-write");
+                    if !got.chars().all(|c| c == 's') && !got.chars().all(|c| c == 'b') {
+                        seen_partial = Some(got.len());
+                        break;
+                    }
+                    if got.len() != 64 && got.len() != 256 * 1024 {
+                        seen_partial = Some(got.len());
+                        break;
+                    }
+                }
+                seen_partial
+            })
+        };
+        for i in 0..40 {
+            let body = if i % 2 == 0 { &big } else { &small };
+            write_atomic(&f, body.as_bytes()).unwrap();
+        }
+        stop.store(true, Ordering::Relaxed);
+        assert_eq!(reader.join().unwrap(), None, "reader saw a torn file");
+    }
+
+    #[test]
+    fn write_atomic_preserves_the_destination_file_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("settings.json");
+        fs::write(&f, b"old").unwrap();
+        fs::set_permissions(&f, fs::Permissions::from_mode(0o600)).unwrap();
+        write_atomic(&f, b"new").unwrap();
+        let mode = fs::metadata(&f).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "atomic swap must not relax a tightened file");
+        assert_eq!(fs::read_to_string(&f).unwrap(), "new");
+    }
+
+    #[test]
+    fn write_atomic_writes_through_a_symlinked_destination() {
+        let dir = tempdir().unwrap();
+        let target = dir.path().join("dotfiles-settings.json");
+        let link = dir.path().join("settings.json");
+        fs::write(&target, b"old").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        write_atomic(&link, b"new").unwrap();
+        assert!(fs::symlink_metadata(&link).unwrap().file_type().is_symlink(),
+            "the link itself must survive");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new", "target must receive the write");
+    }
+
+    #[test]
+    fn write_atomic_keeps_the_old_file_and_cleans_up_when_the_write_fails() {
+        let dir = tempdir().unwrap();
+        let f = dir.path().join("settings.json");
+        write_atomic(&f, b"good").unwrap();
+        // A directory at the destination makes the rename fail after the temp
+        // file is already written.
+        let blocked = dir.path().join("blocked.json");
+        fs::create_dir(&blocked).unwrap();
+        assert!(write_atomic(&blocked, b"nope").is_err());
+        assert_eq!(fs::read_to_string(&f).unwrap(), "good", "unrelated file untouched");
+        let strays: Vec<String> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|n| n.contains(".tmp."))
+            .collect();
+        assert!(strays.is_empty(), "failed write left staging files: {strays:?}");
     }
 }

--- a/src-tauri/src/repo_config.rs
+++ b/src-tauri/src/repo_config.rs
@@ -131,7 +131,7 @@ pub fn save(repo_root: &Path, cfg: &RepoConfig) -> Result<()> {
     let raw = serde_yml::to_string(&cfg).context("serialize .termic.yaml")?;
     let text = indent_block_sequences(&raw);
     let path = repo_root.join(FILE_NAME);
-    std::fs::write(&path, text).with_context(|| format!("write {}", path.display()))?;
+    crate::write_atomic(&path, text.as_bytes()).with_context(|| format!("write {}", path.display()))?;
     Ok(())
 }
 


### PR DESCRIPTION
Related to #195 

## Problems

All persisted app state (`settings.json`, `projects.json`, task metadata, editor saves) was written with plain `fs::write`. A crash, or mid-write interrupt leaves a corrupted file.

## Changes

- New `write_atomic` helper to writes a temp file, syncs it, then atomically `rename()`s over the destination
- Migrated all risky writers to it: `settings.json` (every path now funnels through `save_settings_inner`, removing four hand-rolled duplicates), `projects.json`, per-task `<id>.json`, `.termic.yaml`, editor saves (`task_file_write`), and the managed `.gitignore` / `.git/info/exclude` rewriters.
- `load_tasks` now skips non-`.json` files so a staging file can never be listed as a duplicate task.

## Implementation

- Uses `sync_data` so synchronous command paths don't stall.
- Writes through symlinks instead of replacing the link with a regular file
- Some `fs::write` on fresh file, low-risk write are left for now:
  - Migration staging writes (protected by its own backup + staging scheme)
  - CLAUDE.md stubs on project create (brand-new files, nothing to lose)
  - Theme dir seeding (one-shot, best-effort)
  - Sandbox filter + profile files (temp-dir scratch, regenerated every launch)

## Tests

7 new unit tests. Full `cargo test` green (398 passed).