### PR TITLE
feat(palette): the 95 commits of features it never learned, plus Recent

### DIFF
--- a/e2e/specs/app.e2e.ts
+++ b/e2e/specs/app.e2e.ts
@@ -136,6 +136,106 @@ describe("command palette", () => {
     });
     await snap("command-palette.png");
   });
+
+  // The reopen case: run something, come back, and it is the first row. The
+  // section is only meant to appear on an EMPTY query — while searching you
+  // want the best match, not a pinned row pushing it down.
+  const sectionLabels = () =>
+    browser.execute(() =>
+      [...document.querySelectorAll("[data-row]")]
+        .map(r => r.parentElement?.querySelector("div")?.textContent ?? "")
+        .filter(Boolean),
+    ) as Promise<string[]>;
+
+  const firstRowText = () =>
+    browser.execute(() =>
+      (document.querySelector('[data-row="0"]') as HTMLElement | null)?.innerText ?? "",
+    ) as unknown as Promise<string>;
+
+  it("puts the command you just ran in a Recent section on top", async () => {
+    // Self-contained: run a command through the palette HERE rather than
+    // leaning on an earlier case. The File-picker case defers its effect
+    // through requestAnimationFrame, which is frozen while this window is
+    // occluded and then fires late, reopening a dialog mid-assertion.
+    // Recording happens synchronously in runCmd, so a row whose deferred
+    // effect never lands still records — which is all this needs.
+    await browser.execute(() => {
+      const ui = window.__termic!.useUI.getState();
+      ui.closeFileFinder?.(); ui.closeShortcutsHelp?.();
+      localStorage.removeItem("commandPaletteRecent");
+    });
+    await open();
+    await waitVisible('input[placeholder*="Type a command"]', 8_000);
+    await browser.execute(() => {
+      const btn = [...document.querySelectorAll("[data-row]")].find(r =>
+        (r as HTMLElement).innerText.includes("Keyboard shortcuts"));
+      if (!btn) throw new Error("Keyboard shortcuts row not found");
+      (btn as HTMLElement).click();
+    });
+    await browser.waitUntil(async () => (await paletteOpen()) === false, {
+      timeout: 5_000, timeoutMsg: "the command did not close the palette",
+    });
+
+    await browser.execute(() => window.__termic!.useUI.getState().closeShortcutsHelp?.());
+    await open();
+    await waitVisible('input[placeholder*="Type a command"]', 8_000);
+
+    await browser.waitUntil(async () => (await firstRowText()).includes("Keyboard shortcuts"), {
+      timeout: 5_000,
+      timeoutMsg: "the just-run command was not the first row on reopen",
+    });
+    // The first row sits under the Recent header, not under Task/View.
+    expect((await sectionLabels())[0]).toContain("Recent");
+    // Lifted out of its home section rather than duplicated — the same command
+    // twice makes the arrow keys feel broken.
+    // Exact-ish match: "Keyboard shortcuts settings" is a DIFFERENT command
+    // (the Settings deep link), so a bare substring count sees two rows and
+    // reads as a dedupe failure when nothing is wrong.
+    const dupes = await browser.execute(() =>
+      [...document.querySelectorAll("[data-row]")]
+        .map(r => (r as HTMLElement).innerText)
+        .filter(t => t.includes("Keyboard shortcuts") && !t.includes("settings")).length);
+    expect(dupes).toBe(1);
+  });
+
+  it("hides Recent as soon as you type", async () => {
+    await setQuery("settings");
+    await browser.waitUntil(
+      async () => !(await sectionLabels()).some(l => l.startsWith("Recent")),
+      { timeout: 5_000, timeoutMsg: "Recent survived a query" },
+    );
+    await setQuery("");
+    await browser.waitUntil(
+      async () => (await sectionLabels()).some(l => l.startsWith("Recent")),
+      { timeout: 5_000, timeoutMsg: "Recent did not come back on an empty query" },
+    );
+  });
+
+  it("forgets a recent command after an hour", async () => {
+    // Age the stored entry past the TTL rather than waiting an hour. The expiry
+    // rule itself is unit-tested against an injected clock
+    // (lib/paletteRecent.test.ts); this only proves the palette consults it.
+    await browser.execute(() => {
+      const raw = localStorage.getItem("commandPaletteRecent");
+      if (!raw) throw new Error("no recents were recorded");
+      const aged = JSON.parse(raw).map((e: { id: string; at: number }) => ({
+        ...e, at: e.at - 61 * 60 * 1000,
+      }));
+      localStorage.setItem("commandPaletteRecent", JSON.stringify(aged));
+    });
+    // Reopen: recents are re-read per open, so the stale entry drops out.
+    await browser.execute(() => window.__termic!.useUI.getState().closeCommandPalette());
+    await open();
+    await waitVisible('input[placeholder*="Type a command"]', 8_000);
+    await browser.waitUntil(
+      async () => !(await sectionLabels()).some(l => l.startsWith("Recent")),
+      { timeout: 5_000, timeoutMsg: "an expired recent was still shown" },
+    );
+    await browser.execute(() => {
+      localStorage.removeItem("commandPaletteRecent");
+      window.__termic!.useUI.getState().closeCommandPalette();
+    });
+  });
 });
 
 // P2: assorted dialogs/palettes open + close. Guards the wiring of the

