### PR TITLE
feat(new-task): give the multi dialog the host-level Main checkout shape

### DIFF
--- a/docs/e2e-coverage.md
+++ b/docs/e2e-coverage.md
@@ -115,6 +115,7 @@ until `make e2e` is green and this file reflects it.
 | ✅ Editor split | Split view shows source + rendered preview together | `editor.e2e.ts` |
 | ✅ Repo config | Save a `.termic.yaml` field and read it back | `projects.e2e.ts` |
 | ✅ Multi member modes | New Task dialog for a multi project: git members seed on Worktree, "Set all" flips every row (and surfaces the live-checkout warning), and each member's last-used mode is remembered across dialog opens (localStorage `newTaskMemberModes`) | `projects.e2e.ts` |
+| ✅ Multi main checkout (dialog) | The multi New Task dialog has the host-level Main checkout / Worktree toggle: Main checkout hides the member list behind a "run live" note and Create opens the host's live checkout (`is_main_checkout`, path = host root, every member linked in), the same task shape the sidebar quick menu creates, so ⌘N and the `+` menu can't drift apart | `projects.e2e.ts` |
 | ✅ Setup script | Configure + launch a Setup tab that spawns | `run.e2e.ts` |
 | ✅ Sidebar layout | Sidebar width setter persists | `tabs-layout.e2e.ts` |
 | ✅ Code editor | Open a .py file → CodeMirror renders with highlight tokens | `editor.e2e.ts` |

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -58,7 +58,7 @@ termic://open?project=web&task=fix-login
 | `name` | task name (max 200 chars) |
 | `prompt` / `p` | first message, pre-filled into the dialog (max 8000 chars) |
 | `agent` / `cli` | agent id to pre-select; ignored if this install doesn't offer it |
-| `mode` | `worktree` or `main`. `worktree=1` is the shorthand. |
+| `mode` | `worktree` or `main`. `worktree=1` is the shorthand. On a multi project `main` is the host-level shape: the live host checkout with every member linked in, the same task the sidebar quick menu's Main checkout creates. |
 | `base` | "Branch from" ref |
 
 `open` (selects an existing task):

--- a/e2e/specs/projects.e2e.ts
+++ b/e2e/specs/projects.e2e.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { clickByText, clickMenuItemUntil, clickWhenVisible, dismissOverlays, pointerDrag, requireTermicApi, keysIn, snap, waitForAppShell, waitForText, waitGone, waitVisible } from "../helpers";
+import { archiveTask, clickByText, clickMenuItemUntil, clickWhenVisible, dismissOverlays, pointerDrag, requireTermicApi, keysIn, snap, waitForAppShell, waitForText, waitGone, waitVisible } from "../helpers";
 
 // P1: adding/removing a project. Cases: a git repo can be added as a project
 // (shows in the store); removing it drops it. Uses a throwaway temp repo and
