### PR TITLE
feat(new-task): remember each member's mode and add a Set all toggle

### DIFF
--- a/docs/e2e-coverage.md
+++ b/docs/e2e-coverage.md
@@ -114,6 +114,7 @@ until `make e2e` is green and this file reflects it.
 | ✅ Project rename | Rename a project (add covered too) | `projects.e2e.ts` |
 | ✅ Editor split | Split view shows source + rendered preview together | `editor.e2e.ts` |
 | ✅ Repo config | Save a `.termic.yaml` field and read it back | `projects.e2e.ts` |
+| ✅ Multi member modes | New Task dialog for a multi project: git members seed on Worktree, "Set all" flips every row (and surfaces the live-checkout warning), and each member's last-used mode is remembered across dialog opens (localStorage `newTaskMemberModes`) | `projects.e2e.ts` |
 | ✅ Setup script | Configure + launch a Setup tab that spawns | `run.e2e.ts` |
 | ✅ Sidebar layout | Sidebar width setter persists | `tabs-layout.e2e.ts` |
 | ✅ Code editor | Open a .py file → CodeMirror renders with highlight tokens | `editor.e2e.ts` |

--- a/e2e/specs/projects.e2e.ts
+++ b/e2e/specs/projects.e2e.ts
@@ -1060,3 +1060,154 @@ describe("dashboard empty state", () => {
     await waitGone(CARD);
   });
 });
