### PR TITLE
enhance(repo): Disable perf job on forked repo

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -44,6 +44,10 @@ concurrency:
 jobs:
   perf:
     name: startup + memory (macos-14)
+
+    # Cron is upstream-only, so forks stop getting nightly failure mail.
+    # Manual dispatch stays open everywhere.
+    if: github.event_name == 'workflow_dispatch' || github.repository == 'simion/termic'
     runs-on: macos-14
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
This PR aims to disable performance CI job to be running on forked repo which results in failure due to no secret provided.