--- a/src/components/dialogs/CommandPalette.coverage.test.ts
+++ b/src/components/dialogs/CommandPalette.coverage.test.ts
@@ -1,0 +1,101 @@
+// The palette went 95 feature commits without gaining a row. Nothing failed,
+// because nothing was checking — a palette silently falls behind rather than
+// breaking. This is the check.
+//
+// Every global `open*` action on the UI store is either surfaced by the palette
+// or listed below with a reason. Adding a new dialog therefore forces a
+// decision at PR time instead of leaving a gap nobody notices for three months.
+//
+// Source-level rather than render-level on purpose: the rows are built from
+// live store state (a task, a project, a sandbox mode), so asserting on a
+// rendered list would mean constructing a plausible world and would only prove
+// the palette works in THAT world. The invariant here is about coverage, not
+// behaviour. Same pattern as cspGuard.test.ts reading tauri.conf.json.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = join(__dirname, "..", "..", "..");
+const uiSrc = readFileSync(join(root, "src", "store", "ui.ts"), "utf8");
+const paletteSrc = readFileSync(
+  join(root, "src", "components", "dialogs", "CommandPalette.tsx"), "utf8",
+);
+
+/** Deliberately absent, with the reason. Anything not here must be reachable. */
+const EXCLUDED: Record<string, string> = {
+  openCommandPalette: "the palette itself",
+  openPromptFire: "needs a specific Prompt object; reached from the prompt palette",
+  openRaceCompare: "needs a raceId; reached from the race board",
+  openEditCommand: "edits the run command of a specific tab; reached from its menu",
+  openCustomCommand: "a New-task variant; reached from the launcher menu",
+  openNewTask: "needs a projectId + seed; the palette routes via openProjectPicker",
+  openWelcome: "first-run onboarding, not a thing you go looking for",
+  openSandbox: "surfaced (task-scoped row)",
+  openFileFinder: "surfaced",
+  openFindInFiles: "surfaced",
+  openProjectPicker: "surfaced as New task",
+  openShortcutsHelp: "surfaced",
+  openChangelog: "surfaced",
+  openNewProject: "surfaced",
+  openPromptPalette: "surfaced",
+  openRace: "surfaced",
+  openBroadcast: "surfaced",
+  openProjectBroadcast: "surfaced",
+  openRunCommands: "surfaced",
+  openResumeOverride: "surfaced",
+};
+
+/** `open*` action names declared in the UI store's interface. */
+function uiOpenActions(): string[] {
+  const names = new Set<string>();
+  for (const m of uiSrc.matchAll(/^\s{2}(open[A-Z][A-Za-z]*): \(/gm)) names.add(m[1]);
+  return [...names].sort();
+}
+
+describe("command palette coverage", () => {
+  it("finds the UI store's open* actions at all", () => {
+    // Guards the regex itself: if the store's shape changes and this stops
+    // matching, every assertion below would pass vacuously.
+    expect(uiOpenActions().length).toBeGreaterThan(8);
+  });
+
+  it("surfaces every global open* action, or names why not", () => {
+    const missing = uiOpenActions().filter(
+      name => !paletteSrc.includes(`${name}(`) && !(name in EXCLUDED),
+    );
+    expect(missing,
+      `These UI-store actions are neither in the palette nor in EXCLUDED.\n`
+      + `Add a row, or add an entry to EXCLUDED saying why not:\n  ${missing.join("\n  ")}`,
+    ).toEqual([]);
+  });
+
+  it("keeps EXCLUDED honest", () => {
+    // An exclusion for an action that no longer exists is stale documentation
+    // that quietly weakens the check above.
+    const actions = new Set(uiOpenActions());
+    const stale = Object.keys(EXCLUDED).filter(n => !actions.has(n));
+    expect(stale, `EXCLUDED names actions that no longer exist: ${stale.join(", ")}`)
+      .toEqual([]);
+  });
+
+  it("never puts an irreversible command in Recent", () => {
+    // The top Recent row is pre-selected, so Enter on a freshly-opened palette
+    // fires it. Archive and Stop must therefore carry noRecent.
+    for (const id of ["archive-task", "stop-task"]) {
+      const at = paletteSrc.indexOf(`id: "${id}"`);
+      expect(at, `command ${id} not found`).toBeGreaterThan(-1);
+      const block = paletteSrc.slice(at, at + 600);
+      expect(block, `${id} must set noRecent`).toContain("noRecent: true");
+    }
+  });
+
+  it("does not offer the focus-dependent terminal commands", () => {
+    // new-tab / close-tab / clear-terminal each read document.activeElement to
+    // decide WHICH pane they act on. From the palette that is the palette's own
+    // input, so a row would act on the wrong thing or do nothing at all.
+    for (const sc of ["new-tab", "close-tab", "clear-terminal"]) {
+      expect(paletteSrc).not.toContain(`shortcutId: "${sc}"`);
+    }
+  });
+});

--- a/src/components/dialogs/CommandPalette.tsx
+++ b/src/components/dialogs/CommandPalette.tsx
@@ -11,11 +11,14 @@ import {
   Search, Plus, FileText, Pencil, GitBranch, Archive, Zap, ShieldCheck,
   PanelLeft, PanelRight, PanelBottom, Palette, Keyboard, Settings as SettingsIcon,
   FolderCog, RefreshCw, ScrollText, Bug, SlidersHorizontal, Bot, BookText,
-  Check, ChevronLeft, ListTodo, Bell, SquareTerminal, type LucideIcon,
+  Check, ChevronLeft, ListTodo, Bell, SquareTerminal, FolderPlus, History, Square,
+  Play, Swords, Megaphone, Columns2, Rows2, Clock, type LucideIcon,
 } from "lucide-react";
 import { useUI } from "@/store/ui";
 import { copyToClipboard } from "@/lib/clipboard";
 import { useApp } from "@/store/app";
+import { jumpToNextWaiting } from "@/lib/waitingAgents";
+import { readRecents, recentIds, recordRecent } from "@/lib/paletteRecent";
 import { usePrefs, type BuiltinThemeMode, type ThemeMode } from "@/store/prefs";
 import { useUpdate } from "@/store/update";
 import { fuzzyMatch, Highlighted } from "@/lib/fuzzy";
@@ -33,6 +36,11 @@ const ISSUE_URL = "https://github.com/simion/termic/issues/new";
 const SECTION_ORDER = ["Task", "Agent", "View", "Application", "Settings"] as const;
 type Section = (typeof SECTION_ORDER)[number];
 
+/** Pseudo-section pinned above the rest, holding what you last ran (expiry and
+ *  ordering live in lib/paletteRecent). Not in SECTION_ORDER: it is built from
+ *  the other sections' commands rather than being a home for any of them. */
+const RECENT_SECTION = "Recent";
+
 interface Cmd {
   id: string;
   section: Section;
@@ -47,6 +55,13 @@ interface Cmd {
   /** Extra search terms (not shown) so e.g. "palette" finds "Command…". */
   keywords?: string;
   destructive?: boolean;
+  /** Keep this command OUT of the Recent section. The top Recent row is the
+   *  pre-selected one, so Enter on a freshly-opened palette runs it — which is
+   *  fine for "Open settings" and emphatically not for anything that ends an
+   *  agent or a task. Archiving twice in a row is not a workflow worth
+   *  optimising; doing it by accident is a real risk, more so once the user has
+   *  ticked "Don't ask again" on the archive confirm. */
+  noRecent?: boolean;
   run: () => void;
 }
 
@@ -161,6 +176,11 @@ export function CommandPalette() {
       icon: Plus, shortcutId: "new-task-quick", keywords: "create worktree project",
       run: act(() => useUI.getState().openProjectPicker()),
     });
+    cmds.push({
+      id: "new-project", section: "Task", label: "Add project…",
+      icon: FolderPlus, keywords: "repository repo clone discover add new",
+      run: act(() => useUI.getState().openNewProject()),
+    });
     if (task) {
       cmds.push({
         id: "file-picker", section: "Task", label: "File picker",
@@ -185,17 +205,71 @@ export function CommandPalette() {
         });
       }
       cmds.push({
+        id: "resume-override", section: "Task", label: "Resume options…",
+        icon: History, keywords: "session continue previous conversation args",
+        run: act(() => useUI.getState().openResumeOverride(task.id)),
+      });
+      cmds.push({
+        // Ends every PTY in the task but keeps the task itself (GH #119).
+        // Also the only way to release a mounted task's terminals, which is
+        // what the idle-cost work made concrete.
+        id: "stop-task", section: "Task", label: `Stop "${task.name}"`,
+        suffix: "Ends its agents, keeps the task",
+        icon: Square, keywords: "kill terminate close ptys unmount free memory",
+        noRecent: true,
+        run: act(() => useApp.getState().stopTask(task.id)),
+      });
+      cmds.push({
         // Not styled destructive — confirmAndArchive normally shows a confirm
         // modal (with the delete-branch checkbox), so the red isn't needed.
         // Once the user has ticked "Don't ask again" there, this entry archives
         // on Enter with no prompt; Settings › Tasks is the way back.
         id: "archive-task", section: "Task", label: `Archive "${task.name}"`,
         icon: Archive, keywords: "delete remove close worktree",
+        noRecent: true,
         run: act(() => { void confirmAndArchive(task); }),
+      });
+    }
+    if (proj) {
+      cmds.push({
+        id: "run-commands", section: "Task", label: "Run commands…",
+        suffix: proj.name, icon: Play, keywords: "script dev server build custom",
+        run: act(() => useUI.getState().openRunCommands(proj.id)),
       });
     }
 
     // ── Agent ──────────────────────────────────────────────────────────
+    cmds.push({
+      id: "prompt-palette", section: "Agent", label: "Prompt library…",
+      icon: BookText, shortcutId: "prompt-palette", keywords: "prompts snippets send template",
+      run: act(() => useUI.getState().openPromptPalette()),
+    });
+    cmds.push({
+      // Store-driven (lib/waitingAgents), shared with the top-bar jump pill —
+      // so it does the same thing from here as from the pill.
+      id: "jump-next-waiting", section: "Agent", label: "Jump to next waiting agent",
+      icon: Bell, shortcutId: "jump-next-waiting", keywords: "attention blocked done next cycle",
+      run: act(() => { jumpToNextWaiting(); }),
+    });
+    if (proj) {
+      cmds.push({
+        id: "race", section: "Agent", label: "Agent Race…",
+        suffix: proj.name, icon: Swords, keywords: "compare parallel multiple contest winner",
+        run: act(() => useUI.getState().openRace(proj.id)),
+      });
+      cmds.push({
+        id: "broadcast-project", section: "Agent", label: "Broadcast to project…",
+        suffix: proj.name, icon: Megaphone, keywords: "send all tasks message every agent",
+        run: act(() => useUI.getState().openProjectBroadcast(proj.id)),
+      });
+    }
+    if (task) {
+      cmds.push({
+        id: "broadcast", section: "Agent", label: "Broadcast to agents…",
+        icon: Megaphone, shortcutId: "broadcast", keywords: "send message all tabs",
+        run: act(() => useUI.getState().openBroadcast(task.id)),
+      });
+    }
     if (task) {
       const enforced = isSandboxEnforced(effectiveSandboxMode(task));
       cmds.push({
@@ -235,6 +309,21 @@ export function CommandPalette() {
         id: "toggle-terminal", section: "View", label: "Toggle terminal panel",
         icon: PanelBottom, shortcutId: "toggle-terminal", keywords: "bottom split shell console hide show",
         run: act(() => useApp.getState().toggleBottomTerminal(task.id)),
+      });
+      // splitPane targets the store's active pane, not DOM focus, so it means
+      // the same thing from here as from the chord. Its focus-dependent
+      // siblings (new-tab, close-tab, clear-terminal) are deliberately NOT
+      // here: each reads document.activeElement to decide WHICH pane it acts
+      // on, and from the palette that is the palette's own input.
+      cmds.push({
+        id: "split-right", section: "View", label: "Split pane right",
+        icon: Columns2, shortcutId: "split-pane-right", keywords: "pane vertical divider new",
+        run: act(() => { useApp.getState().splitPane(task.id, "v"); }),
+      });
+      cmds.push({
+        id: "split-down", section: "View", label: "Split pane down",
+        icon: Rows2, shortcutId: "split-pane-below", keywords: "pane horizontal divider new",
+        run: act(() => { useApp.getState().splitPane(task.id, "h"); }),
       });
     }
     cmds.push({
@@ -313,6 +402,17 @@ export function CommandPalette() {
     return cmds;
   }, [view, task, proj, themeMode, themeEntries]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Recents, re-read on every open so an hour spent with the palette closed
+  // expires them (the list is only ever consulted at build time). Empty query
+  // only: once you are searching, you want the best match, and a pinned
+  // section would push it down and duplicate rows.
+  const recents = useMemo(
+    () => (open && view === "root" && !query
+      ? recentIds(readRecents(), new Set(commands.map(c => c.id)))
+      : []),
+    [open, view, query, commands],
+  );
+
   // Filter + score against the query, preserving section order. Each command
   // matches on "<label> <keywords>"; only label-range hits are highlighted.
   const filtered = useMemo(() => {
@@ -333,16 +433,25 @@ export function CommandPalette() {
       arr.push(s);
       bySection.set(s.cmd.section, arr);
     }
-    const groups: Array<{ section: Section; items: Scored[] }> = [];
+    const groups: Array<{ section: string; items: Scored[] }> = [];
+    // Recent goes first and its members are LIFTED out of their home sections
+    // rather than duplicated — the same command twice in one list makes the
+    // arrow keys feel broken.
+    const recentSet = new Set(recents);
+    if (recentSet.size > 0) {
+      const byId = new Map(out.map(s => [s.cmd.id, s]));
+      const items = recents.map(id => byId.get(id)).filter(Boolean) as Scored[];
+      if (items.length > 0) groups.push({ section: RECENT_SECTION, items });
+    }
     for (const section of SECTION_ORDER) {
-      const items = bySection.get(section);
-      if (!items || items.length === 0) continue;
+      const items = (bySection.get(section) ?? []).filter(s => !recentSet.has(s.cmd.id));
+      if (items.length === 0) continue;
       if (query) items.sort((a, b) => b.score - a.score);
       groups.push({ section, items });
     }
     const rows: Scored[] = groups.flatMap(g => g.items);
     return { groups, rows };
-  }, [commands, query]);
+  }, [commands, query, recents]);
 
   const rows = filtered.rows;
 
@@ -373,7 +482,8 @@ export function CommandPalette() {
       setActiveIdx(i => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      rows[activeIdx]?.cmd.run();
+      const c = rows[activeIdx]?.cmd;
+      if (c) runCmd(c);
     } else if (e.key === "Escape") {
       e.preventDefault();
       if (view === "theme") cancelThemePreview(); else close();
@@ -385,6 +495,15 @@ export function CommandPalette() {
 
   // Resolve a command's shortcut glyphs (if it has a binding).
   const glyphsFor = (id?: ShortcutId) => (id && binds[id] ? bindingGlyphs(binds[id]) : null);
+
+  /** Every path that runs a command goes through here, so recording can't drift
+   *  from invocation. Theme submenu entries are not recorded: they are a live
+   *  preview you arrow through, and remembering the last one you happened to
+   *  land on is noise, not intent. */
+  const runCmd = (cmd: Cmd) => {
+    if (view === "root" && !cmd.noRecent) recordRecent(cmd.id);
+    cmd.run();
+  };
 
   let rowIdx = -1; // running index across sections for keyboard nav mapping
 
@@ -462,9 +581,20 @@ export function CommandPalette() {
               <div className="px-3 py-3 text-[13px] text-[var(--color-fg-faint)]">No matching commands</div>
             )}
             {filtered.groups.map(group => (
-              <div key={group.section}>
-                <div className="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wider text-[var(--color-fg-faint)]">
+              <div
+                key={group.section}
+                // Hairline under Recent so it reads as pinned above the real
+                // list rather than as just another section.
+                className={group.section === RECENT_SECTION
+                  ? "mb-1 border-b border-[var(--color-border-soft)] pb-1"
+                  : undefined}
+              >
+                <div className="flex items-center gap-1.5 px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wider text-[var(--color-fg-faint)]">
+                  {group.section === RECENT_SECTION && <Clock className="h-3 w-3" />}
                   {group.section}
+                  {group.section === RECENT_SECTION && (
+                    <span className="normal-case tracking-normal opacity-70">· what you just ran</span>
+                  )}
                 </div>
                 {group.items.map(({ cmd, labelMatches }) => {
                   rowIdx += 1;
@@ -475,7 +605,7 @@ export function CommandPalette() {
                     <button
                       key={cmd.id}
                       data-row={i}
-                      onClick={() => cmd.run()}
+                      onClick={() => runCmd(cmd)}
                       onMouseMove={() => setActiveIdx(i)}
                       // Subtle neutral highlight (Conductor-style) — a faint
                       // fg-tinted overlay, theme-aware, no accent/border.

--- a/src/lib/paletteRecent.test.ts
+++ b/src/lib/paletteRecent.test.ts
@@ -1,0 +1,118 @@
+// The expiry rule is the whole point of this module, so it is tested against an
+// injected clock. A test that slept for an hour would not be run, and one that
+// mocked Date.now globally would pin the behaviour to how the mock is wired
+// rather than to the rule.
+
+import { describe, expect, it } from "vitest";
+import {
+  RECENT_MAX,
+  RECENT_TTL_MS,
+  parseRecents,
+  recentIds,
+  withRecorded,
+  type RecentEntry,
+} from "./paletteRecent";
+
+const T0 = 1_700_000_000_000;
+const raw = (entries: RecentEntry[]) => JSON.stringify(entries);
+
+describe("withRecorded", () => {
+  it("puts the newest run first", () => {
+    let list: RecentEntry[] = [];
+    list = withRecorded(list, "a", T0);
+    list = withRecorded(list, "b", T0 + 1000);
+    expect(list.map(e => e.id)).toEqual(["b", "a"]);
+  });
+
+  it("moves a re-run command up instead of duplicating it", () => {
+    let list: RecentEntry[] = [];
+    list = withRecorded(list, "a", T0);
+    list = withRecorded(list, "b", T0 + 1000);
+    list = withRecorded(list, "a", T0 + 2000);
+    expect(list.map(e => e.id)).toEqual(["a", "b"]);
+    expect(list.filter(e => e.id === "a")).toHaveLength(1);
+  });
+
+  it("keeps at most RECENT_MAX", () => {
+    let list: RecentEntry[] = [];
+    for (let i = 0; i < RECENT_MAX + 4; i++) list = withRecorded(list, `c${i}`, T0 + i * 1000);
+    expect(list).toHaveLength(RECENT_MAX);
+    // The oldest fell off, the newest is on top.
+    expect(list[0].id).toBe(`c${RECENT_MAX + 3}`);
+  });
+
+  it("drops entries that expired while the palette was closed", () => {
+    let list = withRecorded([], "old", T0);
+    list = withRecorded(list, "fresh", T0 + RECENT_TTL_MS + 1);
+    expect(list.map(e => e.id)).toEqual(["fresh"]);
+  });
+});
+
+describe("parseRecents expiry", () => {
+  it("keeps an entry just under the hour", () => {
+    const r = parseRecents(raw([{ id: "a", at: T0 }]), T0 + RECENT_TTL_MS - 1);
+    expect(r.map(e => e.id)).toEqual(["a"]);
+  });
+
+  it("drops it exactly AT the hour", () => {
+    const r = parseRecents(raw([{ id: "a", at: T0 }]), T0 + RECENT_TTL_MS);
+    expect(r).toEqual([]);
+  });
+
+  it("drops an entry stamped in the future", () => {
+    // A clock change backwards would otherwise pin a row to the top for over
+    // an hour, since `now - at` stays negative.
+    const r = parseRecents(raw([{ id: "a", at: T0 + 5000 }]), T0);
+    expect(r).toEqual([]);
+  });
+
+  it("returns newest-first regardless of stored order", () => {
+    const r = parseRecents(
+      raw([{ id: "old", at: T0 }, { id: "new", at: T0 + 9000 }]),
+      T0 + 10_000,
+    );
+    expect(r.map(e => e.id)).toEqual(["new", "old"]);
+  });
+});
+
+describe("parseRecents robustness", () => {
+  it("survives absent, corrupt and wrong-shaped storage", () => {
+    // A broken recents list must never stop the palette from opening.
+    expect(parseRecents(null, T0)).toEqual([]);
+    expect(parseRecents("not json", T0)).toEqual([]);
+    expect(parseRecents('{"id":"a"}', T0)).toEqual([]);   // object, not array
+    expect(parseRecents("[1,2,3]", T0)).toEqual([]);
+    expect(parseRecents(raw([{ id: "", at: T0 }] as RecentEntry[]), T0)).toEqual([]);
+    expect(parseRecents('[{"id":"a"}]', T0)).toEqual([]); // no timestamp
+    expect(parseRecents('[{"at":123}]', T0)).toEqual([]); // no id
+    expect(parseRecents('[{"id":"a","at":"soon"}]', T0)).toEqual([]);
+  });
+
+  it("keeps the good entries in a partly-corrupt list", () => {
+    const r = parseRecents(
+      '[{"id":"a","at":' + T0 + '},{"bogus":true},{"id":"b","at":' + (T0 + 1) + "}]",
+      T0 + 2,
+    );
+    expect(r.map(e => e.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("recentIds", () => {
+  it("hides ids whose command is not currently available", () => {
+    // Task-scoped rows (Stop task, Copy branch) vanish when no task is active;
+    // a remembered id must not render a dead row.
+    const entries = [
+      { id: "stop-task", at: T0 + 2 },
+      { id: "settings", at: T0 + 1 },
+    ];
+    expect(recentIds(entries, new Set(["settings"]))).toEqual(["settings"]);
+  });
+
+  it("preserves newest-first order", () => {
+    const entries = [
+      { id: "b", at: T0 + 2 },
+      { id: "a", at: T0 + 1 },
+    ];
+    expect(recentIds(entries, new Set(["a", "b"]))).toEqual(["b", "a"]);
+  });
+});

--- a/src/lib/paletteRecent.ts
+++ b/src/lib/paletteRecent.ts
@@ -1,0 +1,85 @@
+// Recently-run commands for the ⇧⌘P palette.
+//
+// Kept OUT of the component (and out of the app store) so the expiry rule can
+// be unit-tested against an injected clock instead of a real one: "clears after
+// an hour" is untestable if the only clock is Date.now() inside a render.
+// localStorage-backed directly, same as the palette's sibling component-local
+// prefs (DiffPane's view mode) — nothing else reads it.
+//
+// The point is the reopen case: run a command, hit ⇧⌘P again a minute later,
+// and the thing you just did is the first row. An hour on, the palette is back
+// to its normal order rather than showing you what you were doing before lunch.
+
+const LS_KEY = "commandPaletteRecent";
+
+/** Entries older than this are dropped on the next read or write. */
+export const RECENT_TTL_MS = 60 * 60 * 1000;
+
+/** How many recents the section shows. Small on purpose: the section sits above
+ *  everything else and pushes the real list down, so it earns its height only
+ *  while it is short. */
+export const RECENT_MAX = 3;
+
+export interface RecentEntry {
+  id: string;
+  /** Epoch ms of the most recent run. */
+  at: number;
+}
+
+/** Parse + prune. Tolerates absent, corrupt, or hand-edited storage by
+ *  returning [] — a broken recents list must never stop the palette opening. */
+export function parseRecents(raw: string | null, now: number): RecentEntry[] {
+  if (!raw) return [];
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(data)) return [];
+  const out: RecentEntry[] = [];
+  for (const e of data) {
+    if (!e || typeof e !== "object") continue;
+    const { id, at } = e as Partial<RecentEntry>;
+    if (typeof id !== "string" || !id) continue;
+    if (typeof at !== "number" || !Number.isFinite(at)) continue;
+    // Expired, or stamped in the future by a clock change — drop both. A
+    // future timestamp would otherwise pin a row to the top for over an hour.
+    if (now - at >= RECENT_TTL_MS || at > now) continue;
+    out.push({ id, at });
+  }
+  out.sort((a, b) => b.at - a.at);
+  return out.slice(0, RECENT_MAX);
+}
+
+/** Fold a newly-run command into the list: most recent first, one row per id
+ *  (re-running something moves it up rather than adding a duplicate). */
+export function withRecorded(prev: RecentEntry[], id: string, now: number): RecentEntry[] {
+  const next = prev.filter(e => e.id !== id && now - e.at < RECENT_TTL_MS && e.at <= now);
+  next.unshift({ id, at: now });
+  return next.slice(0, RECENT_MAX);
+}
+
+/** Ids to show, newest first, restricted to commands that still exist.
+ *  A task-scoped command (Stop task, Copy branch) is absent whenever no task is
+ *  active, and a stale id must not render a dead row. */
+export function recentIds(entries: RecentEntry[], available: ReadonlySet<string>): string[] {
+  return entries.filter(e => available.has(e.id)).map(e => e.id);
+}
+
+export function readRecents(now = Date.now()): RecentEntry[] {
+  try {
+    return parseRecents(localStorage.getItem(LS_KEY), now);
+  } catch {
+    return [];
+  }
+}
+
+export function recordRecent(id: string, now = Date.now()): void {
+  try {
+    const next = withRecorded(parseRecents(localStorage.getItem(LS_KEY), now), id, now);
+    localStorage.setItem(LS_KEY, JSON.stringify(next));
+  } catch {
+    // Private mode / quota. Recents are a convenience; never break the palette.
+  }
+}


### PR DESCRIPTION
The palette was last extended in July (`cd3643d`). **95 feature commits** landed after that and it gained no rows — because nothing was checking. A palette falls behind silently rather than breaking.

Two things here, the second so it can't happen again.

## 1. The missing commands

Diffed every `open*` action on the UI store, and every shortcut id, against what the palette offers.

| Added | Section | Why it was missing |
|---|---|---|
| Add project… | Task | palette could create a task but not a project |
| Run commands… | Task | #124, no palette presence |
| Resume options… | Task | launcher-only |
| Stop task | Task | #119; also the only way to release a mounted task |
| Prompt library… | Agent | bound chord, no row |
| Agent Race… | Agent | #113, a headline feature with no presence at all |
| Broadcast to agents… | Agent | bound chord, no row |
| Broadcast to project… | Agent | menu-only |
| Jump to next waiting agent | Agent | arguably the most useful command in a multi-agent app |
| Split pane right / down | View | `bcc146e` added them to the tab menu, not here |

**Two clean negatives**, so nobody goes fixing non-problems: the settings deep links are *not* stale (the `settingsTab` union still has all 9 despite the rail being split and renamed), and the theme submenu reads `customThemes` live so new theme files appear automatically.

### Deliberately not added

`new-tab`, `close-tab` and `clear-terminal` each read `document.activeElement` to decide **which** pane they act on. From the palette that's the palette's own input, so a row would act on the wrong pane or silently do nothing. A row that quietly does the wrong thing is worse than an absent one.

The git sub-views (Commit / Compare / History) are absent for a different reason: `RightPanel` owns that view as local `useState`, so reaching them needs it lifted to the store. Worth doing — "jump straight to Compare" is exactly what a palette is for — but it's a refactor, not a list addition. Separate PR.

## 2. Recent

Run a command, reopen the palette, and it's the first row under a pinned **Recent** header with a hairline beneath it. Last three, newest first, cleared after an hour.

- **Empty query only.** While searching you want the best match, not a pinned row pushing it down.
- **Lifted, not duplicated.** Recent members are removed from their home sections; the same command twice makes the arrow keys feel broken.
- **Archive and Stop are excluded** (`noRecent`). The top Recent row is pre-selected, so Enter on a freshly-opened palette runs it. That must never be "archive another task" — least of all once the user has ticked "Don't ask again" on the archive confirm.
- Theme submenu entries aren't recorded: it's a live preview you arrow through, so the last one you landed on is noise, not intent.

The expiry rule lives in `lib/paletteRecent` with an **injected clock**, because "clears after an hour" is untestable against a real one. The boundary is asserted just under, exactly at, and with a future timestamp from a backwards clock change (which would otherwise pin a row for over an hour).

## 3. The drift guard — the actual fix

`CommandPalette.coverage.test.ts` asserts every UI-store `open*` action is either surfaced or listed in `EXCLUDED` **with a reason**, so adding a dialog forces a decision at PR time instead of leaving a gap for three months. It also pins that Archive/Stop carry `noRecent` and that the focus-dependent trio stays out.

Source-level rather than render-level on purpose: rows are built from live store state, so a rendered assertion would only prove the palette works in one constructed world. The invariant is about coverage, not behaviour. Same pattern as `cspGuard.test.ts` reading `tauri.conf.json`.

**Verified by injecting the regression**: adding an unreferenced action to the store fails it by name.

## Testing

`npm test` 882 pass (17 new: 12 recency, 5 coverage) · `npm run build` clean · 3 new e2e cases in `app.e2e.ts` covering the reopen, the hide-on-query, and the hour expiry (aged via storage rather than waiting).

`make e2e` has **7 failures, all pre-existing** — verified by stashing this branch and running the full suite on clean `main`: identical failures, identical spec files. Worth a separate look, since that's more red than `main` carried a day ago.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2JzhUsFa9YLjBBvUJQGYj