+
+// Per-member mode memory + bulk flip in the multi-repo New Task dialog.
+//
+// Each git member row remembers its last-used mode (localStorage
+// `newTaskMemberModes`, keyed by member root_path) across dialog opens, and a
+// "Set all" pair in the Members header flips every row at once. Dialog-only
+// coverage: no task is ever created here, so the fixture is two tiny member
+// repos plus a host dir, torn down completely.
+describe("multi member modes (New Task dialog)", () => {
+  let tmp = "";
+  let projectId = "";
+
+  /** Member rows as `{ name, mode }`, from the row's own state attributes. */
+  const rowModes = () =>
+    browser.execute(() =>
+      [...document.querySelectorAll('[data-testid="member-mode-row"]')].map((e) => ({
+        name: e.getAttribute("data-member-name"),
+        mode: e.getAttribute("data-member-mode"),
+      })),
+    ) as Promise<Array<{ name: string | null; mode: string | null }>>;
+
+  const openDialog = async () => {
+    await browser.execute((id) => window.__termic!.useUI.getState().openNewTask(id), projectId);
+    // Seeding runs in the dialog's reset effect; wait for both rows to exist.
+    await browser.waitUntil(async () => (await rowModes()).length === 2, {
+      timeout: 10_000,
+      timeoutMsg: "the member rows never rendered",
+    });
+  };
+
+  const closeDialog = async () => {
+    await browser.execute(() => window.__termic!.useUI.getState().closeNewTask());
+    // Wait out the dialog's unmount: a lingering row would let the reopen's
+    // row-count wait pass BEFORE the reset effect reseeds, and the memory
+    // assertions would then read stale state instead of the seeded one.
+    await waitGone('[data-testid="member-mode-row"]');
+  };
+
+  /** Click one row's Main checkout / Worktree toggle by member name. */
+  const clickRowMode = (name: string, label: "Main checkout" | "Worktree") =>
+    browser.execute(
+      (n, l) => {
+        const row = document.querySelector(`[data-testid="member-mode-row"][data-member-name="${n}"]`)!;
+        const btn = [...row.querySelectorAll("button")].find(
+          (b) => b.textContent?.trim() === l,
+        ) as HTMLButtonElement;
+        btn.click();
+      },
+      name,
+      label,
+    );
+
+  before(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "e2e-member-modes-"));
+    mkdirSync(path.join(tmp, "host"));
+    for (const name of ["alpha", "beta"]) {
+      const p = path.join(tmp, name);
+      mkdirSync(p);
+      execSync(`git init -b main -q "${p}"`);
+      execSync(`git -C "${p}" -c user.email=e2e@termic.dev -c user.name=e2e commit -q --allow-empty -m init`);
+    }
+  });
+
+  after(async () => {
+    await closeDialog();
+    await browser.execute(async (id) => {
+      try { localStorage.removeItem("newTaskMemberModes"); } catch { /* fine */ }
+      if (id) {
+        await window.__termic!.ipc.projectRemove(id);
+        await window.__termic!.useApp.getState().loadAll();
+      }
+    }, projectId);
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("seeds every git member row on Worktree when nothing is remembered", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+    projectId = await browser.execute(
+      async (host, alpha, beta) => {
+        const t = window.__termic!;
+        try { localStorage.removeItem("newTaskMemberModes"); } catch { /* fine */ }
+        // A run that died before teardown leaves the project behind (fresh
+        // path, same name) — drop any stale one first.
+        for (const p of t.useApp.getState().projects.filter((p: any) => p.name === "e2e-member-modes")) {
+          try { await t.ipc.projectRemove(p.id); } catch { /* has live tasks */ }
+        }
+        const spec = (root_path: string, name: string) => ({
+          root_path,
+          name,
+          base_branch: "main",
+          setup_script: "",
+          run_script: "",
+          archive_script: "",
+        });
+        const proj = await t.ipc.projectAddMulti(
+          host,
+          "e2e-member-modes",
+          [spec(alpha, "alpha"), spec(beta, "beta")],
+          true, // non-git wrapper host
+        );
+        await t.useApp.getState().loadAll();
+        return proj.id as string;
+      },
+      path.join(tmp, "host"),
+      path.join(tmp, "alpha"),
+      path.join(tmp, "beta"),
+    );
+    await openDialog();
+    expect(await rowModes()).toEqual([
+      { name: "alpha", mode: "worktree" },
+      { name: "beta", mode: "worktree" },
+    ]);
+  });
+
+  it("Set all: Main checkout flips every row and surfaces the live-checkout warning", async () => {
+    await clickWhenVisible('[data-testid="members-all-main"]');
+    await browser.waitUntil(
+      async () => (await rowModes()).every((r) => r.mode === "repo_root"),
+      { timeout: 5_000, timeoutMsg: "Set all: Main checkout did not flip every member row" },
+    );
+    // The warning is the user-facing consequence of running on live checkouts.
+    await waitForText("One or more members are linked to live checkouts.");
+  });
+
+  it("remembers each member's mode across dialog opens", async () => {
+    // Split the modes so memory is per member, not one shared flag.
+    await clickRowMode("alpha", "Worktree");
+    await browser.waitUntil(
+      async () => (await rowModes()).find((r) => r.name === "alpha")?.mode === "worktree",
+      { timeout: 5_000, timeoutMsg: "the alpha row never flipped back to worktree" },
+    );
+    await closeDialog();
+    await openDialog();
+    expect(await rowModes()).toEqual([
+      { name: "alpha", mode: "worktree" },
+      { name: "beta", mode: "repo_root" },
+    ]);
+  });
+
+  it("Set all: Worktree restores every row and persists too", async () => {
+    await clickWhenVisible('[data-testid="members-all-worktree"]');
+    await browser.waitUntil(
+      async () => (await rowModes()).every((r) => r.mode === "worktree"),
+      { timeout: 5_000, timeoutMsg: "Set all: Worktree did not flip every member row" },
+    );
+    await closeDialog();
+    await openDialog();
+    expect((await rowModes()).every((r) => r.mode === "worktree")).toBe(true);
+  });
+});