@@ -1141,7 +1141,13 @@ describe("multi member modes (New Task dialog)", () => {
     projectId = await browser.execute(
       async (host, alpha, beta) => {
         const t = window.__termic!;
-        try { localStorage.removeItem("newTaskMemberModes"); } catch { /* fine */ }
+        try {
+          localStorage.removeItem("newTaskMemberModes");
+          // The member rows only render in the Worktree host shape (the
+          // host-level toggle is remembered app-wide), so pin it here; the
+          // main-checkout describe below restores whatever it finds.
+          localStorage.setItem("newTaskLastMode", "worktree");
+        } catch { /* fine */ }
         // A run that died before teardown leaves the project behind (fresh
         // path, same name) — drop any stale one first.
         for (const p of t.useApp.getState().projects.filter((p: any) => p.name === "e2e-member-modes")) {
@@ -1209,5 +1215,143 @@ describe("multi member modes (New Task dialog)", () => {
     await closeDialog();
     await openDialog();
     expect((await rowModes()).every((r) => r.mode === "worktree")).toBe(true);
+  });
+});
+
+// The host-level Main checkout shape of the multi New Task dialog.
+//
+// Main checkout on a multi project is the SAME task the sidebar quick menu's
+// Main checkout creates (task_open_repo: the live host checkout with every
+// member linked in, no wrapper, no branch), so ⌘N and the `+` menu can't
+// drift into different task shapes. Fixture: two tiny member repos plus a
+// host dir, torn down completely (task archived, project removed, tmp gone).
+describe("multi main checkout (New Task dialog)", () => {
+  let tmp = "";
+  let projectId = "";
+  let taskId = "";
+  /** The app-wide task-type memory this spec drives; restored in teardown. */
+  let savedMode: string | null = null;
+
+  before(() => {
+    tmp = mkdtempSync(path.join(os.tmpdir(), "e2e-multi-main-"));
+    mkdirSync(path.join(tmp, "host"));
+    for (const name of ["alpha", "beta"]) {
+      const p = path.join(tmp, name);
+      mkdirSync(p);
+      execSync(`git init -b main -q "${p}"`);
+      execSync(`git -C "${p}" -c user.email=e2e@termic.dev -c user.name=e2e commit -q --allow-empty -m init`);
+    }
+  });
+
+  after(async () => {
+    await browser.execute(() => window.__termic!.useUI.getState().closeNewTask());
+    if (taskId) await archiveTask(taskId);
+    await browser.execute(async (id, mode) => {
+      try {
+        if (mode === null) localStorage.removeItem("newTaskLastMode");
+        else localStorage.setItem("newTaskLastMode", mode);
+      } catch { /* fine */ }
+      if (id) {
+        await window.__termic!.ipc.projectRemove(id);
+        await window.__termic!.useApp.getState().loadAll();
+      }
+    }, projectId, savedMode);
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("shows the host-level toggle; Main checkout replaces the member rows with a run-live note", async () => {
+    await waitForAppShell();
+    await requireTermicApi();
+    const created = await browser.execute(
+      async (host, alpha, beta) => {
+        const t = window.__termic!;
+        let saved: string | null = null;
+        try {
+          // Start from Worktree so the member rows are on screen and the
+          // flip below is a real transition, not a no-op.
+          saved = localStorage.getItem("newTaskLastMode");
+          localStorage.setItem("newTaskLastMode", "worktree");
+        } catch { /* fine */ }
+        // A run that died before teardown leaves the project behind (fresh
+        // path, same name) — drop any stale one first.
+        for (const p of t.useApp.getState().projects.filter((p: any) => p.name === "e2e-multi-main")) {
+          try { await t.ipc.projectRemove(p.id); } catch { /* has live tasks */ }
+        }
+        const spec = (root_path: string, name: string) => ({
+          root_path,
+          name,
+          base_branch: "main",
+          setup_script: "",
+          run_script: "",
+          archive_script: "",
+        });
+        const proj = await t.ipc.projectAddMulti(
+          host,
+          "e2e-multi-main",
+          [spec(alpha, "alpha"), spec(beta, "beta")],
+          true, // non-git wrapper host
+        );
+        await t.useApp.getState().loadAll();
+        t.useUI.getState().openNewTask(proj.id);
+        return { id: proj.id as string, saved };
+      },
+      path.join(tmp, "host"),
+      path.join(tmp, "alpha"),
+      path.join(tmp, "beta"),
+    );
+    projectId = created.id;
+    savedMode = created.saved;
+
+    // Worktree shape: one row per member, host toggle present.
+    await waitVisible('[data-testid="task-type-main"]');
+    await waitForText("Members (2)");
+
+    await clickWhenVisible('[data-testid="task-type-main"]');
+    await waitVisible('[data-testid="members-live-note"]');
+    await waitForText("All 2 members run live");
+    const rows = await browser.execute(() => document.body.textContent?.includes("Members (2)"));
+    expect(rows).toBe(false);
+  });
+
+  it("Create opens the live host checkout with every member linked in, no wrapper", async () => {
+    await browser.execute(() => {
+      const input = document.querySelector(
+        '[role="dialog"] input[placeholder="fix login bug"]',
+      ) as HTMLInputElement;
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+      setter.call(input, "e2e-mm-live");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    // Terminal (shell) is token-free; both clicks scoped to THIS dialog.
+    for (const label of ["Terminal", "Create"]) {
+      await browser.execute((l) => {
+        const dlg = [...document.querySelectorAll('[role="dialog"]')].find((d) =>
+          d.textContent?.includes("New multi-repo task in the main checkout"),
+        )!;
+        const btn = [...dlg.querySelectorAll("button")].find((b) => b.textContent?.trim() === l) as HTMLButtonElement;
+        btn.click();
+      }, label);
+    }
+
+    const task = await browser.waitUntil(
+      async () => {
+        const t = await browser.execute(() =>
+          window.__termic!.useApp.getState().tasks.find((w: any) => w.name === "e2e-mm-live"),
+        );
+        return t ?? false;
+      },
+      { timeout: 15_000, timeoutMsg: "the main-checkout multi task never appeared" },
+    ) as any;
+    taskId = task.id;
+    const hostRoot = await browser.execute(
+      (id) => window.__termic!.useApp.getState().projects.find((p: any) => p.id === id).root_path,
+      projectId,
+    );
+    expect(task.is_main_checkout).toBe(true);
+    expect(task.path).toBe(hostRoot);
+    expect(task.composition.map((m: any) => [m.dir_name, m.mode])).toEqual([
+      ["alpha", "repo_root"],
+      ["beta", "repo_root"],
+    ]);
   });
 });

--- a/src/components/dialogs/NewTaskDialog.tsx
+++ b/src/components/dialogs/NewTaskDialog.tsx
@@ -94,8 +94,11 @@ export function NewTaskDialog() {
   // the same shape as the sidebar's "Run in repo with <agent>"). Main checkout
   // (repo_root) is the default (most people start there, reach for worktrees
   // later); repo_root hides the branch fields + sandbox panel and creates via
-  // task_open_repo. Multi-repo ignores this (it has its own per-member
-  // toggle); non-git projects force repo_root (no branches).
+  // task_open_repo. Multi-repo honours it at the HOST level: repo_root opens
+  // the host's live checkout with every member linked in (task_open_repo's
+  // multi branch, the same shape the sidebar quick menu creates), while
+  // worktree builds the wrapper + per-member toggles. Non-git projects force
+  // repo_root (no branches).
   const [mode, setMode] = useState<"worktree" | "repo_root">("repo_root");
   // Flipping the toggle writes through to the shared `newTaskLastMode` key
   // right away (not just on submit), so the sidebar quick menu and this modal
@@ -144,11 +147,10 @@ export function NewTaskDialog() {
     }
   };
   const isMulti = (project?.type ?? "single") === "multi";
-  // Sandbox is offered for single-repo tasks in BOTH locations: the seatbelt +
-  // proxy cage the main checkout identically to a worktree (see task_open_repo,
-  // which now takes sandbox args). Multi keeps its own handling (its mode stays
-  // "worktree"), so the repo-root case is gated on !isMulti.
-  const canSandbox = mode === "worktree" || (mode === "repo_root" && !isMulti);
+  // Sandbox is offered in every shape: the seatbelt + proxy cage the main
+  // checkout identically to a worktree (task_open_repo takes sandbox args,
+  // for single AND multi hosts), and the multi wrapper carries its own.
+  const canSandbox = true;
   // Derived: any cage on. Drives the 2-column layout + "send lists" gating.
   const sandbox = sandboxMode !== "off" && canSandbox;
   // Import mode (issue #5): instead of branching a fresh worktree, adopt
@@ -549,10 +551,10 @@ export function NewTaskDialog() {
   }
 
   async function submit() {
-    // Remember how the user works for next time. Task type is a
-    // single-repo concept (multi has its own per-member toggle); sandbox mode
-    // is remembered whenever a worktree/multi create can carry one.
-    if (!isMulti) persistLast(LS_LAST_MODE, mode);
+    // Remember how the user works for next time. The task type is the
+    // host-level shape for multi too (members keep their own per-row memory);
+    // sandbox mode is remembered whenever a create can carry one.
+    persistLast(LS_LAST_MODE, mode);
     // Sandbox can now ride on a single-repo main-checkout create too, so
     // remember the mode whenever a create can carry one (i.e. always here).
     persistLast(LS_LAST_SANDBOX, sandboxMode);
@@ -562,7 +564,11 @@ export function NewTaskDialog() {
     // (the remembered default). Checking repo_root first would silently open
     // the main checkout instead of importing the picked worktree.
     if (importMode) { submitImport(); return; }
-    if (mode === "repo_root" && !isMulti) { submitRepoRoot(); return; }
+    // Main checkout, single or multi: task_open_repo opens the live checkout
+    // (for multi, with every member linked into the host). This is the SAME
+    // task the sidebar quick menu's Main checkout creates, so the two entry
+    // points can't drift into different task shapes.
+    if (mode === "repo_root") { submitRepoRoot(); return; }
     if (!projectId || !name.trim() || !branch.trim()) return;
     if (submittingRef.current) return;
     submittingRef.current = true;
@@ -673,7 +679,7 @@ export function NewTaskDialog() {
       // (worktree/multi creates close the dialog immediately; see submit()).
       open={!!projectId}
       onOpenChange={(v) => { if (!v && !busy) close(); }}
-      title={isMulti ? "New multi-repo task" : importMode ? "Import existing worktree" : mode === "repo_root" ? "New task in the main checkout" : "New task in a worktree"}
+      title={isMulti ? (mode === "repo_root" ? "New multi-repo task in the main checkout" : "New multi-repo task") : importMode ? "Import existing worktree" : mode === "repo_root" ? "New task in the main checkout" : "New task in a worktree"}
       description={undefined}
       // Widen the dialog to fit what's inside. Base width per mode (xl 36rem /
       // 2xl 42rem / 3xl 48rem) sizes the single-column form. Enabling the
@@ -789,11 +795,11 @@ export function NewTaskDialog() {
           </Field>
         )}
 
-        {/* Worktree vs repo-root toggle (single-repo only — multi has its
-            own per-member toggle below). Repo root hides the branch + sandbox
-            fields and creates in the repo's live checkout. Non-git projects
-            can't worktree, so the Worktree button is disabled there. */}
-        {!isMulti && !importMode && (
+        {/* Worktree vs repo-root toggle. Repo root hides the branch fields
+            (and, for multi, the per-member list: every member runs live) and
+            creates in the repo's live checkout. Non-git projects can't
+            worktree, so the Worktree button is disabled there. */}
+        {!importMode && (
           <div className="flex flex-col gap-1.5">
             {/* Label + toggle share one row (not label-above-control like
                 every other Field) — this is the field people re-adjust most
@@ -803,6 +809,7 @@ export function NewTaskDialog() {
               <div className="inline-flex shrink-0 items-stretch rounded-md border border-[var(--color-border)] bg-[var(--color-bg)] p-[3px]">
                 <button
                   type="button"
+                  data-testid="task-type-main"
                   onClick={() => chooseMode("repo_root")}
                   className={cn(
                     "flex h-7 items-center gap-1.5 rounded-[5px] px-2.5 text-[12.5px] transition-colors",
@@ -815,6 +822,7 @@ export function NewTaskDialog() {
                 </button>
                 <button
                   type="button"
+                  data-testid="task-type-worktree"
                   onClick={() => chooseMode("worktree")}
                   disabled={!!project?.non_git}
                   className={cn(
@@ -830,8 +838,12 @@ export function NewTaskDialog() {
             </div>
             <p className="text-[12px] text-[var(--color-fg-faint)]">
               {mode === "worktree"
-                ? "Isolated branch in its own working directory. Run agents in parallel without touching your main checkout."
-                : "No worktree. The agent runs in the repo's main checkout, on its current branch. Edits land on your real files."}
+                ? (isMulti
+                    ? "Branch every member into its own working directory, run agents in parallel."
+                    : "Isolated branch in its own working directory. Run agents in parallel without touching your main checkout.")
+                : (isMulti
+                    ? "No worktrees, nothing copied. The agent runs in the host's live checkout with every member linked in. Edits land on your real files."
+                    : "No worktree. The agent runs in the repo's main checkout, on its current branch. Edits land on your real files.")}
             </p>
           </div>
         )}
@@ -988,7 +1000,17 @@ export function NewTaskDialog() {
             row renders a small toggle (Worktree | Repo root) and, when
             in Worktree mode, a branch + base override. RepoRoot mode
             collapses to a single warning line. */}
-        {isMulti && (
+        {isMulti && mode === "repo_root" && (
+          <div
+            data-testid="members-live-note"
+            className="rounded-md border border-[var(--color-warn)]/40 bg-[var(--color-warn)]/10 px-3 py-2 text-[12px] text-[var(--color-warn)]"
+          >
+            <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
+            All {members.length} members run live, linked into the host checkout. The agent
+            can directly modify every repo. No worktree isolation.
+          </div>
+        )}
+        {isMulti && mode === "worktree" && (
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between">
               <label className="text-[13px] font-medium text-[var(--color-fg)]">
@@ -1124,8 +1146,7 @@ export function NewTaskDialog() {
             strip of buttons whose purpose isn't obvious). Pinned at
             creation - lists below freeze onto the task and can't be
             edited after (archive + recreate to change). */}
-        {/* Offered for single-repo worktree AND main checkout (see canSandbox);
-            multi has its own per-member handling. */}
+        {/* Offered in every shape (see canSandbox). */}
         {canSandbox && (
         <Field label="Sandbox" hint="Cage the agent's filesystem + network access. Pinned at creation.">
           <SandboxModeSelector value={sandboxMode} onChange={setSandboxMode} osUnavailable={osSandboxOk === false} compact />


### PR DESCRIPTION
The sidebar `+` menu and the New Task dialog disagreed on what "Main checkout" means for a multi-repo project. The quick menu called task_open_repo: the host's live checkout, every member linked in, no wrapper, no branch. The dialog had no such shape at all: its host toggle was hidden for multi and submit always went through task_create_multi, which builds a wrapper plus a host worktree even when every member row sits on Main checkout. Someone opening the dialog with ⌘N could not get the task the quick menu gives them, and vice versa.

The dialog now shows the Task type toggle for multi projects too, and Main checkout routes submit through submitRepoRoot exactly like a single-repo project, so both entry points produce the same task. In that shape the per-member list is replaced by a note saying all members run live (task_open_repo pins every member to RepoRoot, there is nothing per-member to pick). The sandbox panel is offered in every shape now, since task_open_repo already takes the sandbox arguments for multi hosts. The host-level choice is remembered in newTaskLastMode for multi as well, the same key the quick menu reads; member rows keep their own per-member memory from #261.

Deep links inherit this: `termic://new?mode=main` on a multi project opens the live host, documented in docs/ipc.md.

Tests: projects.e2e.ts gains a dialog-driven describe against a throwaway two-member project: the host toggle is present in the Worktree shape with a row per member, flipping to Main checkout swaps the rows for the run-live note, and Create produces an is_main_checkout task at the host root with both members linked as repo_root. The member modes describe from #261 now pins newTaskLastMode to worktree in its setup, since its rows only render in that host shape. Host toggle buttons carry data-testid="task-type-main" / "task-type-worktree".


Claude-Session: https://claude.ai/code/session_01DENEDvamh5bU5rzKFdxviu


<img width="658" height="676" alt="image" src="https://github.com/user-attachments/assets/78e1f987-5ba1-4b59-b5be-a5e3b4d5ea24" />