--- a/src/components/dialogs/NewTaskDialog.tsx
+++ b/src/components/dialogs/NewTaskDialog.tsx
@@ -23,6 +23,7 @@ import { Check, Loader2, AlertTriangle, GitBranch, Link2, FolderGit2, Plus, Hist
 import { SandboxModeSelector } from "@/components/SandboxModeSelector";
 import { SANDBOX_PRESETS } from "@/lib/sandboxPresets";
 import type { MemberMode, ImportableWorktree, SandboxMode } from "@/lib/types";
+import { readMemberModes, persistMemberMode, seedMemberMode } from "@/components/dialogs/memberModes";
 
 const CLIS = ["claude", "codex", "agy", "grok", "opencode"] as const;
 
@@ -133,6 +134,15 @@ export function NewTaskDialog() {
     base_branch: string;
   };
   const [members, setMembers] = useState<MemberSpec[]>([]);
+  // Bulk flip for compositions with many members. Non-git members are pinned
+  // to repo_root (no branches, no worktree), so "all worktree" skips them.
+  // Persists each git member's new mode, same write-through as the row toggle.
+  const setAllMemberModes = (mode: MemberMode) => {
+    setMembers(prev => prev.map(m => ({ ...m, mode: m.non_git ? "repo_root" : mode })));
+    for (const m of members) {
+      if (!m.non_git) persistMemberMode(m.root_path, mode);
+    }
+  };
   const isMulti = (project?.type ?? "single") === "multi";
   // Sandbox is offered for single-repo tasks in BOTH locations: the seatbelt +
   // proxy cage the main checkout identically to a worktree (see task_open_repo,
@@ -342,18 +352,18 @@ export function NewTaskDialog() {
     // merge global defaults on top (dedupe-preserving order).
     setSbRw((p?.sandbox_rw_paths ?? []).join("\n"));
     setSbHosts((p?.sandbox_allowed_hosts ?? []).join("\n"));
-    // Seed the per-member spec (multi-repo only). Each member starts
-    // in Worktree mode on its own default branch — the simplest +
-    // safest default. User can flip per-member to Repo root or change
-    // branches before submit.
+    // Seed the per-member spec (multi-repo only). Each git member starts
+    // on its last-used mode (remembered per root_path, like the single-repo
+    // dialog remembers its toggle) and falls back to Worktree — the simplest
+    // + safest default. Non-git members can't be worktreed (no branches), so
+    // they force repo_root, same rule as a non-git single project / host.
     if ((p?.type ?? "single") === "multi") {
+      const remembered = readMemberModes();
       const seeded: MemberSpec[] = (p?.members ?? []).map(pm => ({
         root_path: pm.root_path,
         name: pm.name,
         non_git: !!pm.non_git,
-        // Non-git members can't be worktreed (no branches) → force
-        // repo_root, same rule as a non-git single project / host.
-        mode: (pm.non_git ? "repo_root" : "worktree") as MemberMode,
+        mode: seedMemberMode(!!pm.non_git, remembered, pm.root_path) as MemberMode,
         branch: "",
         base_branch: pm.base_branch || "",
       }));
@@ -984,17 +994,54 @@ export function NewTaskDialog() {
               <label className="text-[13px] font-medium text-[var(--color-fg)]">
                 Members ({members.length})
               </label>
-              <span className="text-[11.5px] text-[var(--color-fg-faint)]">
-                Per-repo mode + branch
-              </span>
+              {members.length > 1 ? (
+                // Bulk flip, for compositions with many members. Same wording
+                // and order as the per-row toggle (main left, worktree right).
+                // Non-git members stay on repo_root: the constraint outranks
+                // the bulk ask, exactly like their disabled per-row button.
+                <div className="flex items-center gap-1 text-[11.5px]">
+                  <span className="text-[var(--color-fg-faint)]">Set all:</span>
+                  <button
+                    type="button"
+                    data-testid="members-all-main"
+                    onClick={() => setAllMemberModes("repo_root")}
+                    className="rounded-[4px] border border-[var(--color-border)] px-2 py-[2px] text-[var(--color-fg-dim)] transition-colors hover:text-[var(--color-fg)]"
+                  >
+                    Main checkout
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="members-all-worktree"
+                    onClick={() => setAllMemberModes("worktree")}
+                    className="rounded-[4px] border border-[var(--color-border)] px-2 py-[2px] text-[var(--color-fg-dim)] transition-colors hover:text-[var(--color-fg)]"
+                  >
+                    Worktree
+                  </button>
+                </div>
+              ) : (
+                <span className="text-[11.5px] text-[var(--color-fg-faint)]">
+                  Per-repo mode + branch
+                </span>
+              )}
             </div>
             <div className="flex flex-col gap-2">
               {members.map((m, idx) => {
                 const update = (patch: Partial<MemberSpec>) =>
                   setMembers(prev => prev.map((x, i) => (i === idx ? { ...x, ...patch } : x)));
+                // Write the flip through to storage right away (not on
+                // submit), mirroring chooseMode above: a cancelled dialog
+                // still teaches the next open. Non-git rows never persist —
+                // their repo_root is a constraint, not a choice.
+                const chooseMemberMode = (mode: MemberMode) => {
+                  update({ mode });
+                  if (!m.non_git) persistMemberMode(m.root_path, mode);
+                };
                 return (
                   <div
                     key={m.root_path}
+                    data-testid="member-mode-row"
+                    data-member-name={m.name}
+                    data-member-mode={m.mode}
                     className="rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2"
                   >
                     <div className="flex items-center justify-between gap-3">
@@ -1008,7 +1055,7 @@ export function NewTaskDialog() {
                             worktree everywhere). */}
                         <button
                           type="button"
-                          onClick={() => update({ mode: "repo_root" })}
+                          onClick={() => chooseMemberMode("repo_root")}
                           className={cn(
                             "flex h-6 items-center gap-1 rounded-[4px] px-2 transition-colors",
                             m.mode === "repo_root"
@@ -1025,7 +1072,7 @@ export function NewTaskDialog() {
                           // single project.
                           disabled={m.non_git}
                           title={m.non_git ? "Not a git repository, runs in the main checkout only" : undefined}
-                          onClick={() => update({ mode: "worktree" })}
+                          onClick={() => chooseMemberMode("worktree")}
                           className={cn(
                             "flex h-6 items-center gap-1 rounded-[4px] px-2 transition-colors",
                             m.mode === "worktree"

--- a/src/components/dialogs/memberModes.test.ts
+++ b/src/components/dialogs/memberModes.test.ts
@@ -1,0 +1,70 @@
+// Per-member last-used mode persistence for the multi-repo New Task dialog.
+// localStorage is stubbed (node vitest has none), so these run everywhere.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  LS_MEMBER_MODES,
+  persistMemberMode,
+  readMemberModes,
+  seedMemberMode,
+} from "./memberModes";
+
+const store = new Map<string, string>();
+
+beforeEach(() => {
+  store.clear();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+});
+
+describe("readMemberModes", () => {
+  it("returns {} when nothing is stored", () => {
+    expect(readMemberModes()).toEqual({});
+  });
+
+  it("drops unknown values and survives a corrupt blob", () => {
+    store.set(LS_MEMBER_MODES, JSON.stringify({ "/a": "worktree", "/b": "yolo", "/c": 3 }));
+    expect(readMemberModes()).toEqual({ "/a": "worktree" });
+    store.set(LS_MEMBER_MODES, "not json {");
+    expect(readMemberModes()).toEqual({});
+    store.set(LS_MEMBER_MODES, JSON.stringify("a string"));
+    expect(readMemberModes()).toEqual({});
+  });
+});
+
+describe("persistMemberMode", () => {
+  it("merges into the stored map instead of clobbering it", () => {
+    persistMemberMode("/repo/a", "repo_root");
+    persistMemberMode("/repo/b", "worktree");
+    expect(readMemberModes()).toEqual({ "/repo/a": "repo_root", "/repo/b": "worktree" });
+    persistMemberMode("/repo/a", "worktree");
+    expect(readMemberModes()).toEqual({ "/repo/a": "worktree", "/repo/b": "worktree" });
+  });
+
+  it("swallows a throwing storage (dialog must not break)", () => {
+    (globalThis as any).localStorage = {
+      getItem: () => { throw new Error("denied"); },
+      setItem: () => { throw new Error("denied"); },
+    };
+    expect(() => persistMemberMode("/repo/a", "worktree")).not.toThrow();
+    expect(readMemberModes()).toEqual({});
+  });
+});
+
+describe("seedMemberMode", () => {
+  it("non-git always forces repo_root, even over a remembered worktree", () => {
+    expect(seedMemberMode(true, { "/a": "worktree" }, "/a")).toBe("repo_root");
+  });
+
+  it("uses the remembered mode for git members", () => {
+    expect(seedMemberMode(false, { "/a": "repo_root" }, "/a")).toBe("repo_root");
+    expect(seedMemberMode(false, { "/a": "worktree" }, "/a")).toBe("worktree");
+  });
+
+  it("defaults to worktree when nothing is remembered", () => {
+    expect(seedMemberMode(false, {}, "/a")).toBe("worktree");
+  });
+});

--- a/src/components/dialogs/memberModes.ts
+++ b/src/components/dialogs/memberModes.ts
@@ -1,0 +1,58 @@
+// Last-used per-member task mode for the multi-repo New Task dialog.
+//
+// The single-repo dialog remembers one global mode (`newTaskLastMode`) because
+// that choice is about how the user works. Member modes are different: they are
+// about the REPO ("this library is always safe to worktree, that config repo I
+// always run live"), so they are remembered per member root_path, globally
+// across projects — the same member added to two multi projects keeps one
+// preference. Kept in its own module (not NewTaskDialog.tsx) so vitest can
+// import it without executing the dialog's DOM code.
+
+export type MemberTaskMode = "worktree" | "repo_root";
+
+export const LS_MEMBER_MODES = "newTaskMemberModes";
+
+/** The remembered map, `{ [root_path]: mode }`. Unknown values and a corrupt
+ *  blob both come back as "nothing remembered" — a bad entry must never wedge
+ *  the dialog. */
+export function readMemberModes(): Record<string, MemberTaskMode> {
+  try {
+    const raw = localStorage.getItem(LS_MEMBER_MODES);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const out: Record<string, MemberTaskMode> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (v === "worktree" || v === "repo_root") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Write through one member's choice. Merges into the stored map so two multi
+ *  projects don't clobber each other's members. */
+export function persistMemberMode(rootPath: string, mode: MemberTaskMode) {
+  try {
+    localStorage.setItem(
+      LS_MEMBER_MODES,
+      JSON.stringify({ ...readMemberModes(), [rootPath]: mode }),
+    );
+  } catch {
+    // Storage full / unavailable: the dialog still works, it just won't
+    // remember. Same silent policy as persistLast in NewTaskDialog.
+  }
+}
+
+/** The mode a member row seeds with: the hard constraint first (non-git has no
+ *  branches, so worktree is impossible), then the remembered choice, then the
+ *  historical default (worktree — the safe, isolated shape). */
+export function seedMemberMode(
+  nonGit: boolean,
+  remembered: Record<string, MemberTaskMode>,
+  rootPath: string,
+): MemberTaskMode {
+  if (nonGit) return "repo_root";
+  return remembered[rootPath] ?? "worktree";
+}


### PR DESCRIPTION
The multi-repo New Task dialog seeded every git member on Worktree each time it opened, so a user who always runs some members live had to flip the same rows before every Create. Single-repo tasks already remember their last-used mode (newTaskLastMode); members now get the same, keyed per member root_path in localStorage (newTaskMemberModes) because the preference belongs to the repo, not the project. Non-git members stay pinned to Main checkout and never persist: that is a constraint, not a choice.

A "Set all: Main checkout / Worktree" pair in the Members header flips every row at once for compositions with many members, skipping non-git ones and persisting the rest. Shown only when there are two or more members, so the single-member case keeps its hint line.

Both writes go through on click rather than on submit, mirroring chooseMode, so a cancelled dialog still teaches the next open.

Tests: memberModes.ts is its own module so vitest can cover the read / merge-persist / seed rules without importing the dialog's DOM code (7 cases, localStorage stubbed). projects.e2e.ts gains a dialog-only describe against a throwaway two-member project: default seed, Set all Main plus the live-checkout warning, per-member memory across dialog opens, Set all Worktree persisting too. Rows expose data-testid="member-mode-row" with data-member-mode for it.


Claude-Session: https://claude.ai/code/session_01DENEDvamh5bU5rzKFdxviu

<img width="657" height="1335" alt="image" src="https://github.com/user-attachments/assets/078ada37-206a-4ac9-963a-0703b5b21e36" />
